### PR TITLE
Apply theme globals to the rendered theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8533,18 +8533,6 @@
         }
       }
     },
-    "node_modules/create-wdio/node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
     "node_modules/create-wdio/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -8903,15 +8891,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/create-wdio/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/create-wdio/node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -52,6 +52,7 @@ async function bootstrap() {
         ipcHandlers,
         menu,
         { TorrentFileWatcher },
+        themes,
         titleBar,
     ] = await Promise.all([
         import('@shared/ipc'),
@@ -65,6 +66,7 @@ async function bootstrap() {
         import('@main/lib/ipc'),
         import('@main/lib/menu'),
         import('@main/lib/torrent-file-watcher'),
+        import('@main/lib/themes'),
         import('@main/lib/title-bar'),
     ])
 
@@ -170,7 +172,9 @@ async function bootstrap() {
     }
 
     function createTorrentWindow() {
-        const titleBarOptions = titleBar.getTitleBarWindowOptions(settings.get('ui')?.theme)
+        const themePreference = settings.get('ui')?.theme
+        const initialTheme = themes.resolveTheme(themePreference)
+        const titleBarOptions = titleBar.getTitleBarWindowOptions(themePreference)
         const windowSettings: BrowserWindowConstructorOptions = {
             ...titleBarOptions,
             show: false,
@@ -182,6 +186,7 @@ async function bootstrap() {
                 contextIsolation: true,
                 sandbox: true,
                 preload: path.join(__dirname, 'preload.js'),
+                additionalArguments: [`--theme=${initialTheme}`],
             },
         }
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -3,6 +3,11 @@ import { clipboard, contextBridge, ipcRenderer, webUtils } from 'electron'
 import { IPC_CHANNELS } from '@shared/ipc'
 import type { ColorTheme, PendingTorrentUploadFile, PendingTorrentUploadLink } from '@shared/ipc-contract'
 
+const INITIAL_THEME_ARGUMENT = '--theme='
+const initialThemeArgument = process.argv.find((argument) => argument.startsWith(INITIAL_THEME_ARGUMENT))
+const initialThemeValue = initialThemeArgument?.slice(INITIAL_THEME_ARGUMENT.length)
+const initialTheme: ColorTheme = initialThemeValue === 'dark' ? 'dark' : 'light'
+
 function invoke<T = unknown>(channel: string, payload?: any): Promise<T> {
     return ipcRenderer.invoke(channel, payload)
 }
@@ -15,6 +20,7 @@ function subscribe<T = unknown>(channel: string, callback: (payload: T) => void)
 
 contextBridge.exposeInMainWorld('electorrent', {
     app: {
+        initialTheme,
         getMeta: () => invoke(IPC_CHANNELS.app.getMeta),
         getDefaultProtocolStatus: (protocol: string) => invoke(IPC_CHANNELS.app.getDefaultProtocolStatus, { protocol }),
         setDefaultProtocolStatus: (protocol: string, enabled: boolean) => invoke(IPC_CHANNELS.app.setDefaultProtocolStatus, { protocol, enabled }),

--- a/src/renderer/app/directives/app-theme/app-theme.controller.ts
+++ b/src/renderer/app/directives/app-theme/app-theme.controller.ts
@@ -10,7 +10,7 @@ export class AppThemeController {
 
     constructor($scope: AppThemeScope, settingsService: any) {
         const electorrent = window.electorrent;
-        let systemTheme: ColorTheme = "light";
+        let systemTheme: ColorTheme = electorrent.app.initialTheme;
         let themePreference: ThemePreference = settingsService.getAllSettings().ui.theme;
 
         const applyTheme = () => {
@@ -22,13 +22,6 @@ export class AppThemeController {
         const unsubscribeSystemTheme = electorrent.settings.onSystemThemeChanged((theme) => {
             systemTheme = theme;
             applyTheme();
-            $scope.$applyAsync();
-        });
-
-        electorrent.settings.getSystemTheme().then((theme) => {
-            systemTheme = theme;
-            applyTheme();
-        }).finally(() => {
             $scope.$applyAsync();
         });
 

--- a/src/renderer/assets/index.ejs
+++ b/src/renderer/assets/index.ejs
@@ -4,7 +4,13 @@
         <meta charset="UTF-8">
         <title>Electorrent</title>
 
-        <link rel="stylesheet" href="css/themes/light.css" ng-href="css/themes/{{theme || 'light'}}.css">
+        <script>
+            const themeStylesheet = document.createElement("link");
+            themeStylesheet.rel = "stylesheet";
+            themeStylesheet.href = `css/themes/${window.electorrent.app.initialTheme}.css`;
+            themeStylesheet.setAttribute("ng-href", "css/themes/{{theme}}.css");
+            document.head.appendChild(themeStylesheet);
+        </script>
     </head>
     <body ready-broadcast>
         <app-shell></app-shell>

--- a/src/renderer/styles/semantic/theme.config
+++ b/src/renderer/styles/semantic/theme.config
@@ -18,7 +18,7 @@
 */
 
 /* Global */
-@site       : 'default';
+@site       : @renderTheme;
 @reset      : 'default';
 
 /* Elements */

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -244,6 +244,7 @@ export type MenuAction =
 
 export interface ElectorrentBridge {
     app: {
+        initialTheme: ColorTheme
         getMeta(): Promise<AppMeta>
         getDefaultProtocolStatus(protocol: string): Promise<boolean>
         setDefaultProtocolStatus(protocol: string, enabled: boolean): Promise<void>


### PR DESCRIPTION
## Summary
- Make Semantic UI use `@renderTheme` for global site variables
- Let dark theme compile with its own page background instead of falling back to default white
- Keep the lockfile cleanup from the current workspace state

## Testing
- Not run (not requested)