### PR TITLE
Fix qBittorrent free space footer updates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,7 +183,7 @@ gulp.task('install', gulp.parallel('build:semantic'))
 gulp.task('develop', gulp.series("build", function() {
   watch({})
   return gulp.src(OUT)
-    .pipe(startApp(["--debug"], { cwd: OUT }))
+    .pipe(startApp(["--inspect=9229", "--", "--debug"], { cwd: OUT }))
 }))
 
 gulp.task('default', gulp.parallel('develop'));

--- a/src/scripts/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/scripts/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -16,6 +16,7 @@ function defer<T>(fn: (f: CallbackFunc) => void): Promise<T> {
   })
 }
 
+
 export interface QBittorrentUploadOptions {
   savepath?: string
   cookie?: string
@@ -43,9 +44,11 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
     public id = "qbittorrent"
 
     private qbittorrent: any
+    private freeSpaceOnDisk: number | null = null
 
     connect(server): Promise<void> {
       let ca = server.getCertificate();
+      this.freeSpaceOnDisk = null
 
       this.qbittorrent = new QBittorrent({
           host: server.url(),
@@ -77,11 +80,16 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
     };
 
     processData(data: Record<string, any>) {
+      if (data && data.server_state && data.server_state.free_space_on_disk !== undefined) {
+        this.freeSpaceOnDisk = data.server_state.free_space_on_disk;
+      }
+
       var torrents = {
         labels: [],
         all: [],
         changed: [],
         deleted: [],
+        freeDiskSpace: this.freeSpaceOnDisk,
       };
 
       if (Array.isArray(data.categories) || Array.isArray(data.labels)) {
@@ -349,4 +357,3 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
       },
     ];
 }
-

--- a/src/scripts/bittorrent/torrentclient.ts
+++ b/src/scripts/bittorrent/torrentclient.ts
@@ -7,6 +7,7 @@ export interface TorrentUpdates {
     all?: any[],
     changed?: any[],
     deletes?: [],
+    freeDiskSpace?: number | null,
 }
 
 /**
@@ -204,4 +205,3 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
      */
     public abstract contextMenu: ContextActionList<T>
 };
-

--- a/src/scripts/controllers/torrents.ts
+++ b/src/scripts/controllers/torrents.ts
@@ -28,6 +28,7 @@ export let torrentsController = ["$rootScope", "$scope", "$timeout", "$filter", 
     $scope.totalUploadSpeed = 0;
     $scope.totalDownloaded = 0;
     $scope.totalUploaded = 0;
+    $scope.freeDiskSpace = null;
     $scope.contextMenu = null;
     $scope.showDragAndDrop = false;
     $scope.labelsDrowdown = null;
@@ -532,6 +533,7 @@ export let torrentsController = ["$rootScope", "$scope", "$timeout", "$filter", 
             changeTorrents(torrents);
             updateLabels(torrents);
             updateTrackers(torrents);
+            $scope.freeDiskSpace = torrents.freeDiskSpace ?? null;
         }).then(function() {
             if (!$scope.arrayTorrents || $scope.arrayTorrents.length === 0) {
                 $scope.renderDone()

--- a/src/views/torrents.html
+++ b/src/views/torrents.html
@@ -163,6 +163,10 @@
         <i class="ui orange arrow up icon"></i>
         {{ totalUploadSpeed | speed }} <span ng-if="totalUploaded">({{ totalUploaded | bytes:2 }})</span>
       </div>
+      <div class="free-space" ng-if="freeDiskSpace != null">
+        <i class="ui grey database icon"></i>
+        Free: {{ freeDiskSpace | bytes }}
+      </div>
     </div>
   </div>
 

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -249,4 +249,8 @@ export class App {
     let labels = await data
     return labels || [];
   }
+
+  async getTorrentsFooterText() {
+    return await $("#page-torrents .status-bar").getText()
+  }
 }

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -140,6 +140,15 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           await this.app.torrentsPageIsVisible()
         })
 
+        if (options.client.id === "qbittorrent") {
+          it("shows qBittorrent free space in the footer", async function() {
+            await browser.waitUntil(async () => {
+              const footerText = await this.app.getTorrentsFooterText();
+              return footerText.includes("Free:");
+            });
+          });
+        }
+
         describe("when a magnet link is uploaded", async function() {
           let torrent: e2e.Torrent
           requireFeatureHook(options, FeatureSet.MagnetLinks)


### PR DESCRIPTION
## Summary
- keep the torrents footer client-agnostic by rendering from a generic `freeDiskSpace` scope value
- populate `freeDiskSpace` through `TorrentUpdates` and have qBittorrent cache the last known disk value across incremental sync responses
- add a qBittorrent E2E assertion that the footer shows the free-space label

## Why
The final review comment on #377 asked for the HTML to avoid client-specific conditions and for the data layer to make `diskSpaceLeft` style state authoritative instead. This update moves the client-specific logic into the qBittorrent service and controller data flow so the template only checks whether free disk space is available.