### PR TITLE
Add tree-based torrent file selection modal for qBittorrent

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -60,6 +60,7 @@ function createTorrentWindow() {
 
     // Create the browser window.
     torrentWindow = new BrowserWindow(windowSettings);
+    electorrent.setWindow(torrentWindow);
 
     // Enable the remote module to access main-process-only objects from
     // the renderer process
@@ -67,7 +68,6 @@ function createTorrentWindow() {
 
     torrentWindow.once('ready-to-show', () => {
         torrentWindow.show();
-        electorrent.setWindow(torrentWindow);
     });
 
     torrentWindow.loadURL(`file://${__dirname}/index.html`);

--- a/src/lib/torrents.js
+++ b/src/lib/torrents.js
@@ -38,8 +38,6 @@ async function browse(askUploadOptions){
 }
 
 function processFiles(filepaths, askUploadOptions) {
-    var win = electorrent.getWindow();
-
     if (!filepaths) return;
 
     var torrents = filepaths.filter(filterFiles);
@@ -56,6 +54,8 @@ function processFiles(filepaths, askUploadOptions) {
     torrents.forEach(function(file){
         fs.readFile(file, (err, data) => {
             if (err) throw err;
+            var win = electorrent.getWindow();
+            if (!win || win.isDestroyed() || !win.webContents) return;
 
             win.webContents.send('torrentfiles', data, path.basename(file), askUploadOptions);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,6 +169,12 @@ import { AddTorrentModalDirective } from "./scripts/directives/add-torrent-modal
 torrentApp.directive('addTorrentModal', AddTorrentModalDirective.getInstance())
 import { TorrentUploadFormDirective } from "./scripts/directives/torrent-upload-form/torrent-upload-form.directive";
 torrentApp.directive('torrentUploadForm', TorrentUploadFormDirective.getInstance())
+import { TorrentFilesTreeDirective } from "./scripts/directives/torrent-files-tree/torrent-files-tree.directive";
+torrentApp.directive('torrentFilesTree', TorrentFilesTreeDirective.getInstance())
+import { indeterminateValueDirective } from "./scripts/directives/torrent-files-tree/indeterminate-value.directive";
+torrentApp.directive('indeterminateValue', indeterminateValueDirective)
+import { TorrentFilesModalDirective } from "./scripts/directives/torrent-files-modal/torrent-files-modal.directive";
+torrentApp.directive('torrentFilesModal', TorrentFilesModalDirective.getInstance())
 
 // Components
 import {menuWin} from "./scripts/components/menuWin"

--- a/src/scripts/bittorrent/abstracttorrent.ts
+++ b/src/scripts/bittorrent/abstracttorrent.ts
@@ -1,5 +1,18 @@
 import { Column } from '../services/column'
 
+/**
+ * Represents a single file inside a torrent. Used for file list display and
+ * selective download (wanted/unwanted). Index is the client API file index.
+ */
+export interface TorrentFile {
+    index: number
+    path: string
+    name: string
+    size: number
+    wanted: boolean
+    priority?: number
+}
+
 export interface TorrentProps {
     hash: string
     status?: number

--- a/src/scripts/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/scripts/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -1,5 +1,6 @@
 import {Torrent} from "../abstracttorrent";
 import {TorrentActionList, TorrentClient, TorrentUpdates, ContextActionList, TorrentUploadOptions, TorrentUploadOptionsEnable} from "../torrentclient";
+import {TorrentFile} from "../abstracttorrent";
 import {QBittorrentTorrent} from "./torrentq";
 
 type CallbackFunc = (err: any, val: any) => void
@@ -37,10 +38,16 @@ type QBittorrentUploadFormData = Partial<Record<keyof QBittorrentUploadOptions, 
 
 const QBittorrent = require("@electorrent/node-qbittorrent");
 
+/** qBittorrent file priority: 0 = do not download, 1 = normal, 2 = high, 6 = maximal */
+const QBITTORRENT_PRIORITY_SKIP = 0;
+const QBITTORRENT_PRIORITY_NORMAL = 1;
+
 export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
 
     public name = "qBittorrent"
     public id = "qbittorrent"
+
+    public supportsFileSelection = true
 
     private qbittorrent: any
 
@@ -252,6 +259,50 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
       return this.delete(torrents)
     }
 
+    async getTorrentFiles(torrent: QBittorrentTorrent): Promise<TorrentFile[]> {
+      const api = (this.qbittorrent as any).api;
+      if (!api || typeof api.getJson !== 'function') {
+        return Promise.reject(new Error('qBittorrent API does not support getTorrentFiles'));
+      }
+      return new Promise((resolve, reject) => {
+        api.getJson('torrents/files', { qs: { hash: torrent.hash } }, (err: any, _res: any, body: any) => {
+          if (err) return reject(err);
+          if (!Array.isArray(body)) return reject(new Error('Invalid response'));
+          const files: TorrentFile[] = body.map((f: any, idx: number) => ({
+            index: f.index != null ? f.index : idx,
+            path: f.name || '',
+            name: (f.name || '').split(/[/\\]/).pop() || '',
+            size: typeof f.size === 'number' ? f.size : (parseInt(String(f.size), 10) || 0),
+            wanted: (f.priority != null ? f.priority : 1) !== QBITTORRENT_PRIORITY_SKIP,
+            priority: f.priority,
+          }));
+          resolve(files);
+        });
+      });
+    }
+
+    async setTorrentFileSelection(torrent: QBittorrentTorrent, files: TorrentFile[]): Promise<void> {
+      const api = (this.qbittorrent as any).api;
+      if (!api || typeof api.post !== 'function') {
+        return Promise.reject(new Error('qBittorrent API does not support setTorrentFileSelection'));
+      }
+      const wantedIds: number[] = [];
+      const unwantedIds: number[] = [];
+      files.forEach((f) => {
+        if (f.wanted) wantedIds.push(f.index);
+        else unwantedIds.push(f.index);
+      });
+      const setPrio = (ids: number[], priority: number) =>
+        new Promise<void>((resolve, reject) => {
+          if (ids.length === 0) return resolve();
+          api.post('torrents/filePrio', {
+            form: { hash: torrent.hash, id: ids.join('|'), priority: String(priority) },
+          }, (err: any) => (err ? reject(err) : resolve()));
+        });
+      await setPrio(unwantedIds, QBITTORRENT_PRIORITY_SKIP);
+      await setPrio(wantedIds, QBITTORRENT_PRIORITY_NORMAL);
+    }
+
 
     actionHeader: TorrentActionList<QBittorrentTorrent> = [
       {
@@ -304,6 +355,12 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
      *                          has to hold for all selected torrents, for the checkbox to be checked.
      */
     contextMenu: ContextActionList<QBittorrentTorrent> = [
+      {
+        id: 'torrent-files',
+        label: "Files",
+        click: () => Promise.resolve(),
+        icon: "file",
+      },
       {
         label: "Recheck",
         click: this.recheck,

--- a/src/scripts/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/scripts/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -356,12 +356,6 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
      */
     contextMenu: ContextActionList<QBittorrentTorrent> = [
       {
-        id: 'torrent-files',
-        label: "Files",
-        click: () => Promise.resolve(),
-        icon: "file",
-      },
-      {
         label: "Recheck",
         click: this.recheck,
         icon: "checkmark",

--- a/src/scripts/bittorrent/torrentclient.ts
+++ b/src/scripts/bittorrent/torrentclient.ts
@@ -171,29 +171,43 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
     /**
      * When true, the client supports listing torrent files and setting which files to download
      * (selective download). When false, the "Files" context menu item and file selection UI are hidden.
+     * Concrete clients that set this flag to true are expected to override
+     * {@link getTorrentFiles} and {@link setTorrentFileSelection}.
      */
     public supportsFileSelection: boolean = false
 
     /**
-     * Get the list of files for a torrent. Only implemented when supportsFileSelection is true.
-     * @throws Error with message "File selection not supported for this client" when not supported.
+     * Get the list of files for a torrent.
+     *
+     * Default implementation always throws:
+     * - when {@link supportsFileSelection} is false: Error("File selection not supported for this client")
+     * - when {@link supportsFileSelection} is true but the client did not override this method:
+     *   Error("File selection not implemented for this client")
+     *
+     * Concrete clients that support file selection must override this method.
      */
     async getTorrentFiles(torrent: T): Promise<TorrentFile[]> {
         if (!this.supportsFileSelection) {
             throw new Error("File selection not supported for this client")
         }
-        return Promise.reject(new Error("File selection not supported for this client"))
+        return Promise.reject(new Error("File selection not implemented for this client"))
     }
 
     /**
-     * Apply wanted/unwanted selection for torrent files. Only implemented when supportsFileSelection is true.
-     * @throws Error with message "File selection not supported for this client" when not supported.
+     * Apply wanted/unwanted selection for torrent files.
+     *
+     * Default implementation always throws:
+     * - when {@link supportsFileSelection} is false: Error("File selection not supported for this client")
+     * - when {@link supportsFileSelection} is true but the client did not override this method:
+     *   Error("File selection not implemented for this client")
+     *
+     * Concrete clients that support file selection must override this method.
      */
     async setTorrentFileSelection(torrent: T, files: TorrentFile[]): Promise<void> {
         if (!this.supportsFileSelection) {
             throw new Error("File selection not supported for this client")
         }
-        return Promise.reject(new Error("File selection not supported for this client"))
+        return Promise.reject(new Error("File selection not implemented for this client"))
     }
 
     /**

--- a/src/scripts/bittorrent/torrentclient.ts
+++ b/src/scripts/bittorrent/torrentclient.ts
@@ -70,8 +70,6 @@ export interface ContextActionButton<T extends Torrent> {
     icon?: string
     role?: TorrentActionRole
     check?(torrent: T): boolean
-    /** Optional id for controller to handle specially (e.g. 'torrent-files' to open file selection modal). */
-    id?: string
 }
 
 export interface ContextActionMenu<T extends Torrent> {

--- a/src/scripts/bittorrent/torrentclient.ts
+++ b/src/scripts/bittorrent/torrentclient.ts
@@ -1,4 +1,4 @@
-import { Torrent } from "./abstracttorrent"
+import { Torrent, TorrentFile } from "./abstracttorrent"
 
 export type TorrentActionRole = "resume" | "stop" | "delete"
 
@@ -70,6 +70,8 @@ export interface ContextActionButton<T extends Torrent> {
     icon?: string
     role?: TorrentActionRole
     check?(torrent: T): boolean
+    /** Optional id for controller to handle specially (e.g. 'torrent-files' to open file selection modal). */
+    id?: string
 }
 
 export interface ContextActionMenu<T extends Torrent> {
@@ -165,6 +167,34 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
      * Whether the client supports sorting by trackers or not
      */
     public enableTrackerFilter: boolean
+
+    /**
+     * When true, the client supports listing torrent files and setting which files to download
+     * (selective download). When false, the "Files" context menu item and file selection UI are hidden.
+     */
+    public supportsFileSelection: boolean = false
+
+    /**
+     * Get the list of files for a torrent. Only implemented when supportsFileSelection is true.
+     * @throws Error with message "File selection not supported for this client" when not supported.
+     */
+    async getTorrentFiles(torrent: T): Promise<TorrentFile[]> {
+        if (!this.supportsFileSelection) {
+            throw new Error("File selection not supported for this client")
+        }
+        return Promise.reject(new Error("File selection not supported for this client"))
+    }
+
+    /**
+     * Apply wanted/unwanted selection for torrent files. Only implemented when supportsFileSelection is true.
+     * @throws Error with message "File selection not supported for this client" when not supported.
+     */
+    async setTorrentFileSelection(torrent: T, files: TorrentFile[]): Promise<void> {
+        if (!this.supportsFileSelection) {
+            throw new Error("File selection not supported for this client")
+        }
+        return Promise.reject(new Error("File selection not supported for this client"))
+    }
 
     /**
      * A set of options supported by the client when uploading torrents (may be either torrent files

--- a/src/scripts/controllers/torrents.ts
+++ b/src/scripts/controllers/torrents.ts
@@ -371,7 +371,13 @@ export let torrentsController = ["$rootScope", "$scope", "$timeout", "$filter", 
             });
     };
 
-    $scope.doContextAction = function(action) {
+    $scope.doContextAction = function(action, label, item) {
+        if (item && item.id === 'torrent-files') {
+            if (selected.length >= 1) {
+                $rootScope.$emit('torrentFiles:open', selected[0]);
+            }
+            return $q.resolve();
+        }
         return action.call($rootScope.$btclient, selected)
             .then(function(){
                 return $scope.update();

--- a/src/scripts/controllers/torrents.ts
+++ b/src/scripts/controllers/torrents.ts
@@ -1,7 +1,9 @@
 import { IRootScopeService } from "angular";
 import Fuse from "fuse.js";
-import { TorrentUploadOptions } from "../bittorrent/torrentclient";
+import { Torrent } from "../bittorrent/abstracttorrent";
+import { ContextActionList, TorrentUploadOptions } from "../bittorrent/torrentclient";
 import { PendingTorrentUploadItem, PendingTorrentUploadList } from "../directives/add-torrent-modal/add-torrent-modal.directive"
+import { uiContextActions } from "../directives/contextmenu/ui-context-actions";
 
 interface TorrentControllerScope {
     pendingTorrentFiles: PendingTorrentUploadList
@@ -29,6 +31,7 @@ export let torrentsController = ["$rootScope", "$scope", "$timeout", "$filter", 
     $scope.totalDownloaded = 0;
     $scope.totalUploaded = 0;
     $scope.contextMenu = null;
+    $scope.composedContextMenu = [];
     $scope.showDragAndDrop = false;
     $scope.labelsDrowdown = null;
     $scope.torrentLimit = LIMIT;
@@ -372,12 +375,6 @@ export let torrentsController = ["$rootScope", "$scope", "$timeout", "$filter", 
     };
 
     $scope.doContextAction = function(action, label, item) {
-        if (item && item.id === 'torrent-files') {
-            if (selected.length >= 1) {
-                $rootScope.$emit('torrentFiles:open', selected[0]);
-            }
-            return $q.resolve();
-        }
         return action.call($rootScope.$btclient, selected)
             .then(function(){
                 return $scope.update();
@@ -387,6 +384,28 @@ export let torrentsController = ["$rootScope", "$scope", "$timeout", "$filter", 
                 $notify.alert("Invalid action", "The action could not be performed because the server responded with a faulty reply");
             })
     }
+
+    function composeContextMenu() {
+        var client = $rootScope.$btclient;
+        if (!client) {
+            $scope.composedContextMenu = [];
+            return;
+        }
+        var prefix = uiContextActions
+            .filter(function (a) { return a.appliesTo(client); })
+            .map(function (a) {
+                return {
+                    label: a.label,
+                    icon: a.icon,
+                    click: function (torrents) {
+                        return a.click({ torrents: torrents, rootScope: $rootScope });
+                    }
+                };
+            });
+        $scope.composedContextMenu = [...prefix, ...client.contextMenu] as ContextActionList<Torrent>;
+    }
+
+    $rootScope.$watch(function () { return $rootScope.$btclient; }, composeContextMenu);
 
     function fetchTorrents() {
         return Array.from(Object.values($scope.torrents));

--- a/src/scripts/directives/contextmenu.ts
+++ b/src/scripts/directives/contextmenu.ts
@@ -39,9 +39,6 @@ export let contextMenu = ['$rootScope', '$document', '$window', 'electron', func
             if (item.menu) {
                 appendSubmenu(list, item, scope);
             } else {
-                if (item.id === 'torrent-files' && (!$rootScope.$btclient || !$rootScope.$btclient.supportsFileSelection)) {
-                    return;
-                }
                 appendMenuItem(list, item, scope);
             }
         });

--- a/src/scripts/directives/contextmenu.ts
+++ b/src/scripts/directives/contextmenu.ts
@@ -39,7 +39,7 @@ export let contextMenu = ['$rootScope', '$document', '$window', 'electron', func
             if (item.menu) {
                 appendSubmenu(list, item, scope);
             } else {
-                if (item.id === 'torrent-files' && $rootScope.$btclient && !$rootScope.$btclient.supportsFileSelection) {
+                if (item.id === 'torrent-files' && (!$rootScope.$btclient || !$rootScope.$btclient.supportsFileSelection)) {
                     return;
                 }
                 appendMenuItem(list, item, scope);

--- a/src/scripts/directives/contextmenu.ts
+++ b/src/scripts/directives/contextmenu.ts
@@ -39,6 +39,9 @@ export let contextMenu = ['$rootScope', '$document', '$window', 'electron', func
             if (item.menu) {
                 appendSubmenu(list, item, scope);
             } else {
+                if (item.id === 'torrent-files' && $rootScope.$btclient && !$rootScope.$btclient.supportsFileSelection) {
+                    return;
+                }
                 appendMenuItem(list, item, scope);
             }
         });
@@ -73,7 +76,7 @@ export let contextMenu = ['$rootScope', '$document', '$window', 'electron', func
 
         menuItem.bind('click', function() {
             contextMenu.hide();
-            scope.click(item.click, item.label);
+            scope.click(item.click, item.label, item);
         });
 
         menuItem.append(item.label);

--- a/src/scripts/directives/contextmenu/ui-context-actions.ts
+++ b/src/scripts/directives/contextmenu/ui-context-actions.ts
@@ -1,0 +1,33 @@
+import { IRootScopeService } from "angular";
+import { Torrent } from "../../bittorrent/abstracttorrent";
+import { TorrentClient } from "../../bittorrent/torrentclient";
+
+export interface UiContextActionContext<T extends Torrent = Torrent> {
+  torrents: T[];
+  rootScope: IRootScopeService;
+}
+
+export interface UiContextAction<T extends Torrent = Torrent> {
+  label: string;
+  icon?: string;
+  appliesTo(client: TorrentClient<T>): boolean;
+  click(ctx: UiContextActionContext<T>): Promise<void>;
+}
+
+/**
+ * Context menu entries owned by the UI layer (not by {@link TorrentClient.contextMenu}).
+ * Each entry is shown only when {@link UiContextAction.appliesTo} holds for the active client.
+ */
+export const uiContextActions: UiContextAction[] = [
+  {
+    label: "Files",
+    icon: "file",
+    appliesTo: (c) => c.supportsFileSelection === true,
+    click: ({ torrents, rootScope }) => {
+      if (torrents.length >= 1) {
+        rootScope.$emit("torrentFiles:open", torrents[0]);
+      }
+      return Promise.resolve();
+    },
+  },
+];

--- a/src/scripts/directives/torrent-files-modal/torrent-files-modal.controller.ts
+++ b/src/scripts/directives/torrent-files-modal/torrent-files-modal.controller.ts
@@ -61,10 +61,10 @@ export class TorrentFilesModalController {
       });
   }
 
-  loadFiles(): ng.IPromise<TorrentFile[] | void> {
+  loadFiles(): Promise<TorrentFile[] | void> {
     const torrent = this.scope.torrent;
     if (!torrent || !this.rootScope.$btclient || !this.rootScope.$btclient.supportsFileSelection) {
-      return this.scope.$q ? this.scope.$q.resolve() : Promise.resolve();
+      return Promise.resolve();
     }
     this.scope.loading = true;
     this.scope.error = null;
@@ -78,7 +78,7 @@ export class TorrentFilesModalController {
       })
       .finally(() => {
         this.scope.loading = false;
-      }) as ng.IPromise<TorrentFile[] | void>;
+      });
   }
 
   onShow() {

--- a/src/scripts/directives/torrent-files-modal/torrent-files-modal.controller.ts
+++ b/src/scripts/directives/torrent-files-modal/torrent-files-modal.controller.ts
@@ -1,0 +1,115 @@
+import { IRootScopeService, IScope } from "angular";
+import { TorrentFile } from "../../bittorrent/abstracttorrent";
+import { ModalController } from "../modal/modal.controller";
+
+export interface TorrentFilesModalScope extends IScope {
+  torrent: any;
+  files: TorrentFile[];
+  loading: boolean;
+  error: string | null;
+  onClose: () => void;
+}
+
+export class TorrentFilesModalController {
+  static $inject = ["$scope", "$rootScope", "$timeout"];
+
+  scope: TorrentFilesModalScope;
+  rootScope: IRootScopeService;
+  modalref: ModalController;
+  $timeout: ng.ITimeoutService;
+  private unsubscribeOpen?: () => void;
+
+  constructor(
+    scope: TorrentFilesModalScope,
+    rootScope: IRootScopeService,
+    $timeout: ng.ITimeoutService
+  ) {
+    this.scope = scope;
+    this.rootScope = rootScope;
+    this.$timeout = $timeout;
+    this.scope.files = [];
+    this.scope.loading = false;
+    this.scope.error = null;
+    this.scope.onClose = () => this.close();
+
+    const off = this.rootScope.$on("torrentFiles:open", (_event, torrent) => {
+      this.open(torrent);
+    });
+    this.unsubscribeOpen = () => off();
+
+    this.scope.$on("$destroy", () => {
+      if (this.unsubscribeOpen) {
+        this.unsubscribeOpen();
+      }
+    });
+  }
+
+  open(torrent: any) {
+    this.scope.torrent = torrent;
+    this.scope.files = [];
+    this.scope.loading = true;
+    this.scope.error = null;
+    this.loadFiles()
+      .then(() => {
+        this.scope.loading = false;
+        if (this.modalref) {
+          this.modalref.showModal();
+        }
+      })
+      .catch(() => {
+        this.scope.loading = false;
+      });
+  }
+
+  loadFiles(): ng.IPromise<TorrentFile[] | void> {
+    const torrent = this.scope.torrent;
+    if (!torrent || !this.rootScope.$btclient || !this.rootScope.$btclient.supportsFileSelection) {
+      return this.scope.$q ? this.scope.$q.resolve() : Promise.resolve();
+    }
+    this.scope.loading = true;
+    this.scope.error = null;
+    return this.rootScope.$btclient
+      .getTorrentFiles(torrent)
+      .then((files) => {
+        this.scope.files = files || [];
+      })
+      .catch((err) => {
+        this.scope.error = err && err.message ? err.message : "Failed to load files";
+      })
+      .finally(() => {
+        this.scope.loading = false;
+      }) as ng.IPromise<TorrentFile[] | void>;
+  }
+
+  onShow() {
+  }
+
+  onHidden() {
+    this.scope.torrent = null;
+    this.scope.files = [];
+    this.scope.error = null;
+  }
+
+  close() {
+    if (this.modalref) {
+      this.modalref.hideModal();
+    }
+  }
+
+  async save() {
+    const { torrent, files } = this.scope;
+    if (!torrent || !files || !files.length) {
+      this.close();
+      return;
+    }
+    try {
+      this.scope.loading = true;
+      await this.rootScope.$btclient.setTorrentFileSelection(torrent, files);
+      this.close();
+    } catch (err) {
+      this.scope.error = err && err.message ? err.message : "Failed to save selection";
+    } finally {
+      this.scope.loading = false;
+    }
+  }
+}

--- a/src/scripts/directives/torrent-files-modal/torrent-files-modal.directive.ts
+++ b/src/scripts/directives/torrent-files-modal/torrent-files-modal.directive.ts
@@ -1,0 +1,16 @@
+import { IDirective, IDirectiveFactory } from "angular";
+import { TorrentFilesModalController } from "./torrent-files-modal.controller";
+import html from "./torrent-files-modal.template.html";
+
+export class TorrentFilesModalDirective implements IDirective {
+  template = html;
+  restrict = "E";
+  scope = {
+  };
+  controller = TorrentFilesModalController;
+  controllerAs = "ctl";
+
+  static getInstance(): IDirectiveFactory {
+    return () => new TorrentFilesModalDirective();
+  }
+}

--- a/src/scripts/directives/torrent-files-modal/torrent-files-modal.template.html
+++ b/src/scripts/directives/torrent-files-modal/torrent-files-modal.template.html
@@ -1,0 +1,33 @@
+<div
+  class="ui small modal"
+  id="torrentFilesModal"
+  modal-new
+  on-show="ctl.onShow()"
+  on-hidden="ctl.onHidden()"
+  ng-ref="ctl.modalref"
+  ng-ref-read="modal-new"
+>
+  <i class="close icon"></i>
+  <div class="header">
+    <i class="file icon"></i>
+    Files
+    <div class="sub header" ng-if="ctl.scope.torrent">{{ ctl.scope.torrent.name }}</div>
+  </div>
+  <div class="content">
+    <div ng-if="ctl.scope.loading && !ctl.scope.files.length" class="ui active inline loader"></div>
+    <div ng-if="ctl.scope.error" class="ui negative message">{{ ctl.scope.error }}</div>
+    <torrent-files-tree files="ctl.scope.files" ng-if="ctl.scope.files.length"></torrent-files-tree>
+  </div>
+  <div class="actions">
+    <button type="button" class="ui black button" ng-click="ctl.close()">Cancel</button>
+    <button
+      type="button"
+      class="ui green right labeled icon button"
+      ng-class="{ disabled: ctl.scope.loading }"
+      ng-click="ctl.save()"
+    >
+      Save
+      <i class="checkmark icon"></i>
+    </button>
+  </div>
+</div>

--- a/src/scripts/directives/torrent-files-tree/indeterminate-value.directive.ts
+++ b/src/scripts/directives/torrent-files-tree/indeterminate-value.directive.ts
@@ -1,0 +1,18 @@
+/**
+ * Sets checkbox element's indeterminate property from scope expression.
+ * Use as: <input type="checkbox" indeterminate-value="row._folderIndeterminate" ... />
+ */
+export function indeterminateValueDirective(): ng.IDirective {
+  return {
+    restrict: "A",
+    link(_scope: ng.IScope, el: ng.IAugmentedJQuery, attrs: ng.IAttributes) {
+      const expr = (attrs as any).indeterminateValue;
+      if (!expr) return;
+      _scope.$watch(expr, (v: boolean) => {
+        if (el[0] && (el[0] as HTMLInputElement).indeterminate !== !!v) {
+          (el[0] as HTMLInputElement).indeterminate = !!v;
+        }
+      });
+    },
+  };
+}

--- a/src/scripts/directives/torrent-files-tree/torrent-files-tree.controller.ts
+++ b/src/scripts/directives/torrent-files-tree/torrent-files-tree.controller.ts
@@ -1,0 +1,101 @@
+import { IScope } from "angular";
+import { TorrentFile } from "../../bittorrent/abstracttorrent";
+import { buildTorrentFileRows, TorrentFileRow } from "./torrent-files-tree.helper";
+
+export interface TorrentFilesTreeScope extends IScope {
+  files: TorrentFile[];
+  rows: TorrentFileRow[];
+  visibleRows: TorrentFileRow[];
+  expandedFolders: Record<string, boolean>;
+  selectAll: () => void;
+  selectNone: () => void;
+  invertSelection: () => void;
+  toggleExpanded: (path: string) => void;
+  isExpanded: (path: string) => boolean;
+  getFolderWanted: (row: TorrentFileRow) => boolean;
+  setFolderWanted: (row: TorrentFileRow, value: boolean) => void;
+  getFolderIndeterminate: (row: TorrentFileRow) => boolean;
+}
+
+export class TorrentFilesTreeController {
+  static $inject = ["$scope"];
+
+  constructor(private scope: TorrentFilesTreeScope) {
+    scope.expandedFolders = {};
+    scope.visibleRows = [];
+    scope.selectAll = () => this.selectAll();
+    scope.selectNone = () => this.selectNone();
+    scope.invertSelection = () => this.invertSelection();
+    scope.toggleExpanded = (path: string) => this.toggleExpanded(path);
+    scope.isExpanded = (path: string) => this.isExpanded(path);
+    scope.getFolderWanted = (row: TorrentFileRow) => this.getFolderWanted(row);
+    scope.setFolderWanted = (row: TorrentFileRow, value: boolean) => this.setFolderWanted(row, value);
+    scope.getFolderIndeterminate = (row: TorrentFileRow) => this.getFolderIndeterminate(row);
+    scope.$watch(
+      () => scope.files,
+      (files: TorrentFile[]) => {
+        scope.rows = buildTorrentFileRows(files || []);
+        this.updateVisibleRows();
+      },
+      true
+    );
+    scope.$watch(
+      () => scope.expandedFolders,
+      () => this.updateVisibleRows(),
+      true
+    );
+  }
+
+  private updateVisibleRows() {
+    const { rows, expandedFolders } = this.scope;
+    if (!rows || !rows.length) {
+      this.scope.visibleRows = [];
+      return;
+    }
+    this.scope.visibleRows = rows.filter(
+      (row) => row.depth === 0 || expandedFolders[row.parentPath!]
+    );
+    this.scope.visibleRows.forEach((row) => {
+      if (row.isDirectory) {
+        (row as any)._folderWanted = this.getFolderWanted(row);
+        (row as any)._folderIndeterminate = this.getFolderIndeterminate(row);
+      }
+    });
+  }
+
+  private toggleExpanded(path: string) {
+    this.scope.expandedFolders[path] = !this.scope.expandedFolders[path];
+    this.updateVisibleRows();
+  }
+
+  private isExpanded(path: string): boolean {
+    return !!this.scope.expandedFolders[path];
+  }
+
+  private getFolderWanted(row: TorrentFileRow): boolean {
+    if (!row.filesInSubtree || !row.filesInSubtree.length) return false;
+    return row.filesInSubtree.every((f) => f.wanted);
+  }
+
+  private setFolderWanted(row: TorrentFileRow, value: boolean) {
+    (row.filesInSubtree || []).forEach((f) => (f.wanted = value));
+  }
+
+  private getFolderIndeterminate(row: TorrentFileRow): boolean {
+    if (!row.filesInSubtree || !row.filesInSubtree.length) return false;
+    const wanted = row.filesInSubtree.filter((f) => f.wanted).length;
+    return wanted > 0 && wanted < row.filesInSubtree.length;
+  }
+
+  selectAll() {
+    (this.scope.files || []).forEach((f) => (f.wanted = true));
+  }
+
+  selectNone() {
+    (this.scope.files || []).forEach((f) => (f.wanted = false));
+  }
+
+  invertSelection() {
+    (this.scope.files || []).forEach((f) => (f.wanted = !f.wanted));
+  }
+}

--- a/src/scripts/directives/torrent-files-tree/torrent-files-tree.controller.ts
+++ b/src/scripts/directives/torrent-files-tree/torrent-files-tree.controller.ts
@@ -57,8 +57,8 @@ export class TorrentFilesTreeController {
     );
     this.scope.visibleRows.forEach((row) => {
       if (row.isDirectory) {
-        (row as any)._folderWanted = this.getFolderWanted(row);
-        (row as any)._folderIndeterminate = this.getFolderIndeterminate(row);
+        row._folderWanted = this.getFolderWanted(row);
+        row._folderIndeterminate = this.getFolderIndeterminate(row);
       }
     });
   }

--- a/src/scripts/directives/torrent-files-tree/torrent-files-tree.directive.ts
+++ b/src/scripts/directives/torrent-files-tree/torrent-files-tree.directive.ts
@@ -1,0 +1,17 @@
+import { IDirective, IDirectiveFactory } from "angular";
+import { TorrentFilesTreeController } from "./torrent-files-tree.controller";
+import html from "./torrent-files-tree.template.html";
+
+export class TorrentFilesTreeDirective implements IDirective {
+  template = html;
+  restrict = "E";
+  scope = {
+    files: "=",
+  };
+  controller = TorrentFilesTreeController;
+  controllerAs = "ctl";
+
+  static getInstance(): IDirectiveFactory {
+    return () => new TorrentFilesTreeDirective();
+  }
+}

--- a/src/scripts/directives/torrent-files-tree/torrent-files-tree.helper.ts
+++ b/src/scripts/directives/torrent-files-tree/torrent-files-tree.helper.ts
@@ -1,0 +1,117 @@
+/**
+ * Builds a flat tree-like list of rows (folders + files) from TorrentFile[].
+ * Folders have size = sum of file sizes inside; folders can be expanded/collapsed.
+ */
+import { TorrentFile } from "../../bittorrent/abstracttorrent";
+
+export interface TorrentFileRow {
+  depth: number;
+  name: string;
+  path: string;
+  parentPath: string | null;
+  size: number;
+  file?: TorrentFile;
+  isDirectory: boolean;
+  /** All files in this folder's subtree (for folder rows only) */
+  filesInSubtree: TorrentFile[];
+}
+
+interface TreeNode {
+  name: string;
+  path: string;
+  children: Map<string, TreeNode>;
+  file?: TorrentFile;
+  totalSize: number;
+  filesInSubtree: TorrentFile[];
+}
+
+function collectSizeAndFiles(node: TreeNode): void {
+  if (node.file != null) {
+    node.totalSize = node.file.size || 0;
+    node.filesInSubtree = [node.file];
+    return;
+  }
+  node.totalSize = 0;
+  node.filesInSubtree = [];
+  const children = Array.from(node.children.values()).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  children.forEach((child) => {
+    collectSizeAndFiles(child);
+    node.totalSize += child.totalSize;
+    node.filesInSubtree.push(...child.filesInSubtree);
+  });
+}
+
+export function buildTorrentFileRows(files: TorrentFile[]): TorrentFileRow[] {
+  if (!files || !files.length) return [];
+
+  const root: TreeNode = {
+    name: "",
+    path: "",
+    children: new Map<string, TreeNode>(),
+    totalSize: 0,
+    filesInSubtree: [],
+  };
+
+  files.forEach((file) => {
+    const rawPath = (file.path || file.name || "").replace(/\\/g, "/");
+    const parts = rawPath.split("/").filter(Boolean);
+    if (!parts.length) return;
+
+    let current = root;
+    let currentPath = "";
+    parts.forEach((part, index) => {
+      currentPath = currentPath ? `${currentPath}/${part}` : part;
+      let child = current.children.get(part);
+      if (!child) {
+        child = {
+          name: part,
+          path: currentPath,
+          children: new Map<string, TreeNode>(),
+          totalSize: 0,
+          filesInSubtree: [],
+        };
+        current.children.set(part, child);
+      }
+      if (index === parts.length - 1) {
+        child.file = file;
+      }
+      current = child;
+    });
+  });
+
+  collectSizeAndFiles(root);
+
+  const rows: TorrentFileRow[] = [];
+
+  const traverse = (node: TreeNode, depth: number, parentPath: string | null) => {
+    if (node === root) {
+      const children = Array.from(node.children.values()).sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+      children.forEach((child) => traverse(child, 0, null));
+      return;
+    }
+
+    const isDirectory = node.file == null || node.children.size > 0;
+    rows.push({
+      depth,
+      name: node.name,
+      path: node.path,
+      parentPath,
+      size: node.totalSize,
+      file: node.file,
+      isDirectory,
+      filesInSubtree: node.filesInSubtree,
+    });
+
+    const children = Array.from(node.children.values()).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+    children.forEach((child) => traverse(child, depth + 1, node.path));
+  };
+
+  traverse(root, 0, null);
+  return rows;
+}

--- a/src/scripts/directives/torrent-files-tree/torrent-files-tree.helper.ts
+++ b/src/scripts/directives/torrent-files-tree/torrent-files-tree.helper.ts
@@ -14,6 +14,9 @@ export interface TorrentFileRow {
   isDirectory: boolean;
   /** All files in this folder's subtree (for folder rows only) */
   filesInSubtree: TorrentFile[];
+  /** Folder-level checkbox state, computed in controller for template convenience. */
+  _folderWanted?: boolean;
+  _folderIndeterminate?: boolean;
 }
 
 interface TreeNode {

--- a/src/scripts/directives/torrent-files-tree/torrent-files-tree.template.html
+++ b/src/scripts/directives/torrent-files-tree/torrent-files-tree.template.html
@@ -1,0 +1,48 @@
+<div class="torrent-files-tree">
+  <div class="ui small buttons" style="margin-bottom: 0.5rem;">
+    <button type="button" class="ui button" ng-click="selectAll()">Select all</button>
+    <button type="button" class="ui button" ng-click="selectNone()">Deselect all</button>
+    <button type="button" class="ui button" ng-click="invertSelection()">Invert</button>
+  </div>
+  <div class="ui list" style="max-height: 320px; overflow-y: auto;">
+    <div
+      class="item"
+      ng-repeat="row in visibleRows track by row.path"
+      style="padding-left: {{ row.depth * 16 + 8 }}px; display: flex; align-items: center; gap: 6px;"
+    >
+      <span
+        ng-if="row.isDirectory"
+        class="expand-icon"
+        ng-click="toggleExpanded(row.path)"
+        style="cursor: pointer; flex-shrink: 0; width: 20px; text-align: center;"
+        title="{{ isExpanded(row.path) ? 'Collapse' : 'Expand' }}"
+      >
+        <i class="ui icon chevron right" ng-if="!isExpanded(row.path)"></i>
+        <i class="ui icon chevron down" ng-if="isExpanded(row.path)"></i>
+      </span>
+      <span ng-if="!row.isDirectory" style="width: 20px; flex-shrink: 0;"></span>
+      <div class="ui checkbox" ng-if="row.isDirectory" ng-click="$event.stopPropagation();">
+        <input
+          type="checkbox"
+          ng-checked="row._folderWanted"
+          indeterminate-value="row._folderIndeterminate"
+          ng-click="setFolderWanted(row, !row._folderWanted); $event.stopPropagation();"
+          id="folder-cb-{{ row.path }}"
+        />
+        <label for="folder-cb-{{ row.path }}"></label>
+      </div>
+      <div class="ui checkbox" ng-if="row.file" ng-click="$event.stopPropagation();">
+        <input type="checkbox" ng-model="row.file.wanted" id="file-cb-{{ row.file.index }}" />
+        <label for="file-cb-{{ row.file.index }}"></label>
+      </div>
+      <span
+        class="content"
+        style="flex: 1; word-break: break-all; min-width: 0;"
+        title="{{ row.path }}"
+        ng-click="row.isDirectory && toggleExpanded(row.path)"
+        ng-style="row.isDirectory && { cursor: 'pointer' }"
+      >{{ row.name }}</span>
+      <span class="meta" style="flex-shrink: 0;">{{ row.size | bytes }}</span>
+    </div>
+  </div>
+</div>

--- a/src/views/torrents.html
+++ b/src/views/torrents.html
@@ -166,7 +166,7 @@
     </div>
   </div>
 
-  <context-menu id="contextmenu" bind="contextMenu" menu="$btclient.contextMenu" click="doContextAction" debug="debug">
+  <context-menu id="contextmenu" bind="contextMenu" menu="composedContextMenu" click="doContextAction" debug="debug">
   </context-menu>
 
   <add-torrent-modal

--- a/src/views/torrents.html
+++ b/src/views/torrents.html
@@ -174,4 +174,6 @@
     labels="labels"
     upload-torrent-action="uploadTorrent">
   </add-torrent-modal>
+
+  <torrent-files-modal></torrent-files-modal>
 </div>

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -201,6 +201,62 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
             await torrent.checkInState(["all", "downloading"])
           })
 
+          describe("given file selection is supported", function () {
+            before(function () {
+              if (!(options.client as any).supportsFileSelection) {
+                this.skip()
+              }
+            })
+
+            it("persists file wanted state via Files modal", async function () {
+              this.timeout(60 * 1000)
+
+              // Open context menu for the torrent row
+              const row = $(torrent.query)
+              await row.waitForExist({ timeout: 60 * 1000 })
+              await row.click({ button: "right" })
+
+              const contextMenu = $("#contextmenu")
+              await contextMenu.waitForDisplayed()
+
+              // Click the Files item in the context menu
+              const filesItem = contextMenu.$("a=Files")
+              await filesItem.waitForDisplayed()
+              await filesItem.click()
+              await contextMenu.waitForDisplayed({ reverse: true })
+
+              const modal = $("#torrentFilesModal")
+              await modal.waitForDisplayed()
+
+              // Wait for at least one file checkbox
+              const firstFileCheckbox = modal.$('.torrent-files-tree input[id^="file-cb-"]')
+              await firstFileCheckbox.waitForExist({ timeout: 30_000 })
+
+              const initialSelected = await firstFileCheckbox.isSelected()
+              await firstFileCheckbox.click()
+
+              const saveButton = modal.$("button.ui.green")
+              await saveButton.waitForEnabled()
+              await saveButton.click()
+              await modal.waitForDisplayed({ reverse: true })
+
+              // Reopen Files modal and verify state persisted
+              await row.click({ button: "right" })
+              await contextMenu.waitForDisplayed()
+              const filesItem2 = contextMenu.$("a=Files")
+              await filesItem2.waitForDisplayed()
+              await filesItem2.click()
+              await contextMenu.waitForDisplayed({ reverse: true })
+              await modal.waitForDisplayed()
+
+              const firstFileCheckboxAfter = modal.$('.torrent-files-tree input[id^="file-cb-"]')
+              await firstFileCheckboxAfter.waitForExist({ timeout: 30_000 })
+              const selectedAfter = await firstFileCheckboxAfter.isSelected()
+
+              chai.expect(selectedAfter).to.equal(!initialSelected)
+            })
+          })
+
           describe("given labels are supported", function () {
             requireFeatureHook(options, FeatureSet.Labels)
 

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -6,7 +6,7 @@ import e2e = require("./e2e");
 import { FeatureSet, setupMochaHooks, waitForHttp } from "./testutil"
 import { dockerComposeHooks, startApplicationHooks, restartApplication } from "./shared"
 import { TorrentClient } from "../src/scripts/bittorrent"
-import { browser } from '@wdio/globals'
+import { browser, $ } from '@wdio/globals'
 import { createTorrentFile } from "./torrent";
 
 
@@ -199,6 +199,62 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
             await torrent.resume({ state: options.downloadLabel });
             await torrent.waitForState(options.downloadLabel)
             await torrent.checkInState(["all", "downloading"])
+          })
+
+          describe("given file selection is supported", function () {
+            before(function () {
+              if (!(options.client as any).supportsFileSelection) {
+                this.skip()
+              }
+            })
+
+            it("persists file wanted state via Files modal", async function () {
+              this.timeout(60 * 1000)
+
+              // Open context menu for the torrent row
+              const row = $(torrent.query)
+              await row.waitForExist({ timeout: 60 * 1000 })
+              await row.click({ button: "right" })
+
+              const contextMenu = $("#contextmenu")
+              await contextMenu.waitForDisplayed()
+
+              // Click the Files item in the context menu
+              const filesItem = contextMenu.$("a=Files")
+              await filesItem.waitForDisplayed()
+              await filesItem.click()
+              await contextMenu.waitForDisplayed({ reverse: true })
+
+              const modal = $("#torrentFilesModal")
+              await modal.waitForDisplayed()
+
+              // Wait for at least one file checkbox
+              const firstFileCheckbox = modal.$('.torrent-files-tree input[id^="file-cb-"]')
+              await firstFileCheckbox.waitForExist({ timeout: 30_000 })
+
+              const initialSelected = await firstFileCheckbox.isSelected()
+              await firstFileCheckbox.click()
+
+              const saveButton = modal.$("button.ui.green")
+              await saveButton.waitForEnabled()
+              await saveButton.click()
+              await modal.waitForDisplayed({ reverse: true })
+
+              // Reopen Files modal and verify state persisted
+              await row.click({ button: "right" })
+              await contextMenu.waitForDisplayed()
+              const filesItem2 = contextMenu.$("a=Files")
+              await filesItem2.waitForDisplayed()
+              await filesItem2.click()
+              await contextMenu.waitForDisplayed({ reverse: true })
+              await modal.waitForDisplayed()
+
+              const firstFileCheckboxAfter = modal.$('.torrent-files-tree input[id^="file-cb-"]')
+              await firstFileCheckboxAfter.waitForExist({ timeout: 30_000 })
+              const selectedAfter = await firstFileCheckboxAfter.isSelected()
+
+              chai.expect(selectedAfter).to.equal(!initialSelected)
+            })
           })
 
           describe("given labels are supported", function () {


### PR DESCRIPTION
## Summary

- Add a new "Files" modal with a tree-based view for torrent contents.
- Implement per-file wanted/unwanted selection for qBittorrent using its Web API.
- Show folder nodes with aggregated size, tri-state checkboxes, and expand/collapse behavior.

## Details

- Introduced a shared `TorrentFile` model and `supportsFileSelection` flag on `TorrentClient`.
- Implemented `getTorrentFiles` and `setTorrentFileSelection` for qBittorrent, backed by `torrents/files` and `torrents/filePrio` endpoints.
- Added a `torrent-files-modal` directive that listens for the `torrentFiles:open` event and lazily loads files before showing the modal.
- Added a `torrent-files-tree` directive that:
  - Builds a folder/file tree from flat paths.
  - Aggregates folder size as the sum of all files in its subtree.
  - Supports collapsing/expanding folders and tri-state folder checkboxes (all, none, partial).
- Integrated the "Files" entry into the torrent context menu, only when `supportsFileSelection` is true (currently qBittorrent only).
