### PR TITLE
Parse torrent metadata for upload flows

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -2,7 +2,7 @@ import { app, dialog, ipcMain, shell, type BrowserWindow, type IpcMainInvokeEven
 import is from 'electron-is'
 
 import { IPC_CHANNELS } from '@shared/ipc'
-import type { AppSettings } from '@shared/ipc-contract'
+import type { AppSettings, PendingTorrentUploadLink } from '@shared/ipc-contract'
 import { getAppVersion } from './app-meta'
 import { bittorrentManager } from './bittorrent'
 import * as certificates from './certificates'
@@ -16,7 +16,7 @@ interface RegisterHandlersOptions {
     isDebug: boolean
     getWindow: () => BrowserWindow | null
     consumePendingLaunchPayload: () => Promise<{
-        magnets: string[]
+        magnets: PendingTorrentUploadLink[]
         torrentFiles: unknown[]
     }>
     onSettingsSaved?: (settings: AppSettings) => void | Promise<void>
@@ -116,6 +116,10 @@ export function registerHandlers({ isDebug, getWindow, consumePendingLaunchPaylo
 
     ipcMain.handle(IPC_CHANNELS.torrents.openFiles, async function(_event: IpcMainInvokeEvent, { askUploadOptions }) {
         return torrents.browse(askUploadOptions)
+    })
+
+    ipcMain.handle(IPC_CHANNELS.torrents.parse, async function(_event: IpcMainInvokeEvent, request) {
+        return torrents.parse(request)
     })
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }) {

--- a/src/main/lib/torrents.ts
+++ b/src/main/lib/torrents.ts
@@ -1,9 +1,15 @@
 import { dialog } from 'electron'
 import fs from 'fs'
 import path from 'path'
+import parseTorrent from 'parse-torrent'
 
 import { IPC_CHANNELS } from '@shared/ipc'
-import type { PendingTorrentUploadFile } from '@shared/ipc-contract'
+import type {
+    ParseTorrentRequest,
+    PendingTorrentUploadFile,
+    PendingTorrentUploadLink,
+    TorrentMetadata,
+} from '@shared/ipc-contract'
 import * as electorrent from './electorrent'
 
 function notify({ title = '', message = '', type = 'info' }) {
@@ -53,16 +59,51 @@ async function waitForStableFile(filePath: string, attempts = 6, delay = 250) {
     }
 }
 
+export function parse(request: ParseTorrentRequest): TorrentMetadata {
+    const source = 'uri' in request ? request.uri : Buffer.from(request.data)
+    const parsed = parseTorrent(source)
+
+    return {
+        name: parsed.name,
+        infoHash: parsed.infoHash,
+        length: parsed.length,
+        announce: parsed.announce || [],
+        files: (parsed.files || []).map((file) => ({
+            name: file.name,
+            path: file.path,
+            length: file.length,
+        })),
+    }
+}
+
+export function serializeMagnetLink(uri: string, askUploadOptions = false): PendingTorrentUploadLink {
+    const link: PendingTorrentUploadLink = {
+        type: 'link',
+        uri,
+        askUploadOptions,
+    }
+
+    try {
+        link.metadata = parse({ uri })
+    } catch {
+        // Invalid links are still passed through so the client can handle them.
+    }
+
+    return link
+}
+
 export async function serializeTorrentFile(filePath: string, askUploadOptions: boolean): Promise<PendingTorrentUploadFile> {
     await waitForStableFile(filePath)
 
     const data = await fs.promises.readFile(filePath)
+    const torrentData = new Uint8Array(data)
 
     return {
         type: 'file',
         filename: path.basename(filePath),
-        data: new Uint8Array(data),
+        data: torrentData,
         askUploadOptions: !!askUploadOptions,
+        metadata: parse({ data: torrentData }),
     }
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -16,6 +16,7 @@ import path from 'path'
 import yargs from 'yargs'
 
 import startup from '@main/lib/startup'
+import type { PendingTorrentUploadLink } from '@shared/ipc-contract'
 
 declare const __non_webpack_require__: NodeRequire | undefined
 
@@ -86,7 +87,7 @@ async function bootstrap() {
     let isQuitting = false
     let rendererLoaded = false
     const pendingLaunchPayload = {
-        magnets: [] as string[],
+        magnets: [] as PendingTorrentUploadLink[],
         torrentFilePaths: [] as string[],
     }
 
@@ -356,12 +357,12 @@ async function bootstrap() {
     }
 
     function queuePendingLaunchArgs(args: string[]) {
-        pendingLaunchPayload.magnets.push(...getMagnetLinks(args))
+        pendingLaunchPayload.magnets.push(...getMagnetLinks(args).map((uri) => torrents.serializeMagnetLink(uri)))
         pendingLaunchPayload.torrentFilePaths.push(...getTorrentFilePaths(args))
     }
 
     async function sendMagnetLinks(args: string[]) {
-        const magnetLinks = getMagnetLinks(args)
+        const magnetLinks = getMagnetLinks(args).map((uri) => torrents.serializeMagnetLink(uri))
         if (magnetLinks.length === 0 || !torrentWindow || torrentWindow.isDestroyed()) return
         torrentWindow.webContents.send(IPC_CHANNELS.launch.magnets, magnetLinks)
     }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,6 +1,7 @@
 import { clipboard, contextBridge, ipcRenderer } from 'electron'
 
 import { IPC_CHANNELS } from '@shared/ipc'
+import type { PendingTorrentUploadFile, PendingTorrentUploadLink } from '@shared/ipc-contract'
 
 function invoke<T = unknown>(channel: string, payload?: any): Promise<T> {
     return ipcRenderer.invoke(channel, payload)
@@ -31,11 +32,12 @@ contextBridge.exposeInMainWorld('electorrent', {
     },
     launch: {
         getPending: () => invoke(IPC_CHANNELS.launch.getPending),
-        onMagnets: (callback: (magnets: string[]) => void) => subscribe(IPC_CHANNELS.launch.magnets, callback),
-        onTorrentFiles: (callback: (files: Array<{ type: 'file'; data: Uint8Array; filename: string; askUploadOptions?: boolean }>) => void) => subscribe(IPC_CHANNELS.launch.torrentFiles, callback),
+        onMagnets: (callback: (magnets: PendingTorrentUploadLink[]) => void) => subscribe(IPC_CHANNELS.launch.magnets, callback),
+        onTorrentFiles: (callback: (files: PendingTorrentUploadFile[]) => void) => subscribe(IPC_CHANNELS.launch.torrentFiles, callback),
     },
     torrents: {
         openFiles: (askUploadOptions: boolean) => invoke(IPC_CHANNELS.torrents.openFiles, { askUploadOptions }),
+        parse: (request: unknown) => invoke(IPC_CHANNELS.torrents.parse, request),
     },
     bittorrent: {
         connect: (server: unknown) => invoke(IPC_CHANNELS.bittorrent.connect, { server }),

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
@@ -73,7 +73,7 @@ export class AddTorrentModalController {
             return ""
         }
 
-        return torrent.type === "file" ? torrent.filename : torrent.uri
+        return torrent.metadata?.name || (torrent.type === "file" ? torrent.filename : torrent.uri)
     }
 
     getPendingUploadCountLabel() {

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.directive.ts
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.directive.ts
@@ -1,6 +1,7 @@
 import { IDirective, IDirectiveFactory, IScope } from "angular";
 import { Torrent } from "@renderer/app/bittorrent";
 import { TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
+import type { TorrentMetadata } from "@shared/ipc-contract";
 import { AddTorrentModalController } from "./add-torrent-modal.controller";
 import html from "./add-torrent-modal.template.html"
 
@@ -12,11 +13,14 @@ export interface PendingTorrentUploadFile {
     type: 'file',
     data: Uint8Array,
     filename: string,
+    metadata?: TorrentMetadata
 }
 
 export interface PendingTorrentUploadLink {
     type: 'link'
     uri: string
+    askUploadOptions?: boolean
+    metadata?: TorrentMetadata
 }
 
 export interface AddTorrentModalScope extends IScope {

--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -97,11 +97,10 @@ export class AppShellController {
             connectToServer(server);
         };
 
-        const queueMagnetLinks = (magnets: string[], askUploadOptions = false) => {
-            pendingMagnets.push(...magnets.map((uri) => ({
-                type: "link" as const,
-                uri,
-                askUploadOptions,
+        const queueMagnetLinks = (magnets: PendingTorrentUploadLink[], askUploadOptions = false) => {
+            pendingMagnets.push(...magnets.map((link) => ({
+                ...link,
+                askUploadOptions: link.askUploadOptions ?? askUploadOptions,
             })));
         };
 
@@ -114,6 +113,7 @@ export class AppShellController {
                 type: "file",
                 data: new Uint8Array(file.data),
                 filename: file.filename,
+                metadata: file.metadata,
             };
             $scope.$broadcast("torrents:add", pendingFile, askUploadOptions);
         };
@@ -122,6 +122,7 @@ export class AppShellController {
             $scope.$broadcast("torrents:add", {
                 type: "link",
                 uri: link.uri,
+                metadata: link.metadata,
             }, askUploadOptions);
         };
 
@@ -139,7 +140,7 @@ export class AppShellController {
             });
         };
 
-        electorrent.launch.onMagnets((magnets: string[]) => {
+        electorrent.launch.onMagnets((magnets: PendingTorrentUploadLink[]) => {
             queueMagnetLinks(magnets);
             drainPendingLaunchPayloads();
             $scope.$applyAsync();

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -160,14 +160,34 @@ export class TorrentsPageController {
             return true;
         };
 
-        const processUploadItem = (item: PendingTorrentUploadItem, askUploadOptions: boolean) => {
+        const addTorrentMetadata = async (item: PendingTorrentUploadItem) => {
+            if (item.metadata) {
+                return item;
+            }
+
+            try {
+                item.metadata = item.type === "file"
+                    ? await window.electorrent.torrents.parse({ data: item.data })
+                    : await window.electorrent.torrents.parse({ uri: item.uri });
+            } catch (error) {
+                console.warn("Could not parse torrent metadata", error);
+            }
+
+            return item;
+        };
+
+        const processUploadItem = async (item: PendingTorrentUploadItem, askUploadOptions: boolean) => {
+            await addTorrentMetadata(item);
+
             if (shouldPromptForUploadOptions(item, askUploadOptions)) {
                 $scope.pendingTorrentFiles.push(item);
             } else if (item.type === "file") {
-                $scope.uploadTorrent(item.data, item.filename);
+                await $scope.uploadTorrent(item.data, item.filename);
             } else {
-                $scope.uploadTorrentURL(item.uri);
+                await $scope.uploadTorrentURL(item.uri);
             }
+
+            $scope.$applyAsync();
         };
 
         const flushDeferredUploads = () => {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -33,7 +33,33 @@ export interface PendingTorrentUploadFile {
     data: Uint8Array
     filename: string
     askUploadOptions?: boolean
+    metadata?: TorrentMetadata
 }
+
+export interface PendingTorrentUploadLink {
+    type: "link"
+    uri: string
+    askUploadOptions?: boolean
+    metadata?: TorrentMetadata
+}
+
+export interface TorrentMetadataFile {
+    name: string
+    path: string
+    length: number
+}
+
+export interface TorrentMetadata {
+    name?: string
+    infoHash?: string
+    length?: number
+    announce: string[]
+    files: TorrentMetadataFile[]
+}
+
+export type ParseTorrentRequest =
+    | { uri: string }
+    | { data: Uint8Array }
 
 export interface BittorrentServerConfig extends StoredServerConfig {
     certificateData?: Uint8Array
@@ -102,7 +128,7 @@ export interface BittorrentSetTorrentFileSelectionRequest {
 }
 
 export interface LaunchPayload {
-    magnets: string[]
+    magnets: PendingTorrentUploadLink[]
     torrentFiles: PendingTorrentUploadFile[]
 }
 
@@ -230,11 +256,12 @@ export interface ElectorrentBridge {
     }
     launch: {
         getPending(): Promise<LaunchPayload>
-        onMagnets(callback: (magnets: string[]) => void): Unsubscribe
+        onMagnets(callback: (magnets: PendingTorrentUploadLink[]) => void): Unsubscribe
         onTorrentFiles(callback: (files: PendingTorrentUploadFile[]) => void): Unsubscribe
     }
     torrents: {
         openFiles(askUploadOptions: boolean): Promise<PendingTorrentUploadFile[]>
+        parse(request: ParseTorrentRequest): Promise<TorrentMetadata>
     }
     bittorrent: {
         connect(server: BittorrentServerConfig): Promise<void>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -22,6 +22,7 @@ export const IPC_CHANNELS = {
     },
     torrents: {
         openFiles: 'torrents:open-files',
+        parse: 'torrents:parse',
     },
     bittorrent: {
         connect: 'bittorrent:connect',

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -294,6 +294,7 @@ export class App {
       const info = parseTorrent(data)
       magnetUri = magnet.encode({
         xt: [`urn:btih:${info.infoHash}`],
+        dn: info.name,
         tr: info.announce,
       })
     }
@@ -311,6 +312,11 @@ export class App {
     }, magnetUri, askUploadOptions)
     this.torrents.push(torrent)
     return torrent
+  }
+
+  async uploadTorrentModalLabel() {
+    const modal = await this.uploadTorrentModalVisible()
+    return modal.$(".content .sub.header").getText()
   }
 
   async waitForLabelInDropdown(labelName) {

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -813,7 +813,10 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
           it("magnet link opens upload options", async function() {
             const torrent = await this.app.uploadMagnetLink({ filename: this.torrentPath, askUploadOptions: true });
+            const torrentMetadata = parseTorrent(fs.readFileSync(this.torrentPath))
+
             await this.app.uploadTorrentModalVisible()
+            await this.app.uploadTorrentModalLabel().should.eventually.equal(torrentMetadata.name)
             await this.app.uploadTorrentModalSubmit()
             await torrent.waitForExist()
             await torrent.waitForStates([options.downloadLabel, "Seeding"], { timeout: 20 * 1000 })


### PR DESCRIPTION
## Summary
- Parse torrent files and magnet links in the main process with `parse-torrent`
- Expose parsed metadata over existing IPC and attach it to pending upload items
- Show the parsed torrent name in the add-torrent modal for magnet uploads
- Carry metadata through argv, second-instance, open-url, file-picker, and deferred upload flows

## Testing
- UI/E2E coverage updated for magnet modal labeling
- Local validation passed for the focused qBittorrent smoketest
- Build and lint completed successfully