### PR TITLE
feat(qbt): Show free space in status bar.

### DIFF
--- a/src/scripts/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/scripts/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -82,8 +82,8 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
         all: [],
         changed: [],
         deleted: [],
+        freeDiskSpace: 0
       };
-
       if (Array.isArray(data.categories) || Array.isArray(data.labels)) {
         torrents.labels = data.categories || data.labels;
       } else if (typeof data.categories === "object") {
@@ -97,6 +97,9 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
       }
 
       torrents.deleted = data.torrents_removed || [];
+      if (data.full_update) {
+        torrents.freeDiskSpace = data.server_state.free_space_on_disk;
+      }
       return torrents;
     }
 

--- a/src/scripts/bittorrent/torrentclient.ts
+++ b/src/scripts/bittorrent/torrentclient.ts
@@ -7,6 +7,7 @@ export interface TorrentUpdates {
     all?: any[],
     changed?: any[],
     deletes?: [],
+    freeDiskSpace?: number
 }
 
 /**

--- a/src/scripts/controllers/torrents.ts
+++ b/src/scripts/controllers/torrents.ts
@@ -28,6 +28,7 @@ export let torrentsController = ["$rootScope", "$scope", "$timeout", "$filter", 
     $scope.totalUploadSpeed = 0;
     $scope.totalDownloaded = 0;
     $scope.totalUploaded = 0;
+    $scope.freeDiskSpace = 0;
     $scope.contextMenu = null;
     $scope.showDragAndDrop = false;
     $scope.labelsDrowdown = null;
@@ -532,6 +533,7 @@ export let torrentsController = ["$rootScope", "$scope", "$timeout", "$filter", 
             changeTorrents(torrents);
             updateLabels(torrents);
             updateTrackers(torrents);
+            $scope.freeDiskSpace = torrents.freeDiskSpace > 0 ? torrents.freeDiskSpace : $scope.freeDiskSpace;
         }).then(function() {
             if (!$scope.arrayTorrents || $scope.arrayTorrents.length === 0) {
                 $scope.renderDone()

--- a/src/views/torrents.html
+++ b/src/views/torrents.html
@@ -163,6 +163,10 @@
         <i class="ui orange arrow up icon"></i>
         {{ totalUploadSpeed | speed }} <span ng-if="totalUploaded">({{ totalUploaded | bytes:2 }})</span>
       </div>
+      <div class="free-disk-space">
+        <i class="ui grey disk outline icon"></i>
+        {{ freeDiskSpace | bytes:2 }}
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
Closes #335 

I'm a frequent user of qbittorrent, so i can see how this would be useful.

The info about space left is send only on `full_update` and is contained in `server_state.free_space_on_disk`.