### PR TITLE
fix: update readme shield anchors to be inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,9 @@
   <img src="assets/electron-icon.png" width="256">
 </p>
 <p align="center">
-  <a href="https://travis-ci.org/tympanix/Electorrent">
-    <img src="https://travis-ci.org/tympanix/Electorrent.svg?branch=master">
-  </a>
-  <a href="https://github.com/tympanix/Electorrent/releases/latest">
-    <img src="https://img.shields.io/github/release/tympanix/Electorrent.svg?maxAge=86400">
-  </a>
-  <a href="http://www.somsubhra.com/github-release-stats/?username=tympanix&repository=Electorrent">
-    <img src="https://img.shields.io/github/downloads/tympanix/Electorrent/total.svg?maxAge=86400">
-  </a>
+  <a href="https://travis-ci.org/tympanix/Electorrent"><img src="https://travis-ci.org/tympanix/Electorrent.svg?branch=master"></a>
+  <a href="https://github.com/tympanix/Electorrent/releases/latest"><img src="https://img.shields.io/github/release/tympanix/Electorrent.svg?maxAge=86400"></a>
+  <a href="http://www.somsubhra.com/github-release-stats/?username=tympanix&repository=Electorrent"><img src="https://img.shields.io/github/downloads/tympanix/Electorrent/total.svg?maxAge=86400"></a>
 </p>
 
 # Electorrent


### PR DESCRIPTION
I ran into the same issue recently while working on a README and thought I’d submit a quick PR to fix it.

When the badge anchors are not written inline, small blue underline artifacts appear between the shields in the README.

This PR removes the extra line breaks and keeps the badges inline to avoid the issue.