### PR TITLE
feat: add system-following theme preference

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -1,4 +1,4 @@
-import { app, dialog, ipcMain, shell, type BrowserWindow, type IpcMainInvokeEvent } from 'electron'
+import { app, dialog, ipcMain, nativeTheme, shell, type BrowserWindow, type IpcMainInvokeEvent } from 'electron'
 import is from 'electron-is'
 
 import { IPC_CHANNELS } from '@shared/ipc'
@@ -8,7 +8,7 @@ import { bittorrentManager } from './bittorrent'
 import * as certificates from './certificates'
 import * as menu from './menu'
 import * as settings from './settings'
-import themes from './themes'
+import themes, { getSystemTheme } from './themes'
 import * as torrents from './torrents'
 import * as updater from './update'
 
@@ -20,6 +20,7 @@ interface RegisterHandlersOptions {
         torrentFiles: unknown[]
     }>
     onSettingsSaved?: (settings: AppSettings) => void | Promise<void>
+    onSystemThemeChanged?: () => void
     onBittorrentConnected?: () => void | Promise<void>
 }
 
@@ -40,7 +41,7 @@ function getAppMeta(isDebug: boolean) {
     }
 }
 
-export function registerHandlers({ isDebug, getWindow, consumePendingLaunchPayload, onSettingsSaved, onBittorrentConnected }: RegisterHandlersOptions) {
+export function registerHandlers({ isDebug, getWindow, consumePendingLaunchPayload, onSettingsSaved, onSystemThemeChanged, onBittorrentConnected }: RegisterHandlersOptions) {
     menu.configure({ isDebug })
 
     ipcMain.handle(IPC_CHANNELS.app.getMeta, async function() {
@@ -92,6 +93,18 @@ export function registerHandlers({ isDebug, getWindow, consumePendingLaunchPaylo
 
     ipcMain.handle(IPC_CHANNELS.settings.listThemes, async function() {
         return themes()
+    })
+
+    ipcMain.handle(IPC_CHANNELS.settings.getSystemTheme, async function() {
+        return getSystemTheme()
+    })
+
+    nativeTheme.on('updated', function() {
+        const window = getWindow()
+        if (window && !window.isDestroyed()) {
+            window.webContents.send(IPC_CHANNELS.settings.systemThemeChanged, getSystemTheme())
+        }
+        onSystemThemeChanged?.()
     })
 
     ipcMain.handle(IPC_CHANNELS.settings.chooseWatchDirectory, async function(_event: IpcMainInvokeEvent, { currentPath }) {

--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -32,7 +32,7 @@ const defaultSettings: MainAppSettings = {
         displayCompact: false,
         cleanNames: true,
         fixedHeader: false,
-        theme: 'light',
+        theme: 'system',
         sidebarCollapsed: false,
     },
 }

--- a/src/main/lib/themes.ts
+++ b/src/main/lib/themes.ts
@@ -1,5 +1,8 @@
 import fs from 'fs'
 import path from 'path'
+import { nativeTheme } from 'electron'
+
+import type { ColorTheme, ThemeInfo, ThemePreference } from '@shared/ipc-contract'
 
 function resolveThemesDir() {
     const candidates = [
@@ -22,16 +25,33 @@ function capitalize(value: string) {
     return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
-export default function themes() {
-    return THEME_NAMES
+export function getSystemTheme(): ColorTheme {
+    return nativeTheme.shouldUseDarkColors ? 'dark' : 'light'
+}
+
+export function resolveTheme(theme?: ThemePreference): ColorTheme {
+    return theme === 'system' || !theme ? getSystemTheme() : theme
+}
+
+export default function themes(): ThemeInfo[] {
+    const installedThemes = THEME_NAMES
         .filter(function(theme: string) {
             return fs.existsSync(path.join(DIR, `${theme}.css`))
         })
         .map(function(theme: string) {
-        return {
-            css: path.join(DIR, `${theme}.css`),
-            basename: theme,
-            theme: capitalize(theme),
-        }
-    })
+            return {
+                css: path.join(DIR, `${theme}.css`),
+                basename: theme as ColorTheme,
+                theme: capitalize(theme),
+            }
+        })
+
+    return [
+        {
+            css: path.join(DIR, `${getSystemTheme()}.css`),
+            basename: 'system',
+            theme: 'System',
+        },
+        ...installedThemes,
+    ]
 }

--- a/src/main/lib/title-bar.ts
+++ b/src/main/lib/title-bar.ts
@@ -1,4 +1,6 @@
 import type { BrowserWindow, BrowserWindowConstructorOptions } from 'electron'
+import type { ThemePreference } from '@shared/ipc-contract'
+import { resolveTheme } from './themes'
 
 const TITLE_BAR_HEIGHT = 38
 
@@ -13,11 +15,11 @@ const THEME_COLORS = {
     },
 }
 
-function getThemeColors(theme?: string) {
-    return theme === 'dark' ? THEME_COLORS.dark : THEME_COLORS.light
+function getThemeColors(theme?: ThemePreference) {
+    return THEME_COLORS[resolveTheme(theme)]
 }
 
-export function getTitleBarWindowOptions(theme?: string): BrowserWindowConstructorOptions {
+export function getTitleBarWindowOptions(theme?: ThemePreference): BrowserWindowConstructorOptions {
     const colors = getThemeColors(theme)
     const options: BrowserWindowConstructorOptions = {
         titleBarStyle: 'hidden',
@@ -35,7 +37,7 @@ export function getTitleBarWindowOptions(theme?: string): BrowserWindowConstruct
     return options
 }
 
-export function updateTitleBarOverlay(window: BrowserWindow, theme?: string) {
+export function updateTitleBarOverlay(window: BrowserWindow, theme?: ThemePreference) {
     if (process.platform === 'darwin' || window.isDestroyed()) {
         return
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -405,6 +405,12 @@ async function bootstrap() {
                 titleBar.updateTitleBarOverlay(torrentWindow, newSettings.ui.theme)
             }
         },
+        onSystemThemeChanged: () => {
+            const theme = settings.get('ui')?.theme
+            if (theme === 'system' && torrentWindow) {
+                titleBar.updateTitleBarOverlay(torrentWindow, theme)
+            }
+        },
         onBittorrentConnected: async () => {
             await torrentFileWatcher.flushPendingSilentWatcherFiles()
         },

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,7 +1,7 @@
 import { clipboard, contextBridge, ipcRenderer } from 'electron'
 
 import { IPC_CHANNELS } from '@shared/ipc'
-import type { PendingTorrentUploadFile, PendingTorrentUploadLink } from '@shared/ipc-contract'
+import type { ColorTheme, PendingTorrentUploadFile, PendingTorrentUploadLink } from '@shared/ipc-contract'
 
 function invoke<T = unknown>(channel: string, payload?: any): Promise<T> {
     return ipcRenderer.invoke(channel, payload)
@@ -28,6 +28,8 @@ contextBridge.exposeInMainWorld('electorrent', {
         getAll: () => invoke(IPC_CHANNELS.settings.getAll),
         saveAll: (settings: unknown) => invoke(IPC_CHANNELS.settings.saveAll, { settings }),
         listThemes: () => invoke(IPC_CHANNELS.settings.listThemes),
+        getSystemTheme: () => invoke(IPC_CHANNELS.settings.getSystemTheme),
+        onSystemThemeChanged: (callback: (theme: ColorTheme) => void) => subscribe(IPC_CHANNELS.settings.systemThemeChanged, callback),
         chooseWatchDirectory: (currentPath?: string) => invoke(IPC_CHANNELS.settings.chooseWatchDirectory, { currentPath }),
     },
     launch: {

--- a/src/renderer/app/directives/app-theme/app-theme.controller.ts
+++ b/src/renderer/app/directives/app-theme/app-theme.controller.ts
@@ -1,18 +1,40 @@
 import { IScope } from "angular";
+import type { ColorTheme, ThemePreference } from "@shared/ipc-contract";
 
 interface AppThemeScope extends IScope {
-    theme: string;
+    theme: ColorTheme;
 }
 
 export class AppThemeController {
     static $inject = ["$scope", "settingsService"];
 
     constructor($scope: AppThemeScope, settingsService: any) {
-        const settings = settingsService.getAllSettings();
-        $scope.theme = settings.ui.theme;
+        const electorrent = window.electorrent;
+        let systemTheme: ColorTheme = "light";
+        let themePreference: ThemePreference = settingsService.getAllSettings().ui.theme;
+
+        const applyTheme = () => {
+            $scope.theme = themePreference === "system" ? systemTheme : themePreference;
+        };
+
+        applyTheme();
+
+        const unsubscribeSystemTheme = electorrent.settings.onSystemThemeChanged((theme) => {
+            systemTheme = theme;
+            applyTheme();
+            $scope.$applyAsync();
+        });
+
+        electorrent.settings.getSystemTheme().then((theme) => {
+            systemTheme = theme;
+            applyTheme();
+        }).finally(() => {
+            $scope.$applyAsync();
+        });
 
         settingsService.whenReady().then(() => {
-            $scope.theme = settingsService.getAllSettings().ui.theme;
+            themePreference = settingsService.getAllSettings().ui.theme;
+            applyTheme();
         }).catch(() => {
             // Settings load errors are reported by the application bootstrap.
         }).finally(() => {
@@ -20,7 +42,12 @@ export class AppThemeController {
         });
 
         $scope.$on("new:settings", (_event: unknown, nextSettings: any) => {
-            $scope.theme = nextSettings.ui.theme || $scope.theme;
+            themePreference = nextSettings.ui.theme || themePreference;
+            applyTheme();
+        });
+
+        $scope.$on("$destroy", () => {
+            unsubscribeSystemTheme();
         });
     }
 }

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -20,7 +20,7 @@ export let settingsService = ['$rootScope', '$bittorrent', 'notificationService'
             displayCompact: false,
             cleanNames: true,
             fixedHeader: false,
-            theme: 'light',
+            theme: 'system',
             sidebarCollapsed: false,
         },
         servers: [],

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,5 +1,8 @@
 export type Unsubscribe = () => void
 
+export type ColorTheme = "light" | "dark"
+export type ThemePreference = ColorTheme | "system"
+
 export interface AppMeta {
     appName: string
     appVersion: string
@@ -17,7 +20,7 @@ export interface AppMeta {
 
 export interface ThemeInfo {
     css: string
-    basename: string
+    basename: ThemePreference
     theme: string
 }
 
@@ -170,7 +173,7 @@ export interface AppSettings<TServer = StoredServerConfig> {
         displayCompact: boolean
         cleanNames: boolean
         fixedHeader: boolean
-        theme: string
+        theme: ThemePreference
         sidebarCollapsed: boolean
     }
     servers: TServer[]
@@ -252,6 +255,8 @@ export interface ElectorrentBridge {
         getAll(): Promise<AppSettings>
         saveAll(settings: AppSettings): Promise<void>
         listThemes(): Promise<ThemeInfo[]>
+        getSystemTheme(): Promise<ColorTheme>
+        onSystemThemeChanged(callback: (theme: ColorTheme) => void): Unsubscribe
         chooseWatchDirectory(currentPath?: string): Promise<string | null>
     }
     launch: {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -13,6 +13,8 @@ export const IPC_CHANNELS = {
         getAll: 'settings:get-all',
         saveAll: 'settings:save-all',
         listThemes: 'settings:list-themes',
+        getSystemTheme: 'settings:get-system-theme',
+        systemThemeChanged: 'settings:system-theme-changed',
         chooseWatchDirectory: 'settings:choose-watch-directory',
     },
     launch: {

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -586,8 +586,8 @@ export class App {
     return values.filter(Boolean)
   }
 
-  getThemeOptions(): readonly ["Light", "Dark"] {
-    return ["Light", "Dark"] as const
+  getThemeOptions(): readonly ["System", "Light", "Dark"] {
+    return ["System", "Light", "Dark"] as const
   }
 
   async selectGeneralDropdownValue(settingName: string, optionText: string) {

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -356,9 +356,9 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
             const initialTheme = await this.app.getGeneralDropdownValue("Theme")
             const initialThemeHref = await this.app.getAppliedThemeHref()
             const availableThemes = this.app.getThemeOptions()
-            assert.deepEqual(availableThemes, ["Light", "Dark"])
-            assert.include(availableThemes, initialTheme, `expected theme to be Light or Dark, got: ${initialTheme}`)
-            const nextTheme = initialTheme === "Light" ? "Dark" : "Light"
+            assert.deepEqual(availableThemes, ["System", "Light", "Dark"])
+            assert.include(availableThemes, initialTheme, `expected a supported theme, got: ${initialTheme}`)
+            const nextTheme = initialThemeHref.includes("/dark.css") ? "Light" : "Dark"
 
             await this.app.selectGeneralDropdownValue("Theme", nextTheme)
             assert.equal(await this.app.getGeneralDropdownValue("Theme"), nextTheme)


### PR DESCRIPTION
## Summary
- Add a `system` theme preference and make it the default
- Resolve the active theme from Electron `nativeTheme` for renderer styles and title bar colors
- Expose system theme changes over the preload bridge so the UI updates when the OS theme changes
- Update the theme end-to-end test to cover System, Light, and Dark preferences

## Regression fix
The existing `can change the theme` test assumed the initial theme was always Light or Dark. With System as the new default, that assertion failed. The test now accepts all supported preferences and selects the explicit theme opposite the currently applied stylesheet, keeping the stylesheet-change assertion deterministic on light and dark hosts.

## Testing
- `npm test -- --suite qbittorrent:latest --mochaOpts.grep "can change the theme"`
- `npm run lint` (passes with one pre-existing unused-variable warning)
- `npm run build`
- `npm run smoketest`