### PR TITLE
fix: Add date completed to the column options.

### DIFF
--- a/src/scripts/bittorrent/abstracttorrent.ts
+++ b/src/scripts/bittorrent/abstracttorrent.ts
@@ -254,6 +254,13 @@ export abstract class Torrent implements TorrentProps {
       attribute: 'dateAdded'
     })
 
+    static COL_DATECOMPLETED = new Column({
+      name: 'Date Completed',
+      enabled: true,
+      template: '<span time="torrent.dateCompleted"></span>',
+      attribute: 'dateCompleted'
+    })
+
     static COL_PEERS = new Column({
       name: 'Peers',
       enabled: false,
@@ -299,6 +306,7 @@ export abstract class Torrent implements TorrentProps {
         Torrent.COL_PROGRESS,
         Torrent.COL_LABEL,
         Torrent.COL_DATEADDED,
+        Torrent.COL_DATECOMPLETED,
         Torrent.COL_PEERS,
         Torrent.COL_SEEDS,
         Torrent.COL_QUEUE,


### PR DESCRIPTION
Closes #150 (not tested, logic is there tho), #204 (tested locally) 

The [pulling of the data was already implemented by what i see](https://github.com/search?q=repo%3Atympanix%2FElectorrent%20dateCompleted&type=code).
Only thing that had to be done was add it to the other columns, im willing to look into it more if you see any issues.