### PR TITLE
feat: torrent menu collaped layout

### DIFF
--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -33,6 +33,7 @@ const defaultSettings: MainAppSettings = {
         cleanNames: true,
         fixedHeader: false,
         theme: 'light',
+        sidebarCollapsed: false,
     },
 }
 

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -116,6 +116,21 @@ export class TorrentsPageController {
             return $scope.filters.status === filter ? "active" : "";
         };
 
+        $scope.isSidebarCollapsed = () => {
+            return $scope.settings.ui.sidebarCollapsed === true;
+        };
+
+        $scope.toggleSidebarCollapsed = () => {
+            const previousValue = $scope.isSidebarCollapsed();
+            $scope.settings.ui.sidebarCollapsed = !previousValue;
+
+            return settingsService.saveAllSettings().catch((err: unknown) => {
+                $scope.settings.ui.sidebarCollapsed = previousValue;
+                $notify.alert("Could not save layout", "The sidebar preference could not be saved");
+                console.error("Sidebar layout save error", err);
+            });
+        };
+
         $scope.renderDone = () => {
             $scope.guiBusy = false;
             $timeout(() => {

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -1,4 +1,4 @@
-<div id="page-torrents" class="wrapper">
+<div id="page-torrents" class="wrapper" ng-class="{ 'is-sidebar-collapsed': isSidebarCollapsed() }">
     <div ng-if="connectionLost" class="popup animated">
         <div class="content">
             <h2 class="ui center aligned icon header">
@@ -8,69 +8,127 @@
         </div>
     </div>
     <div class="torrent sidebar">
-        <ul class="nav">
+        <div class="sidebar-scroll">
+            <div class="torrent-sidebar-header">
+                <button
+                    type="button"
+                    class="ui icon basic mini button torrent-sidebar-toggle"
+                    data-role="torrent-sidebar-toggle"
+                    ng-click="toggleSidebarCollapsed()"
+                    ng-attr-aria-label="{{ isSidebarCollapsed() ? 'Expand torrent sidebar' : 'Collapse torrent sidebar' }}"
+                    title="{{ isSidebarCollapsed() ? 'Expand sidebar' : 'Collapse sidebar' }}"
+                >
+                    <i class="angle double {{ isSidebarCollapsed() ? 'right' : 'left' }} icon"></i>
+                </button>
+            </div>
+            <ul class="nav">
             <li data-state="all" ng-click="filterByStatus('all')" ng-class="activeOn('all')">
                 <i class="ui large teal asterisk icon"></i>
-                All
+                <span class="torrent-sidebar-item-label">All</span>
                 <div class="ui torrent sort label">{{numInFilter('all')}}</div>
             </li>
             <li data-state="downloading" ng-click="filterByStatus('downloading')" ng-class="activeOn('downloading')">
                 <i class="ui large blue arrow down icon"></i>
-                Downloading
+                <span class="torrent-sidebar-item-label">Downloading</span>
                 <div class="ui torrent sort label">{{numInFilter('downloading')}}</div>
             </li>
             <li data-state="finished" ng-click="filterByStatus('finished')" ng-class="activeOn('finished')">
                 <i class="ui large green checkmark icon"></i>
-                Finished
+                <span class="torrent-sidebar-item-label">Finished</span>
                 <div class="ui torrent sort label">{{numInFilter('finished')}}</div>
             </li>
             <li data-state="seeding" ng-click="filterByStatus('seeding')" ng-class="activeOn('seeding')">
                 <i class="ui large orange arrow up icon"></i>
-                Seeding
+                <span class="torrent-sidebar-item-label">Seeding</span>
                 <div class="ui torrent sort label">{{numInFilter('seeding')}}</div>
             </li>
             <li data-state="stopped" ng-click="filterByStatus('stopped')" ng-class="activeOn('stopped')">
                 <i class="ui large grey pause icon"></i>
-                Stopped
+                <span class="torrent-sidebar-item-label">Stopped</span>
                 <div class="ui torrent sort label">{{numInFilter('stopped')}}</div>
             </li>
             <li data-state="error" ng-click="filterByStatus('error')" ng-class="activeOn('error')">
                 <i class="ui large red remove icon"></i>
-                Failed
+                <span class="torrent-sidebar-item-label">Failed</span>
                 <div class="ui torrent sort label">{{numInFilter('error')}}</div>
             </li>
-        </ul>
-        <div id="torrent-sidebar-labels">
-            <div class="section">
-                <span>Labels</span>
-                <a data-role="labels-clear" class="ui gray basic mini clear button" ng-click="filterByLabel()">Clear</a>
-            </div>
-            <ul class="filter label">
-                <span ng-if="labels.length == 0" class="meta text">No labels...</span>
-                <li data-label="{{label}}" ng-repeat="label in labels">
-                    <div class="ui fluid torrent tag label" ng-click="filterByLabel(label)" ng-class="{blue: activeLabel(label)}">
-                        {{label}}
-                    </div>
-                </li>
             </ul>
+            <div id="torrent-sidebar-labels" ng-if="!isSidebarCollapsed()">
+                <div class="section">
+                    <span>Labels</span>
+                    <a data-role="labels-clear" class="ui gray basic mini clear button" ng-click="filterByLabel()">Clear</a>
+                </div>
+                <ul class="filter label">
+                    <span ng-if="labels.length == 0" class="meta text">No labels...</span>
+                    <li data-label="{{label}}" ng-repeat="label in labels">
+                        <div class="ui fluid torrent tag label" ng-click="filterByLabel(label)" ng-class="{blue: activeLabel(label)}">
+                            {{label}}
+                        </div>
+                    </li>
+                </ul>
+            </div>
+            <div id="torrent-sidebar-trackers" ng-if="$btclient.enableTrackerFilter && !isSidebarCollapsed()">
+                <div class="section">
+                    <span>Trackers</span>
+                    <a data-role="trackers-clear" class="ui gray basic mini clear button" ng-click="filterByTracker()">Clear</a>
+                </div>
+                <ul class="filter label">
+                    <span ng-if="trackers.length == 0" class="meta text">No trackers...</span>
+                    <li ng-repeat="tracker in trackers">
+                        <div
+                            class="ui fluid torrent tag label"
+                            ng-click="filterByTracker(tracker)"
+                            ng-class="{blue: activeTracker(tracker)}"
+                        >
+                            {{tracker}}
+                        </div>
+                    </li>
+                </ul>
+            </div>
         </div>
-        <div id="torrent-sidebar-trackers" ng-if="$btclient.enableTrackerFilter">
-            <div class="section">
-                <span>Trackers</span>
-                <a data-role="trackers-clear" class="ui gray basic mini clear button" ng-click="filterByTracker()">Clear</a>
+        <div class="sidebar-collapsed-sections" ng-if="isSidebarCollapsed()">
+            <div class="sidebar-collapsed-section">
+            <div class="torrent-sidebar-section-trigger" data-role="torrent-sidebar-labels-toggle" title="Labels">
+                <i class="tags icon"></i>
             </div>
-            <ul class="filter label">
-                <span ng-if="trackers.length == 0" class="meta text">No trackers...</span>
-                <li ng-repeat="tracker in trackers">
-                    <div
-                        class="ui fluid torrent tag label"
-                        ng-click="filterByTracker(tracker)"
-                        ng-class="{blue: activeTracker(tracker)}"
-                    >
-                        {{tracker}}
+            <div id="torrent-sidebar-labels" class="sidebar-flyout">
+                <div class="section">
+                    <span>Labels</span>
+                        <a data-role="labels-clear" class="ui gray basic mini clear button" ng-click="filterByLabel()">Clear</a>
                     </div>
-                </li>
-            </ul>
+                    <ul class="filter label">
+                        <span ng-if="labels.length == 0" class="meta text">No labels...</span>
+                        <li data-label="{{label}}" ng-repeat="label in labels">
+                            <div class="ui fluid torrent tag label" ng-click="filterByLabel(label)" ng-class="{blue: activeLabel(label)}">
+                                {{label}}
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="sidebar-collapsed-section" ng-if="$btclient.enableTrackerFilter">
+                <div class="torrent-sidebar-section-trigger" data-role="torrent-sidebar-trackers-toggle" title="Trackers">
+                    <i class="sitemap icon"></i>
+                </div>
+                <div id="torrent-sidebar-trackers" class="sidebar-flyout">
+                    <div class="section">
+                        <span>Trackers</span>
+                        <a data-role="trackers-clear" class="ui gray basic mini clear button" ng-click="filterByTracker()">Clear</a>
+                    </div>
+                    <ul class="filter label">
+                        <span ng-if="trackers.length == 0" class="meta text">No trackers...</span>
+                        <li ng-repeat="tracker in trackers">
+                            <div
+                                class="ui fluid torrent tag label"
+                                ng-click="filterByTracker(tracker)"
+                                ng-class="{blue: activeTracker(tracker)}"
+                            >
+                                {{tracker}}
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -20,7 +20,8 @@ export let settingsService = ['$rootScope', '$bittorrent', 'notificationService'
             displayCompact: false,
             cleanNames: true,
             fixedHeader: false,
-            theme: 'light'
+            theme: 'light',
+            sidebarCollapsed: false,
         },
         servers: [],
         certificates: []

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -47,6 +47,32 @@ html, body {
     min-height: 100%;
     overflow: hidden;
 }
+#page-torrents {
+    --torrent-sidebar-width: 260px;
+    --torrent-sidebar-collapsed-width: 72px;
+}
+#page-torrents.is-sidebar-collapsed {
+    --torrent-sidebar-width: var(--torrent-sidebar-collapsed-width);
+}
+#page-torrents .sidebar {
+    display: flex;
+    flex-direction: column;
+    width: var(--torrent-sidebar-width);
+    overflow: visible;
+    z-index: 3;
+    transition: width 0.2s ease;
+}
+#page-torrents .sidebar + div {
+    width: calc(~"100% - var(--torrent-sidebar-width)");
+    transition: width 0.2s ease;
+}
+#page-torrents .sidebar-scroll {
+    flex: 1 1 auto;
+    height: 100%;
+    min-height: 0;
+    overflow-x: visible;
+    overflow-y: auto;
+}
 .torrent.sidebar {
     background-color: @pageForeground;
 }
@@ -67,6 +93,90 @@ html, body {
 }
 .sidebar .nav li:hover {
     background: @highlightBackground !important;
+}
+#page-torrents .torrent-sidebar-header {
+    display: flex;
+    justify-content: flex-end;
+    padding: 12px 14px 0;
+}
+#page-torrents.is-sidebar-collapsed .torrent-sidebar-header {
+    justify-content: center;
+    padding-left: 0;
+    padding-right: 0;
+}
+#page-torrents .torrent-sidebar-toggle {
+    margin: 0;
+    padding: 0 !important;
+    min-width: 0;
+    min-height: 0;
+    background: transparent !important;
+    border: 0 !important;
+    box-shadow: none !important;
+}
+#page-torrents .torrent-sidebar-toggle:hover,
+#page-torrents .torrent-sidebar-toggle:focus {
+    background: transparent !important;
+}
+#page-torrents .sidebar .nav {
+    transition: padding 0.2s ease;
+}
+#page-torrents .sidebar .nav li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    position: relative;
+    transition: margin 0.2s ease, padding 0.2s ease;
+}
+#page-torrents .sidebar .nav li > .icon {
+    margin: 0;
+    width: 1.25em;
+    min-width: 1.25em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+#page-torrents .torrent-sidebar-item-label {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    opacity: 1;
+    transition: opacity 0.15s ease, width 0.15s ease;
+}
+#page-torrents .torrent.sort.label {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    float: none;
+    min-height: 1.75em;
+    margin-left: auto;
+    line-height: 1;
+    transition: transform 0.2s ease;
+}
+#page-torrents.is-sidebar-collapsed .sidebar .nav {
+    padding-left: 8px;
+    padding-right: 8px;
+}
+#page-torrents.is-sidebar-collapsed .sidebar .nav li {
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: .2em;
+    padding: 13px 8px;
+    margin-left: 4px;
+    margin-right: 4px;
+}
+#page-torrents.is-sidebar-collapsed .torrent-sidebar-item-label {
+    flex: 0 0 0;
+    width: 0;
+    opacity: 0;
+}
+#page-torrents.is-sidebar-collapsed .torrent.sort.label {
+    min-width: 1.75em;
+    margin-left: 0;
+    padding: 0.35em 0.5em;
+    font-size: 0.7rem;
 }
 .sidebar .nav + .divider {
     margin-top: 0;
@@ -91,6 +201,66 @@ html, body {
     margin: 5px;
     list-style-type: none;
     cursor: pointer;
+}
+.sidebar-collapsed-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px 8px 16px;
+    border-top: 1px solid @borderColor;
+    background-color: @pageForeground;
+}
+.sidebar-collapsed-section {
+    position: relative;
+    display: flex;
+    justify-content: center;
+}
+.sidebar-collapsed-section::after {
+    content: '';
+    position: absolute;
+    top: -12px;
+    bottom: -12px;
+    left: 100%;
+    width: 12px;
+}
+.torrent-sidebar-section-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 10px;
+}
+.sidebar-collapsed-section:hover .torrent-sidebar-section-trigger {
+    background-color: @highlightBackground;
+}
+.sidebar-flyout {
+    position: absolute;
+    bottom: 0;
+    left: calc(~"100% + 12px");
+    width: 300px;
+    max-width: calc(~"100vw - 108px");
+    max-height: calc(~"100vh - 32px");
+    overflow-y: auto;
+    background-color: @pageForeground;
+    border: 1px solid @borderColor;
+    border-radius: 8px;
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.18);
+    opacity: 0;
+    transform: translateX(-10px);
+    pointer-events: none;
+    transition: opacity 0.18s ease, transform 0.18s ease;
+}
+.sidebar-collapsed-section:hover .sidebar-flyout {
+    opacity: 1;
+    transform: translateX(0);
+    pointer-events: auto;
+}
+.sidebar-flyout .section {
+    background-color: @pageForeground;
+}
+.sidebar-flyout .filter.label {
+    padding-right: 24px;
 }
 .torrent.tag {
     background-color: @highlightBackground;
@@ -154,6 +324,18 @@ html, body {
   max-width: none;
   min-width: 0;
   margin: 0;
+}
+@media (max-width: 900px) {
+    #page-torrents {
+        --torrent-sidebar-collapsed-width: 64px;
+    }
+    .sidebar-flyout {
+        left: calc(~"100% + 1.5em");
+        max-width: calc(~"100vw - 92px");
+    }
+    .sidebar-collapsed-section::after {
+        width: 1.5em;
+    }
 }
 .container > .content {
     position: absolute;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -139,6 +139,7 @@ export interface AppSettings<TServer = StoredServerConfig> {
         cleanNames: boolean
         fixedHeader: boolean
         theme: string
+        sidebarCollapsed: boolean
     }
     servers: TServer[]
     certificates: string[]

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -350,6 +350,27 @@ export class App {
     return await $("#page-torrents .status-bar").getText()
   }
 
+  async isTorrentSidebarCollapsed() {
+    const className = (await $("#page-torrents").getAttribute("class")) || ""
+    return className.includes("is-sidebar-collapsed")
+  }
+
+  async setTorrentSidebarCollapsed(collapsed: boolean) {
+    const toggle = $("[data-role='torrent-sidebar-toggle']")
+    await toggle.waitForDisplayed()
+
+    if (await this.isTorrentSidebarCollapsed() !== collapsed) {
+      await toggle.waitForClickable()
+      await toggle.click()
+      await browser.waitUntil(async () => {
+      return await this.isTorrentSidebarCollapsed() === collapsed
+      }, {
+      timeout: this.timeout,
+      timeoutMsg: `Expected torrent sidebar collapsed state to become ${collapsed}`,
+      })
+    }
+  }
+
   async openSettings() {
     const settingsPage = $("#page-settings")
     if (await settingsPage.isDisplayed()) {

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -154,6 +154,21 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           await this.app.torrentsPageIsVisible()
         })
 
+        it("sidebar can be collapsed and restored after refresh", async function() {
+          await this.app.setTorrentSidebarCollapsed(false)
+          await this.app.setTorrentSidebarCollapsed(true)
+
+          assert.isTrue(await this.app.isTorrentSidebarCollapsed())
+          await $("[data-role='torrent-sidebar-labels-toggle']").waitForDisplayed()
+
+          await restartApplication(this)
+          await this.app.torrentsPageIsVisible()
+          assert.isTrue(await this.app.isTorrentSidebarCollapsed())
+
+          await this.app.setTorrentSidebarCollapsed(false)
+          assert.isFalse(await this.app.isTorrentSidebarCollapsed())
+        })
+
         it("show settings when connection error after restarting app", async function() {
           this.timeout(25 * 1000)
           await backend.pause()


### PR DESCRIPTION
The left menu on the torrent page may not be collapsed to reduce consumed space. When collapsed, only icons will be shown for each state and labels/trackers use flyout menus