### PR TITLE
Fix Transmission 409 Conflict when adding new server

### DIFF
--- a/scripts/bittorrent/transmission/transmissionservice.js
+++ b/scripts/bittorrent/transmission/transmissionservice.js
@@ -75,7 +75,7 @@ angular.module('torrentApp')
             saveConnection(ip, port, encoded, session);
             defer.resolve(response);
         }).catch(function(response){
-            if(status === 409){
+            if(response.status === 409){
                 var session = response.headers('X-Transmission-Session-Id');
                 saveConnection(ip, port, encoded, session);
                 return defer.resolve(response);


### PR DESCRIPTION
Hi,
Electorrent failed to add a new Transmission server and logged a 409 Conflict to the console.
I changed `status` to `response.status` then it worked.
I'm new to JS and Angular, so this may be a workaround but not a real "fix" 😅 