### PR TITLE
feature: extend upload options for clients

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -9,6 +9,7 @@ const DELUGE_TORRENT_FIELDS = [
     "download_payload_rate",
     "eta",
     "is_auto_managed",
+    "max_connections",
     "max_download_speed",
     "max_upload_speed",
     "name",
@@ -73,6 +74,11 @@ export class DelugeRuntime implements BittorrentRuntime {
         return Object.fromEntries(
             Object.entries({
                 download_location: options.saveLocation,
+                add_paused: options.startTorrent === undefined ? undefined : !options.startTorrent,
+                max_connections: options.peerLimit,
+                max_download_speed: options.downloadSpeedLimit,
+                max_upload_speed: options.uploadSpeedLimit,
+                prioritize_first_last_pieces: options.firstAndLastPiecePrio,
             }).filter(([, value]) => value !== undefined && value !== null),
         )
     }
@@ -209,8 +215,11 @@ export class DelugeRuntime implements BittorrentRuntime {
                 pieceSize: details.piece_length ?? null,
                 totalDownloaded: details.total_done ?? null,
                 totalUploaded: details.total_uploaded ?? null,
+                uploadLimit: details.max_upload_speed ?? null,
+                downloadLimit: details.max_download_speed ?? null,
                 timeElapsed: details.active_time ?? null,
                 seedingTime: details.seeding_time ?? null,
+                connectionsLimit: details.max_connections ?? null,
                 shareRatio: details.ratio ?? null,
                 additionDate: details.time_added ?? null,
                 completionDate: details.completed_time ?? null,

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -244,10 +244,11 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 reannounce: properties.reannounce ?? null,
                 seeds: properties.seeds ?? null,
                 seedsTotal: properties.seeds_total ?? null,
+                sequentialDownload: properties.seq_dl ?? null,
                 totalSize: properties.total_size ?? null,
                 averageUploadSpeed: properties.up_speed_avg ?? null,
                 uploadSpeed: properties.up_speed ?? null,
-                isPrivate: properties.isPrivate ?? null,
+                isPrivate: properties.is_private ?? properties.isPrivate ?? null,
             },
             files: files.map((file: any, idx: number) => {
                 const priority = file.priority != null ? Number(file.priority) : undefined

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -39,6 +39,14 @@ export class RtorrentRuntime implements BittorrentRuntime {
         await this.call(method, params)
     }
 
+    private getLoadMethod(method: "url" | "file", options?: Record<string, any>) {
+        const shouldStart = options?.startTorrent !== false
+        if (method === "url") {
+            return shouldStart ? "load.start" : "load.normal"
+        }
+        return shouldStart ? "load.raw_start" : "load.raw"
+    }
+
     private async getMulticall(method: string, params: any[], commands: Record<string, string>): Promise<Record<string, any>[]> {
         const commandParams = [...params, ...Object.values(commands).map(postfix)]
         const data = await this.call<any[][]>(method, commandParams)
@@ -280,21 +288,23 @@ export class RtorrentRuntime implements BittorrentRuntime {
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {
+        const method = this.getLoadMethod("url", options)
         if (options?.saveLocation) {
-            await this.loadTorrentWithSaveLocation("load.start", uri, options.saveLocation)
+            await this.loadTorrentWithSaveLocation(method, uri, options.saveLocation)
             return
         }
 
-        await this.call("load.start", ["", uri])
+        await this.call(method, ["", uri])
     }
 
     async uploadTorrent(buffer: Uint8Array, _filename: string, options?: Record<string, any>): Promise<void> {
+        const method = this.getLoadMethod("file", options)
         if (options?.saveLocation) {
-            await this.loadTorrentWithSaveLocation("load.raw_start", buffer, options.saveLocation)
+            await this.loadTorrentWithSaveLocation(method, buffer, options.saveLocation)
             return
         }
 
-        await this.call("load.raw_start", ["", Buffer.from(buffer)])
+        await this.call(method, ["", Buffer.from(buffer)])
     }
 
     async start(hashes: string[]): Promise<void> {

--- a/src/main/lib/bittorrent/clients/synology.ts
+++ b/src/main/lib/bittorrent/clients/synology.ts
@@ -92,6 +92,7 @@ export class SynologyRuntime implements BittorrentRuntime {
                         version: this.dlVersion,
                         method: 'create',
                         uri: args[0],
+                        destination: args[1],
                     },
                     timeout: this.timeout,
                 }
@@ -194,19 +195,28 @@ export class SynologyRuntime implements BittorrentRuntime {
         return response.data.data
     }
 
-    async addTorrentUrl(uri: string): Promise<void> {
-        const response = await this.http.get(`${serverUrl(this.server)}${this.taskPath}`, this.config('tUrl', [uri]))
+    private getUploadOptions(options?: Record<string, any>) {
+        return {
+            destination: options?.saveLocation,
+        }
+    }
+
+    async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {
+        const response = await this.http.get(`${serverUrl(this.server)}${this.taskPath}`, this.config('tUrl', [uri, this.getUploadOptions(options).destination]))
         this.handleError(response)
         if (!this.isSuccess(response.data)) {
             throw new Error(`Create a DownloadStation task with the provided URL failed. Error: ${response.data.error}`)
         }
     }
 
-    async uploadTorrent(buffer: Uint8Array, filename?: string): Promise<void> {
+    async uploadTorrent(buffer: Uint8Array, filename?: string, options?: Record<string, any>): Promise<void> {
         const formData = new FormData()
         formData.append('api', API_TASK)
         formData.append('version', this.dlVersion)
         formData.append('method', 'create')
+        if (options?.saveLocation) {
+            formData.append('destination', options.saveLocation)
+        }
         formData.append('file', Buffer.from(buffer), {
             filename: filename || 'upload.torrent',
             contentType: 'application/x-bittorrent',

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -58,6 +58,8 @@ const TRANSMISSION_FIELDS = [
     'recheckProgress',
     'secondsDownloading',
     'secondsSeeding',
+    'sequentialDownload',
+    'sequential_download',
     'seedIdleLimit',
     'seedIdleMode',
     'seedRatioLimit',
@@ -229,6 +231,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
                 isPrivate: torrent.isPrivate ?? null,
                 errorString: torrent.errorString ?? null,
                 queuePosition: torrent.queuePosition ?? null,
+                sequentialDownload: torrent.sequentialDownload ?? torrent.sequential_download ?? null,
             },
             files: files.map((file: any, index: number) => {
                 const stats = fileStats[index] || {}
@@ -278,42 +281,77 @@ export class TransmissionRuntime implements BittorrentRuntime {
 
         return this.removeEmpty({
             'download-dir': uploadOptions.saveLocation,
-            paused: !uploadOptions.startTorrent,
+            paused: uploadOptions.startTorrent === undefined ? undefined : !uploadOptions.startTorrent,
         })
     }
 
-    async addTorrentUrl(uri: string, uploadOptions?: Record<string, any>): Promise<void> {
-        const resp = await this.getHttpClient().post(this.url(), {
+    private getPostAddUploadOptions(uploadOptions?: Record<string, any>) {
+        if (!uploadOptions) {
+            return {}
+        }
+
+        const downloadLimit = uploadOptions.downloadSpeedLimit
+        const uploadLimit = uploadOptions.uploadSpeedLimit
+
+        return this.removeEmpty({
+            'peer-limit': uploadOptions.peerLimit,
+            sequentialDownload: uploadOptions.sequentialDownload,
+            sequential_download: uploadOptions.sequentialDownload,
+            downloadLimit,
+            downloadLimited: downloadLimit === undefined ? undefined : true,
+            uploadLimit,
+            uploadLimited: uploadLimit === undefined ? undefined : true,
+        })
+    }
+
+    private getAddedTorrentId(response: any) {
+        const added = response?.data?.arguments?.['torrent-added']
+            || response?.data?.arguments?.torrent_added
+
+        return typeof added?.id === 'number' ? added.id : null
+    }
+
+    private async addTorrent(argumentsData: Record<string, any>, uploadOptions?: Record<string, any>) {
+        const response = await this.getHttpClient().post(this.url(), {
             arguments: {
-                filename: uri,
+                ...argumentsData,
                 ...this.getUploadOptions(uploadOptions),
             },
             method: 'torrent-add',
         }, {})
 
-        if ('torrent-duplicate' in resp.data.arguments) {
+        if ('torrent-duplicate' in response.data.arguments) {
             throw new Error('Could not add duplicate torrent to transmission')
         }
-        if (resp.data.result !== 'success') {
-            throw new Error(`Could not add torrent to transmission: ${resp.data.result}`)
+        if (response.data.result !== 'success') {
+            throw new Error(`Could not add torrent to transmission: ${response.data.result}`)
         }
+
+        const postAddOptions = this.getPostAddUploadOptions(uploadOptions)
+        const addedTorrentId = this.getAddedTorrentId(response)
+        if (Object.keys(postAddOptions).length === 0) {
+            return
+        }
+        if (addedTorrentId == null) {
+            throw new Error('Transmission did not return the added torrent id')
+        }
+
+        await this.doAction('torrent-set', [], {
+            ids: [addedTorrentId],
+            ...postAddOptions,
+        }).then((setResponse) => this.ensureSuccess(setResponse)).then(() => undefined)
+    }
+
+    async addTorrentUrl(uri: string, uploadOptions?: Record<string, any>): Promise<void> {
+        await this.addTorrent({
+            filename: uri,
+        }, uploadOptions)
     }
 
     async uploadTorrent(buffer: Uint8Array, _filename: string, uploadOptions?: Record<string, any>): Promise<void> {
-        const resp = await this.getHttpClient().post(this.url(), {
-            arguments: {
-                metainfo: Buffer.from(buffer).toString('base64'),
-                ...this.getUploadOptions(uploadOptions),
-            },
-            method: 'torrent-add',
-        }, {})
-
-        if ('torrent-duplicate' in resp.data.arguments) {
-            throw new Error('Could not add duplicate torrent to transmission')
-        }
-        if (resp.data.result !== 'success') {
-            throw new Error(`Could not add torrent to transmission: ${resp.data.result}`)
-        }
+        await this.addTorrent({
+            metainfo: Buffer.from(buffer).toString('base64'),
+        }, uploadOptions)
     }
 
     private doAction(command: string, hashes: string[], mutator?: string | Record<string, any>, value?: any) {

--- a/src/renderer/app/bittorrent/deluge/delugeservice.ts
+++ b/src/renderer/app/bittorrent/deluge/delugeservice.ts
@@ -9,6 +9,11 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
     public supportsTorrentDetails = true
     public uploadOptionsEnable = {
         saveLocation: true,
+        startTorrent: true,
+        peerLimit: true,
+        firstAndLastPiecePrio: true,
+        downloadSpeedLimit: true,
+        uploadSpeedLimit: true,
     }
 
     connect(server): Promise<void> {
@@ -100,6 +105,8 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
                 this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
                 this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
                 this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
+                this.createTorrentDetailsField("download-limit", "Download Limit (KB/s)", this.toNumber(info.downloadLimit), "number"),
+                this.createTorrentDetailsField("upload-limit", "Upload Limit (KB/s)", this.toNumber(info.uploadLimit), "number"),
                 this.createTorrentDetailsField("eta", "ETA", this.toEpochSeconds(info.eta), "eta"),
                 this.createTorrentDetailsField("active-time", "Active Time", this.toNumber(info.timeElapsed), "number"),
                 this.createTorrentDetailsField("seeding-time", "Seeding Time", this.toNumber(info.seedingTime), "number"),
@@ -109,6 +116,7 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
                 this.createTorrentDetailsField("seeds-total", "Total Seeds", this.toNumber(info.seedsTotal), "number"),
                 this.createTorrentDetailsField("peers", "Connected Peers", this.toNumber(info.peers), "number"),
                 this.createTorrentDetailsField("peers-total", "Total Peers", this.toNumber(info.peersTotal), "number"),
+                this.createTorrentDetailsField("connections-limit", "Peer Limit", this.toNumber(info.connectionsLimit), "number"),
                 this.createTorrentDetailsField("copies", "Distributed Copies", this.toNumber(info.distributedCopies), "number"),
                 this.createTorrentDetailsField("tracker", "Tracker", info.trackerHost as string | null),
             ]),

--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -214,6 +214,8 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
           this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
           this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
           this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
+          this.createTorrentDetailsField("download-limit", "Download Limit (KB/s)", this.toNumber(info.downloadLimit) ?? this.toNumber(torrent.downLimit), "number"),
+          this.createTorrentDetailsField("upload-limit", "Upload Limit (KB/s)", this.toNumber(info.uploadLimit) ?? this.toNumber(torrent.upLimit), "number"),
           this.createTorrentDetailsField("download-speed-avg", "Average Download Speed", this.toNumber(info.averageDownloadSpeed), "speed"),
           this.createTorrentDetailsField("upload-speed-avg", "Average Upload Speed", this.toNumber(info.averageUploadSpeed), "speed"),
           this.createTorrentDetailsField("eta", "ETA", this.toEpochSeconds(info.eta), "eta"),
@@ -222,9 +224,18 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
         this.createTorrentDetailsSection("content", "Content", [
           this.createTorrentDetailsField("piece-size", "Piece Size", this.toNumber(info.pieceSize), "bytes"),
           this.createTorrentDetailsField("pieces", "Pieces", piecesHave != null && piecesTotal != null ? `${piecesHave} / ${piecesTotal}` : null),
+          this.createTorrentDetailsField("sequential-download", "Sequential Download", (info.sequentialDownload as boolean | null) ?? torrent.sequentialDownload, "boolean"),
           this.createTorrentDetailsField("private", "Private Torrent", info.isPrivate as boolean | null, "boolean"),
           this.createTorrentDetailsField("created-by", "Created By", info.createdBy as string | null),
           this.createTorrentDetailsField("comment", "Comment", info.comment as string | null, "text", { multiline: true }),
+        ]),
+        this.createTorrentDetailsSection("swarm", "Swarm", [
+          this.createTorrentDetailsField("connections", "Connected Peers", this.toNumber(info.connections), "number"),
+          this.createTorrentDetailsField("connections-limit", "Peer Limit", this.toNumber(info.connectionsLimit) ?? this.toNumber(torrent.connectionsLimit), "number"),
+          this.createTorrentDetailsField("seeds", "Connected Seeds", this.toNumber(info.seeds) ?? torrent.seedsConnected, "number"),
+          this.createTorrentDetailsField("seeds-total", "Total Seeds", this.toNumber(info.seedsTotal) ?? torrent.seedsInSwarm, "number"),
+          this.createTorrentDetailsField("peers", "Connected Peers", this.toNumber(info.peers) ?? torrent.peersConnected, "number"),
+          this.createTorrentDetailsField("peers-total", "Total Peers", this.toNumber(info.peersTotal) ?? torrent.peersInSwarm, "number"),
         ]),
         this.createTorrentDetailsSection("dates", "Dates", [
           this.createTorrentDetailsField("added-on", "Added On", this.toEpochSeconds(info.additionDate), "epoch"),

--- a/src/renderer/app/bittorrent/rtorrent/rtorrentservice.ts
+++ b/src/renderer/app/bittorrent/rtorrent/rtorrentservice.ts
@@ -10,6 +10,7 @@ export class RtorrentClient extends TorrentClient<RtorrentTorrent> {
     public supportsTorrentDetails = true
     public uploadOptionsEnable = {
       saveLocation: true,
+      startTorrent: true,
     }
 
     connect(server): Promise<void> {

--- a/src/renderer/app/bittorrent/synology/synologyservice.ts
+++ b/src/renderer/app/bittorrent/synology/synologyservice.ts
@@ -1,4 +1,4 @@
-import { ContextActionList, TorrentActionList, TorrentClient, TorrentUpdates } from "@renderer/app/bittorrent/torrentclient";
+import { ContextActionList, TorrentActionList, TorrentClient, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { SynologyTorrent } from "./synologytorrent";
 import { addTorrentUrl, connect, getSnapshot, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 
@@ -6,6 +6,9 @@ export class SynologyClient extends TorrentClient<SynologyTorrent> {
     public name = 'Synology Download Station'
     public id = 'downloadstation'
     public supportsSetLocation = true
+    public uploadOptionsEnable = {
+        saveLocation: true,
+    }
 
     connect(server): Promise<void> {
         return connect(server)
@@ -33,12 +36,12 @@ export class SynologyClient extends TorrentClient<SynologyTorrent> {
         return "/webapi";
     }
 
-    addTorrentUrl(magnet: string): Promise<void> {
-        return addTorrentUrl(magnet)
+    addTorrentUrl(magnet: string, options?: TorrentUploadOptions): Promise<void> {
+        return addTorrentUrl(magnet, options)
     }
 
-    uploadTorrent(buffer: Uint8Array, filename?: string): Promise<void> {
-        return uploadTorrent(buffer, filename || "upload.torrent")
+    uploadTorrent(buffer: Uint8Array, filename?: string, options?: TorrentUploadOptions): Promise<void> {
+        return uploadTorrent(buffer, filename || "upload.torrent", options)
     }
 
     start(torrents: SynologyTorrent[]): Promise<void> {

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -25,6 +25,7 @@ export interface TorrentUploadOptions {
     renameTorrent?: string
     category?: string
     startTorrent?: boolean
+    peerLimit?: number
     skipCheck?: boolean
     sequentialDownload?: boolean
     firstAndLastPiecePrio?: boolean

--- a/src/renderer/app/bittorrent/transmission/transmissionservice.ts
+++ b/src/renderer/app/bittorrent/transmission/transmissionservice.ts
@@ -15,6 +15,10 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
     public uploadOptionsEnable: TorrentUploadOptionsEnable = {
       saveLocation: true,
       startTorrent: true,
+      peerLimit: true,
+      sequentialDownload: true,
+      downloadSpeedLimit: true,
+      uploadSpeedLimit: true,
     }
 
     connect(server): Promise<void> {
@@ -138,11 +142,14 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
           this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
           this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
           this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
+          this.createTorrentDetailsField("download-limit", "Download Limit (KB/s)", this.toNumber(info.downloadLimit), "number"),
+          this.createTorrentDetailsField("upload-limit", "Upload Limit (KB/s)", this.toNumber(info.uploadLimit), "number"),
           this.createTorrentDetailsField("eta", "ETA", this.toEpochSeconds(info.eta), "eta"),
         ]),
         this.createTorrentDetailsSection("content", "Content", [
           this.createTorrentDetailsField("piece-size", "Piece Size", this.toNumber(info.pieceSize), "bytes"),
           this.createTorrentDetailsField("pieces", "Pieces", this.toNumber(info.piecesTotal), "number"),
+          this.createTorrentDetailsField("sequential-download", "Sequential Download", info.sequentialDownload as boolean | null, "boolean"),
           this.createTorrentDetailsField("private", "Private Torrent", info.isPrivate as boolean | null, "boolean"),
           this.createTorrentDetailsField("created-by", "Created By", info.createdBy as string | null),
           this.createTorrentDetailsField("comment", "Comment", info.comment as string | null, "text", { multiline: true }),

--- a/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.template.html
+++ b/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.template.html
@@ -60,15 +60,22 @@
                 <div class="field" ng-if="ctl.optionsEnabled.downloadSpeedLimit">
                     <div class="ui left icon input">
                         <i class="arrow circle down icon"></i>
-                        <input id="upload-options-downloadspeedlimit" type="number" placeholder="Download speed limit (KB/s)" ng-model="options.downloadSpeedLimit">
+                        <input data-action="download-speed-limit" id="upload-options-downloadspeedlimit" type="number" placeholder="Download speed limit (KB/s)" ng-model="options.downloadSpeedLimit">
                     </div>
                 </div>
                 <div class="field" ng-if="ctl.optionsEnabled.uploadSpeedLimit">
                     <div class="ui left icon input">
                         <i class="arrow circle up icon"></i>
-                        <input id="upload-options-uploadspeedlimit" type="number" placeholder="Upload speed limit (KB/s)" ng-model="options.uploadSpeedLimit">
+                        <input data-action="upload-speed-limit" id="upload-options-uploadspeedlimit" type="number" placeholder="Upload speed limit (KB/s)" ng-model="options.uploadSpeedLimit">
                     </div>
                 </div>
+            </div>
+        </div>
+
+        <div class="field" ng-if="ctl.optionsEnabled.peerLimit">
+            <div class="ui left icon input">
+                <i class="users icon"></i>
+                <input data-action="peer-limit" id="upload-options-peerlimit" type="number" placeholder="Peer limit" ng-model="options.peerLimit">
             </div>
         </div>
 

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -161,7 +161,38 @@ export class App {
     return modal
   }
 
-  async uploadTorrentModalSubmit(options?: { label?: string, start?: boolean, name?: string, saveLocation?: string }) {
+  private async setUploadToggle(modal: WebdriverIO.Element, action: string, enabled: boolean) {
+    const toggle = modal.$(`div[data-action="${action}"]`)
+    const toggleInput = toggle.$("input")
+    await toggle.waitForDisplayed()
+    await toggleInput.waitForExist()
+    await toggleInput.scrollIntoView()
+    if (await toggleInput.isSelected() !== enabled) {
+      await toggleInput.click()
+      await browser.waitUntil(async () => (await toggleInput.isSelected()) === enabled, {
+        timeout: 5_000,
+        timeoutMsg: `Expected ${action} toggle to become ${enabled}`,
+      })
+    }
+  }
+
+  private async setUploadNumberInput(modal: WebdriverIO.Element, action: string, value: number) {
+    const input = modal.$(`input[data-action='${action}']`)
+    await input.waitForDisplayed()
+    await input.setValue(String(value))
+  }
+
+  async uploadTorrentModalSubmit(options?: {
+    label?: string
+    start?: boolean
+    name?: string
+    saveLocation?: string
+    peerLimit?: number
+    sequentialDownload?: boolean
+    firstAndLastPiecePrio?: boolean
+    downloadSpeedLimit?: number
+    uploadSpeedLimit?: number
+  }) {
     const modal = await this.uploadTorrentModalVisible()
     await browser.pause(200)
 
@@ -178,18 +209,27 @@ export class App {
     }
 
     if (options?.start !== undefined) {
-      const startToggle = modal.$(`div[data-action="start-torrent"]`)
-      const startToggleInput = startToggle.$("input")
-      await startToggle.waitForDisplayed()
-      await startToggleInput.waitForExist()
-      await startToggleInput.scrollIntoView()
-      if (await startToggleInput.isSelected() !== options.start) {
-        await startToggleInput.click()
-        await browser.waitUntil(async () => (await startToggleInput.isSelected()) === options.start, {
-          timeout: 5_000,
-          timeoutMsg: `Expected start torrent toggle to become ${options.start}`,
-        })
-      }
+      await this.setUploadToggle(modal, "start-torrent", options.start)
+    }
+
+    if (options?.sequentialDownload !== undefined) {
+      await this.setUploadToggle(modal, "sequential-download", options.sequentialDownload)
+    }
+
+    if (options?.firstAndLastPiecePrio !== undefined) {
+      await this.setUploadToggle(modal, "first-last-piece-prio", options.firstAndLastPiecePrio)
+    }
+
+    if (options?.downloadSpeedLimit !== undefined) {
+      await this.setUploadNumberInput(modal, "download-speed-limit", options.downloadSpeedLimit)
+    }
+
+    if (options?.uploadSpeedLimit !== undefined) {
+      await this.setUploadNumberInput(modal, "upload-speed-limit", options.uploadSpeedLimit)
+    }
+
+    if (options?.peerLimit !== undefined) {
+      await this.setUploadNumberInput(modal, "peer-limit", options.peerLimit)
     }
 
     if (options?.label) {

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -143,6 +143,15 @@ export class Torrent {
     await panel.waitForDisplayed({ timeout: this.timeout, reverse: true })
   }
 
+  async getDetailsFieldValue(fieldId: string) {
+    const panel = $("[data-role='torrent-details-panel']")
+    await panel.waitForDisplayed({ timeout: this.timeout })
+
+    const field = panel.$(`[data-role='torrent-details-field'][data-field-id='${fieldId}'] .value`)
+    await field.waitForDisplayed({ timeout: this.timeout })
+    return await field.getText()
+  }
+
   async setLocation(location: string) {
     const modal = await this.openSetLocationModal();
     const input = modal.$("input[name='location']");

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -773,6 +773,68 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
             await torrent.delete()
           })
 
+          it("torrent uploaded with peer limit", async function() {
+            this.timeout(30 * 1000)
+            if (!options.client.uploadOptionsEnable?.peerLimit) return this.skip()
+            const peerLimit = 8
+            const torrent = await this.app.uploadTorrent({ filename: this.torrentPath, askUploadOptions: true });
+            await this.app.uploadTorrentModalSubmit({ peerLimit })
+            await torrent.waitForExist({ timeout: 20 * 1000 })
+            await torrent.waitForStates([options.downloadLabel, "Seeding"], { timeout: 20 * 1000 })
+            await torrent.openDetailsPanel()
+            await browser.waitUntil(async () => (await torrent.getDetailsFieldValue("connections-limit")) === String(peerLimit), {
+              timeout: 10 * 1000,
+              timeoutMsg: `Expected peer limit to become ${peerLimit}`,
+            })
+            await torrent.closeDetailsPanel()
+            await torrent.delete()
+          })
+
+          it("torrent uploaded with speed limits", async function() {
+            this.timeout(30 * 1000)
+            if (!options.client.uploadOptionsEnable?.downloadSpeedLimit && !options.client.uploadOptionsEnable?.uploadSpeedLimit) return this.skip()
+            const downloadSpeedLimit = 111
+            const uploadSpeedLimit = 37
+            const torrent = await this.app.uploadTorrent({ filename: this.torrentPath, askUploadOptions: true });
+            await this.app.uploadTorrentModalSubmit({
+              downloadSpeedLimit: options.client.uploadOptionsEnable?.downloadSpeedLimit ? downloadSpeedLimit : undefined,
+              uploadSpeedLimit: options.client.uploadOptionsEnable?.uploadSpeedLimit ? uploadSpeedLimit : undefined,
+            })
+            await torrent.waitForExist({ timeout: 20 * 1000 })
+            await torrent.waitForStates([options.downloadLabel, "Seeding"], { timeout: 20 * 1000 })
+            await torrent.openDetailsPanel()
+            if (options.client.uploadOptionsEnable?.downloadSpeedLimit) {
+              await browser.waitUntil(async () => (await torrent.getDetailsFieldValue("download-limit")) === String(downloadSpeedLimit), {
+                timeout: 10 * 1000,
+                timeoutMsg: `Expected download limit to become ${downloadSpeedLimit}`,
+              })
+            }
+            if (options.client.uploadOptionsEnable?.uploadSpeedLimit) {
+              await browser.waitUntil(async () => (await torrent.getDetailsFieldValue("upload-limit")) === String(uploadSpeedLimit), {
+                timeout: 10 * 1000,
+                timeoutMsg: `Expected upload limit to become ${uploadSpeedLimit}`,
+              })
+            }
+            await torrent.closeDetailsPanel()
+            await torrent.delete()
+          })
+
+          it("torrent uploaded with sequential download", async function() {
+            this.timeout(30 * 1000)
+            if (!options.client.uploadOptionsEnable?.sequentialDownload) return this.skip()
+            const torrent = await this.app.uploadTorrent({ filename: this.torrentPath, askUploadOptions: true });
+            await this.app.uploadTorrentModalSubmit({ sequentialDownload: true })
+            await torrent.waitForExist({ timeout: 20 * 1000 })
+            await torrent.waitForStates([options.downloadLabel, "Seeding"], { timeout: 20 * 1000 })
+            await torrent.openDetailsPanel()
+            await browser.waitUntil(async () => (await torrent.getDetailsFieldValue("sequential-download")) === "Yes", {
+              timeout: 10 * 1000,
+              timeoutMsg: "Expected sequential download to be enabled",
+            })
+            await torrent.closeDetailsPanel()
+            await torrent.delete()
+          })
+
           it("torrent uploaded with name", async function() {
             if (!options.client.uploadOptionsEnable?.renameTorrent) return this.skip()
             const torrentName = "my awesome torrent"


### PR DESCRIPTION
Added upload options:
- Deluge now supports startTorrent, peerLimit, downloadSpeedLimit, uploadSpeedLimit, and firstAndLastPiecePrio
- Transmission now supports startTorrent, peerLimit, downloadSpeedLimit, uploadSpeedLimit, and sequentialDownload
- rTorrent now respects startTorrent (fix)
- Synology Download Station now supports saveLocation (untested)