### PR TITLE
Add remove torrent shortcut to macOS menu

### DIFF
--- a/src/scripts/components/menuMac.js
+++ b/src/scripts/components/menuMac.js
@@ -109,6 +109,15 @@ angular.module('torrentApp').factory("menuMac", ['electron', '$rootScope', '$bit
                     role: 'paste'
                 },
                 {
+                    label: 'Remove',
+                    accelerator: 'Delete',
+                    click() {
+                        if (document.activeElement.nodeName !== 'INPUT') {
+                            $rootScope.$broadcast('menu:remove')
+                        }
+                    },
+                },
+                {
                     label: 'Select All',
                     accelerator: 'CmdOrCtrl+A',
                     click() {


### PR DESCRIPTION
Fixing omission from [previous PR](https://github.com/tympanix/Electorrent/pull/226).

Unfortunately I don't have a mac available atm to test it out, but I don't see why this wouldn't just work since it's just a copy paste from the Windows version that I was able to verify.