### PR TITLE
feat: remove torrent files after successful upload

### DIFF
--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -1,3 +1,5 @@
+import fs from "fs"
+import path from "path"
 import type { WebContents } from "electron"
 import type {
     BittorrentAddTorrentUrlRequest,
@@ -7,6 +9,8 @@ import type {
     BittorrentTorrentDetailsData,
     BittorrentUploadTorrentRequest,
 } from "@shared/ipc-contract"
+import logger from "../logger"
+import * as settings from "../settings"
 import { createRuntime } from "./registry"
 import type { BittorrentRuntime } from "./types"
 
@@ -32,6 +36,20 @@ class BittorrentManager {
         }
 
         throw new Error("No active bittorrent session")
+    }
+
+    private canAutoRemoveUploadedTorrent(request: BittorrentUploadTorrentRequest) {
+        if (!request.sourcePath) {
+            return false
+        }
+
+        const filename = typeof request.filename === "string" ? request.filename : ""
+        if (!filename || filename !== path.basename(filename) || !filename.toLowerCase().endsWith(".torrent")) {
+            return false
+        }
+
+        const sourceBasename = path.basename(request.sourcePath)
+        return sourceBasename === filename && sourceBasename.toLowerCase().endsWith(".torrent")
     }
 
     async connect(sender: WebContents, server: BittorrentServerConfig): Promise<void> {
@@ -89,7 +107,24 @@ class BittorrentManager {
 
     async uploadTorrent(sender: WebContents, request: BittorrentUploadTorrentRequest) {
         const session = await this.getSession(sender)
-        return session.uploadTorrent(request.data, request.filename, request.options)
+        await session.uploadTorrent(request.data, request.filename, request.options)
+
+        if (settings.getAllSettings().autoRemoveTorrents !== true || !this.canAutoRemoveUploadedTorrent(request)) {
+            return
+        }
+
+        try {
+            await fs.promises.unlink(request.sourcePath)
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+                return
+            }
+
+            logger.error("Failed to delete uploaded torrent file", {
+                filePath: request.sourcePath,
+                error,
+            })
+        }
     }
 
     async invokeAction(sender: WebContents, request: BittorrentInvokeActionRequest) {

--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -176,7 +176,7 @@ export function put(key: string, value: any, callback?: (err?: Error | null) => 
     }
 }
 
-export function getAllSettings() {
+export function getAllSettings(): MainAppSettings {
     load()
     return copy(data)
 }

--- a/src/main/lib/torrent-file-watcher.ts
+++ b/src/main/lib/torrent-file-watcher.ts
@@ -145,6 +145,7 @@ export class TorrentFileWatcher {
             type: 'file',
             filename: file.filename,
             data: new Uint8Array(file.data),
+            sourcePath: file.sourcePath,
             askUploadOptions: !!file.askUploadOptions,
         }
     }
@@ -202,6 +203,7 @@ export class TorrentFileWatcher {
             await bittorrentManager.uploadTorrent(window.webContents, {
                 data: file.data,
                 filename: file.filename,
+                sourcePath: file.sourcePath,
             })
             this.showNativeNotification('Torrent added', `${file.filename} is downloading in Electorrent`)
         } catch (error) {

--- a/src/main/lib/torrents.ts
+++ b/src/main/lib/torrents.ts
@@ -24,7 +24,7 @@ function notify({ title = '', message = '', type = 'info' }) {
 }
 
 function filterFiles(filePath: string) {
-    return filePath.endsWith('.torrent')
+    return filePath.toLowerCase().endsWith('.torrent')
 }
 
 function sleep(timeout: number) {
@@ -102,6 +102,7 @@ export async function serializeTorrentFile(filePath: string, askUploadOptions: b
         type: 'file',
         filename: path.basename(filePath),
         data: torrentData,
+        sourcePath: filePath,
         askUploadOptions: !!askUploadOptions,
         metadata: parse({ data: torrentData }),
     }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,4 +1,4 @@
-import { clipboard, contextBridge, ipcRenderer } from 'electron'
+import { clipboard, contextBridge, ipcRenderer, webUtils } from 'electron'
 
 import { IPC_CHANNELS } from '@shared/ipc'
 import type { PendingTorrentUploadFile, PendingTorrentUploadLink } from '@shared/ipc-contract'
@@ -38,6 +38,7 @@ contextBridge.exposeInMainWorld('electorrent', {
     torrents: {
         openFiles: (askUploadOptions: boolean) => invoke(IPC_CHANNELS.torrents.openFiles, { askUploadOptions }),
         parse: (request: unknown) => invoke(IPC_CHANNELS.torrents.parse, request),
+        getPathForFile: (file: any) => webUtils.getPathForFile(file),
     },
     bittorrent: {
         connect: (server: unknown) => invoke(IPC_CHANNELS.bittorrent.connect, { server }),

--- a/src/renderer/app/bittorrent/deluge/delugeservice.ts
+++ b/src/renderer/app/bittorrent/deluge/delugeservice.ts
@@ -40,8 +40,8 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
         return addTorrentUrl(magnet, options)
     }
 
-    uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions): Promise<void> {
-        return uploadTorrent(buffer, filename, options)
+    uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions, sourcePath?: string): Promise<void> {
+        return uploadTorrent(buffer, filename, options, sourcePath)
     }
 
     resume(torrents: DelugeTorrent[]): Promise<void> {

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -37,8 +37,8 @@ export function addTorrentUrl(uri: string, options?: TorrentUploadOptions) {
     return bridge().addTorrentUrl({ uri, options })
 }
 
-export function uploadTorrent(data: Uint8Array, filename: string, options?: TorrentUploadOptions) {
-    return bridge().uploadTorrent({ data, filename, options })
+export function uploadTorrent(data: Uint8Array, filename: string, options?: TorrentUploadOptions, sourcePath?: string) {
+    return bridge().uploadTorrent({ data, filename, options, sourcePath })
 }
 
 export function invokeAction(action: string, hashes: string[] = [], ...args: any[]) {

--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -83,8 +83,8 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
       return "/";
     };
 
-    uploadTorrent(buffer: Uint8Array, filename: string, options: TorrentUploadOptions): Promise<void> {
-      return uploadTorrent(buffer, filename, options);
+    uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions, sourcePath?: string): Promise<void> {
+      return uploadTorrent(buffer, filename, options, sourcePath);
     };
 
     addTorrentUrl(magnet: string, options?: TorrentUploadOptions): Promise<void> {

--- a/src/renderer/app/bittorrent/rtorrent/rtorrentservice.ts
+++ b/src/renderer/app/bittorrent/rtorrent/rtorrentservice.ts
@@ -38,8 +38,8 @@ export class RtorrentClient extends TorrentClient<RtorrentTorrent> {
       return addTorrentUrl(magnet, options)
     };
 
-    uploadTorrent(buffer: Uint8Array, filename?: string, options?: TorrentUploadOptions): Promise<void> {
-      return uploadTorrent(buffer, filename || "upload.torrent", options)
+    uploadTorrent(buffer: Uint8Array, filename?: string, options?: TorrentUploadOptions, sourcePath?: string): Promise<void> {
+      return uploadTorrent(buffer, filename || "upload.torrent", options, sourcePath)
     };
 
     start(torrents: RtorrentTorrent[]): Promise<void> {

--- a/src/renderer/app/bittorrent/synology/synologyservice.ts
+++ b/src/renderer/app/bittorrent/synology/synologyservice.ts
@@ -40,8 +40,8 @@ export class SynologyClient extends TorrentClient<SynologyTorrent> {
         return addTorrentUrl(magnet, options)
     }
 
-    uploadTorrent(buffer: Uint8Array, filename?: string, options?: TorrentUploadOptions): Promise<void> {
-        return uploadTorrent(buffer, filename || "upload.torrent", options)
+    uploadTorrent(buffer: Uint8Array, filename?: string, options?: TorrentUploadOptions, sourcePath?: string): Promise<void> {
+        return uploadTorrent(buffer, filename || "upload.torrent", options, sourcePath)
     }
 
     start(torrents: SynologyTorrent[]): Promise<void> {

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -205,7 +205,7 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
      * @param {string} filename
      * @return {promise} isAdded
      */
-    abstract uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions): Promise<void>
+    abstract uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions, sourcePath?: string): Promise<void>
 
     /**
      * Delete torrent(s) from the client. If the client has multiple methods of deleting a torrent,

--- a/src/renderer/app/bittorrent/transmission/transmissionservice.ts
+++ b/src/renderer/app/bittorrent/transmission/transmissionservice.ts
@@ -75,8 +75,8 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
       return addTorrentUrl(magnet, uploadOptions)
     };
 
-    uploadTorrent(buffer: Uint8Array, filename?: string, uploadOptions?: TorrentUploadOptions): Promise<void> {
-      return uploadTorrent(buffer, filename || "upload.torrent", uploadOptions)
+    uploadTorrent(buffer: Uint8Array, filename?: string, uploadOptions?: TorrentUploadOptions, sourcePath?: string): Promise<void> {
+      return uploadTorrent(buffer, filename || "upload.torrent", uploadOptions, sourcePath)
     };
 
     start(torrents: TransmissionTorrent[]): Promise<void> {

--- a/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
+++ b/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
@@ -25,8 +25,8 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
     return addTorrentUrl(url, options)
   };
 
-  uploadTorrent(buffer: Uint8Array, filename?: string, options?: TorrentUploadOptions): Promise<void> {
-    return uploadTorrent(buffer, filename || "upload.torrent", options)
+  uploadTorrent(buffer: Uint8Array, filename?: string, options?: TorrentUploadOptions, sourcePath?: string): Promise<void> {
+    return uploadTorrent(buffer, filename || "upload.torrent", options, sourcePath)
   };
 
   async torrents(): Promise<TorrentUpdates> {

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
@@ -93,7 +93,7 @@ export class AddTorrentModalController {
             this.isLoading = true
             let torrent = this.getCurrentTorrentUpload()
             if (torrent.type === 'file') {
-                await this.performTorrentUpload(torrent.data, torrent.filename, this.uploadOptions)
+                await this.performTorrentUpload(torrent.data, torrent.filename, this.uploadOptions, torrent.sourcePath)
             } else {
                 await this.performTorrentURIUpload(torrent.uri, this.uploadOptions)
             }
@@ -136,11 +136,11 @@ export class AddTorrentModalController {
         }
     }
 
-    async performTorrentUpload(torrent: Uint8Array, filename: string, options: TorrentUploadOptions) {
+    async performTorrentUpload(torrent: Uint8Array, filename: string, options: TorrentUploadOptions, sourcePath?: string) {
         if (this.scope.uploadTorrentAction) {
-            await this.scope.uploadTorrentAction(torrent, filename, options)
+            await this.scope.uploadTorrentAction(torrent, filename, options, sourcePath)
         } else {
-            await this.rootScope.$btclient.uploadTorrent(torrent, filename, options)
+            await this.rootScope.$btclient.uploadTorrent(torrent, filename, options, sourcePath)
         }
     }
 

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.directive.ts
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.directive.ts
@@ -13,7 +13,8 @@ export interface PendingTorrentUploadFile {
     type: 'file',
     data: Uint8Array,
     filename: string,
-    metadata?: TorrentMetadata
+    metadata?: TorrentMetadata,
+    sourcePath?: string,
 }
 
 export interface PendingTorrentUploadLink {
@@ -25,7 +26,7 @@ export interface PendingTorrentUploadLink {
 
 export interface AddTorrentModalScope extends IScope {
     torrents: PendingTorrentUploadList
-    uploadTorrentAction: (torrent: Uint8Array, filename: string, options: TorrentUploadOptions) => Promise<void>
+    uploadTorrentAction: (torrent: Uint8Array, filename: string, options: TorrentUploadOptions, sourcePath?: string) => Promise<void>
     uploadTorrentUrlAction: (uri: string, options: TorrentUploadOptions) => Promise<void>
 }
 

--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -114,6 +114,7 @@ export class AppShellController {
                 data: new Uint8Array(file.data),
                 filename: file.filename,
                 metadata: file.metadata,
+                sourcePath: file.sourcePath,
             };
             $scope.$broadcast("torrents:add", pendingFile, askUploadOptions);
         };

--- a/src/renderer/app/directives/drag-and-drop/drag-and-drop.directive.ts
+++ b/src/renderer/app/directives/drag-and-drop/drag-and-drop.directive.ts
@@ -29,13 +29,16 @@ export class DragAndDropDirective implements IDirective {
         return file.name.toLowerCase().endsWith(".torrent");
     }
 
-    private readDroppedFile(file: File, askUploadOptions: boolean): Promise<PendingTorrentUploadFile> {
-        return file.arrayBuffer().then((buffer) => ({
+    private async serializeDroppedTorrent(file: File, askUploadOptions: boolean): Promise<PendingTorrentUploadFile> {
+        const sourcePath = window.electorrent.torrents.getPathForFile(file);
+
+        return {
             type: "file",
             filename: file.name,
-            data: new Uint8Array(buffer),
+            data: new Uint8Array(await file.arrayBuffer()),
+            sourcePath: sourcePath || undefined,
             askUploadOptions,
-        }));
+        };
     }
 
     private broadcastTorrentFiles(files: PendingTorrentUploadFile[]) {
@@ -44,6 +47,7 @@ export class DragAndDropDirective implements IDirective {
                 type: "file",
                 filename: file.filename,
                 data: new Uint8Array(file.data),
+                sourcePath: file.sourcePath,
             }, !!file.askUploadOptions);
         });
     }
@@ -98,7 +102,7 @@ export class DragAndDropDirective implements IDirective {
                     return [];
                 }
 
-                return Promise.all(torrentFiles.map((file) => this.readDroppedFile(file, advancedKey)));
+                return Promise.all(torrentFiles.map((file) => this.serializeDroppedTorrent(file, advancedKey)));
             }).then((files: PendingTorrentUploadFile[]) => {
                 this.$rootScope.$applyAsync(() => {
                     this.broadcastTorrentFiles(files);

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -182,7 +182,7 @@ export class TorrentsPageController {
             if (shouldPromptForUploadOptions(item, askUploadOptions)) {
                 $scope.pendingTorrentFiles.push(item);
             } else if (item.type === "file") {
-                await $scope.uploadTorrent(item.data, item.filename);
+                await $scope.uploadTorrent(item.data, item.filename, undefined, item.sourcePath);
             } else {
                 await $scope.uploadTorrentURL(item.uri);
             }
@@ -225,9 +225,9 @@ export class TorrentsPageController {
             $scope.$apply();
         });
 
-        $scope.uploadTorrent = async (torrent: Uint8Array, filename: string, options?: TorrentUploadOptions) => {
+        $scope.uploadTorrent = async (torrent: Uint8Array, filename: string, options?: TorrentUploadOptions, sourcePath?: string) => {
             try {
-                await $rootScope.$btclient?.uploadTorrent(torrent, filename, options);
+                await $rootScope.$btclient?.uploadTorrent(torrent, filename, options, sourcePath);
             } catch (e) {
                 $notify.alert("Could not upload torrent", "The torrent could not be uploaded to the server");
                 console.error(e);

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -32,6 +32,7 @@ export interface PendingTorrentUploadFile {
     type: "file"
     data: Uint8Array
     filename: string
+    sourcePath?: string
     askUploadOptions?: boolean
     metadata?: TorrentMetadata
 }
@@ -78,6 +79,7 @@ export interface BittorrentUploadTorrentRequest {
     data: Uint8Array
     filename: string
     options?: Record<string, any>
+    sourcePath?: string
 }
 
 export interface BittorrentInvokeActionRequest {
@@ -262,6 +264,7 @@ export interface ElectorrentBridge {
     torrents: {
         openFiles(askUploadOptions: boolean): Promise<PendingTorrentUploadFile[]>
         parse(request: ParseTorrentRequest): Promise<TorrentMetadata>
+        getPathForFile(file: unknown): string
     }
     bittorrent: {
         connect(server: BittorrentServerConfig): Promise<void>

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -268,22 +268,23 @@ export class App {
     await waitForModalClose(modal, this.timeout)
   }
 
-  async uploadTorrent({ filename, askUploadOptions }: { filename: string, askUploadOptions?: boolean }) {
+  async uploadTorrent({ filename, askUploadOptions, sourcePath }: { filename: string, askUploadOptions?: boolean, sourcePath?: string }) {
     const data = fs.readFileSync(path.join(filename));
     const info = parseTorrent(data)
     const hash = info.infoHash
     const torrent = new Torrent({ hash: hash, app: this });
     await expect(await torrent.isExisting()).toBe(false);
-    await browser.execute((data, filename, askUploadOptions) => {
+    await browser.execute((data, filename, askUploadOptions, sourcePath) => {
       const injector = angular.element(document.body).injector()
       const $rootScope = injector.get("$rootScope")
       $rootScope.$broadcast("torrents:add", {
         type: "file",
         data: new Uint8Array(data),
         filename,
+        sourcePath,
       }, !!askUploadOptions)
       $rootScope.$apply()
-    }, Array.from(data), path.basename(filename), askUploadOptions)
+    }, Array.from(data), path.basename(filename), askUploadOptions, sourcePath)
     this.torrents.push(torrent);
     return torrent;
   }

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -480,6 +480,49 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           })
         })
 
+        describe("automatic torrent file removal", function() {
+          it("removes local torrent file after successful upload", async function() {
+            this.timeout(90 * 1000)
+
+            const torrentPath = await createTorrentFile(tracker, { fileSize: 1 })
+            let initialAutoRemoveSetting = false
+            let torrent: e2e.Torrent | undefined
+
+            try {
+              await restartApplication(this)
+              await this.app.torrentsPageIsVisible()
+              await this.app.openSettings()
+              await this.app.settingsGotoTab("general")
+              initialAutoRemoveSetting = await this.app.getGeneralToggleState("Delete Torrent Files")
+              await this.app.setGeneralToggle("Delete Torrent Files", true)
+              await this.app.settingsSave()
+              await this.app.torrentsPageIsVisible()
+
+              torrent = await this.app.uploadTorrent({
+                filename: torrentPath,
+                sourcePath: torrentPath,
+              })
+              await torrent.waitForExist({ timeout: 30 * 1000 })
+              await browser.waitUntil(async () => !fs.existsSync(torrentPath), {
+                timeout: 10 * 1000,
+                timeoutMsg: `expected torrent file ${torrentPath} to be removed after upload`,
+              })
+            } finally {
+              if (torrent && await torrent.isExisting()) {
+                await torrent.delete()
+              }
+
+              await this.app.openSettings()
+              await this.app.settingsGotoTab("general")
+              if (await this.app.getGeneralToggleState("Delete Torrent Files") !== initialAutoRemoveSetting) {
+                await this.app.setGeneralToggle("Delete Torrent Files", initialAutoRemoveSetting)
+              }
+              await this.app.settingsSave()
+              await this.app.torrentsPageIsVisible()
+            }
+          })
+        })
+
         describe("when a magnet link is uploaded", async function() {
           let torrent: e2e.Torrent
           requireFeatureHook(options, FeatureSet.MagnetLinks)


### PR DESCRIPTION
## Summary
- track local torrent source paths through browse, drag-and-drop, launch, and advanced upload flows
- delete source `.torrent` files only after the backend upload succeeds and auto-removal is enabled
- preserve torrent metadata parsing introduced on `master` while rebasing the upload flow changes
- add focused end-to-end coverage for removing an uploaded local torrent file

## Impact
Local torrent files can be cleaned up automatically after a confirmed successful upload without changing client-specific upload behavior. Failed uploads retain their source files.

## Validation
- `npm run lint` (passes with one existing unused-variable warning in `src/renderer/app.ts`)
- `npm run build`
- `npm run smoketest` (1 passing)