### PR TITLE
fix: replace deprecated --debug flag with --inspect

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,7 +183,7 @@ gulp.task('install', gulp.parallel('build:semantic'))
 gulp.task('develop', gulp.series("build", function() {
   watch({})
   return gulp.src(OUT)
-    .pipe(startApp(["--debug"], { cwd: OUT }))
+    .pipe(startApp(["--inspect=9229", "--", "--debug"], { cwd: OUT }))
 }))
 
 gulp.task('default', gulp.parallel('develop'));


### PR DESCRIPTION
## Summary
- replace deprecated Node debug flag usage in the Electron dev task
- pass modern inspector flag to Electron: --inspect=9229
- preserve app-level debug behavior by forwarding --debug after --

## Why
Electron/Node no longer supports --debug/--debug-brk and emits DEP0062.