### PR TITLE
Fix Download Station connection error / resolves tympanix/Electorrent#99

### DIFF
--- a/src/scripts/bittorrent/synology/synologytorrent.js
+++ b/src/scripts/bittorrent/synology/synologytorrent.js
@@ -24,7 +24,7 @@ angular.module('torrentApp').factory('TorrentS', ['AbstractTorrent', function(Ab
          // Calculates the total amount of peers and seeds over all connected trackers.
          // Takes a map function from peersInSwarm and seedsInSwarm to get the correct numbers.
          function trackCount(mapFun) {
-             if (!track) {
+             if (!track || track.length === 0) {
                  return 0;
              }
              var numArr = track.map(mapFun)


### PR DESCRIPTION
The error happens when any returned task has a "tracker" property with an empty array value