### PR TITLE
Add system startup options to general settings

### DIFF
--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -16,6 +16,7 @@ type MainAppSettings = AppSettings & {
 
 const defaultSettings: MainAppSettings = {
     startup: 'default',
+    systemStartup: 'disabled',
     refreshRate: 2000,
     servers: [],
     certificates: [],

--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -92,6 +92,9 @@ function load() {
 
     try {
         data = mergeWithDefaults(defaultSettings, JSON.parse(file))
+        if (data.systemStartup === 'minimized') {
+            data.systemStartup = 'background'
+        }
     } catch (_e) {
         if (app.isReady()) {
             showCorruptDialog()

--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -92,9 +92,6 @@ function load() {
 
     try {
         data = mergeWithDefaults(defaultSettings, JSON.parse(file))
-        if (data.systemStartup === 'minimized') {
-            data.systemStartup = 'background'
-        }
     } catch (_e) {
         if (app.isReady()) {
             showCorruptDialog()

--- a/src/main/lib/startup.ts
+++ b/src/main/lib/startup.ts
@@ -76,7 +76,7 @@ export function configureSystemStartup(option: SystemStartupOption) {
         return
     }
 
-    const openAtLogin = option === 'open' || option === 'minimized'
+    const openAtLogin = option === 'open' || option === 'background'
 
     if (process.platform === 'win32') {
         const appFolder = path.dirname(process.execPath)
@@ -94,8 +94,8 @@ export function configureSystemStartup(option: SystemStartupOption) {
     app.setLoginItemSettings({ openAtLogin })
 }
 
-export function shouldStartMinimized(option: SystemStartupOption) {
-    if (option !== 'minimized') {
+export function shouldStartInBackground(option: SystemStartupOption) {
+    if (option !== 'background') {
         return false
     }
 

--- a/src/main/lib/startup.ts
+++ b/src/main/lib/startup.ts
@@ -4,7 +4,10 @@ import path from 'path'
 import Q from 'q'
 import electronRegedit from 'electron-regedit'
 
+import type { SystemStartupOption } from '@shared/ipc-contract'
+
 const { ProgId, Regedit } = electronRegedit as any
+const STARTED_AT_LOGIN_ARG = '--started-at-login'
 
 new ProgId({
     description: 'Torrent File',
@@ -67,5 +70,40 @@ function checkSquirrel() {
 }
 
 const shouldQuitFromStartup = checkSquirrel()
+
+export function configureSystemStartup(option: SystemStartupOption) {
+    if (!app.isPackaged || !['darwin', 'win32'].includes(process.platform)) {
+        return
+    }
+
+    const openAtLogin = option === 'open' || option === 'minimized'
+
+    if (process.platform === 'win32') {
+        const appFolder = path.dirname(process.execPath)
+        const executableName = path.basename(process.execPath)
+        const stubLauncher = path.resolve(appFolder, '..', executableName)
+
+        app.setLoginItemSettings({
+            openAtLogin,
+            path: stubLauncher,
+            args: openAtLogin ? [STARTED_AT_LOGIN_ARG] : [],
+        })
+        return
+    }
+
+    app.setLoginItemSettings({ openAtLogin })
+}
+
+export function shouldStartMinimized(option: SystemStartupOption) {
+    if (option !== 'minimized') {
+        return false
+    }
+
+    if (process.platform === 'win32') {
+        return process.argv.includes(STARTED_AT_LOGIN_ARG)
+    }
+
+    return process.platform === 'darwin' && app.getLoginItemSettings().wasOpenedAtLogin
+}
 
 export default shouldQuitFromStartup

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,7 +15,7 @@ import is from 'electron-is'
 import path from 'path'
 import yargs from 'yargs'
 
-import startup from '@main/lib/startup'
+import startup, { configureSystemStartup, shouldStartMinimized } from '@main/lib/startup'
 import type { PendingTorrentUploadLink } from '@shared/ipc-contract'
 
 declare const __non_webpack_require__: NodeRequire | undefined
@@ -172,7 +172,7 @@ async function bootstrap() {
         showTorrentWindow()
     }
 
-    function createTorrentWindow() {
+    function createTorrentWindow(startMinimized = false) {
         const themePreference = settings.get('ui')?.theme
         const initialTheme = themes.resolveTheme(themePreference)
         const titleBarOptions = titleBar.getTitleBarWindowOptions(themePreference)
@@ -204,6 +204,9 @@ async function bootstrap() {
 
         torrentWindow.once('ready-to-show', () => {
             torrentWindow?.show()
+            if (startMinimized) {
+                torrentWindow?.minimize()
+            }
         })
 
         torrentWindow.loadURL(`file://${__dirname}/index.html`)
@@ -409,6 +412,7 @@ async function bootstrap() {
         getWindow: () => torrentWindow,
         consumePendingLaunchPayload,
         onSettingsSaved: async (newSettings) => {
+            configureSystemStartup(newSettings.systemStartup)
             syncTray()
             torrentFileWatcher.refresh()
             if (torrentWindow) {
@@ -463,7 +467,8 @@ async function bootstrap() {
 
     app.on('ready', function() {
         queuePendingLaunchArgs(process.argv)
-        createTorrentWindow()
+        configureSystemStartup(settings.getAllSettings().systemStartup)
+        createTorrentWindow(shouldStartMinimized(settings.getAllSettings().systemStartup))
         syncTray()
         torrentFileWatcher.start()
         updater.initialise(torrentWindow)

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,7 +15,7 @@ import is from 'electron-is'
 import path from 'path'
 import yargs from 'yargs'
 
-import startup, { configureSystemStartup, shouldStartMinimized } from '@main/lib/startup'
+import startup, { configureSystemStartup, shouldStartInBackground } from '@main/lib/startup'
 import type { PendingTorrentUploadLink } from '@shared/ipc-contract'
 
 declare const __non_webpack_require__: NodeRequire | undefined
@@ -92,6 +92,7 @@ async function bootstrap() {
     let tray: Tray | null = null
     let isQuitting = false
     let rendererLoaded = false
+    let startedInBackground = false
     const pendingLaunchPayload = {
         magnets: [] as PendingTorrentUploadLink[],
         torrentFilePaths: [] as string[],
@@ -106,7 +107,8 @@ async function bootstrap() {
     })
 
     function shouldUseTray() {
-        return !app.commandLine.hasSwitch('headless') && settings.get('closeToTray') !== false
+        return !app.commandLine.hasSwitch('headless')
+            && (startedInBackground || settings.get('closeToTray') !== false)
     }
 
     function destroyTray() {
@@ -172,7 +174,7 @@ async function bootstrap() {
         showTorrentWindow()
     }
 
-    function createTorrentWindow(startMinimized = false) {
+    function createTorrentWindow(startInBackground = false) {
         const themePreference = settings.get('ui')?.theme
         const initialTheme = themes.resolveTheme(themePreference)
         const titleBarOptions = titleBar.getTitleBarWindowOptions(themePreference)
@@ -203,9 +205,8 @@ async function bootstrap() {
         menu.setWindow(torrentWindow)
 
         torrentWindow.once('ready-to-show', () => {
-            torrentWindow?.show()
-            if (startMinimized) {
-                torrentWindow?.minimize()
+            if (!startInBackground) {
+                torrentWindow?.show()
             }
         })
 
@@ -468,7 +469,11 @@ async function bootstrap() {
     app.on('ready', function() {
         queuePendingLaunchArgs(process.argv)
         configureSystemStartup(settings.getAllSettings().systemStartup)
-        createTorrentWindow(shouldStartMinimized(settings.getAllSettings().systemStartup))
+        startedInBackground = shouldStartInBackground(settings.getAllSettings().systemStartup)
+        if (startedInBackground && is.macOS()) {
+            app.dock.hide()
+        }
+        createTorrentWindow(startedInBackground)
         syncTray()
         torrentFileWatcher.start()
         updater.initialise(torrentWindow)

--- a/src/renderer/app/directives/settings-general/settings-general.template.html
+++ b/src/renderer/app/directives/settings-general/settings-general.template.html
@@ -34,6 +34,24 @@
             </dropdown>
         </div>
     </div>
+    <div class="ui card" ng-if="!is.linux()">
+        <div class="content">
+            <div class="header">
+                <i class="power icon"></i>
+                System Startup
+            </div>
+            <div class="description">
+                Configure whether Electorrent starts automatically when you log in
+            </div>
+        </div>
+        <div class="center aligned extra content">
+            <dropdown class="fluid" title="System Startup" ng-model="settings.systemStartup">
+                <dropdown-group data-value="disabled">Disabled</dropdown-group>
+                <dropdown-group data-value="open">Start Electorrent</dropdown-group>
+                <dropdown-group data-value="minimized">Start Electorrent Minimized</dropdown-group>
+            </dropdown>
+        </div>
+    </div>
     <div class="ui card">
         <div class="content">
             <div class="header">

--- a/src/renderer/app/directives/settings-general/settings-general.template.html
+++ b/src/renderer/app/directives/settings-general/settings-general.template.html
@@ -47,8 +47,8 @@
         <div class="center aligned extra content">
             <dropdown class="fluid" title="System Startup" ng-model="settings.systemStartup">
                 <dropdown-group data-value="disabled">Disabled</dropdown-group>
-                <dropdown-group data-value="open">Start Electorrent</dropdown-group>
-                <dropdown-group data-value="minimized">Start Electorrent Minimized</dropdown-group>
+                <dropdown-group data-value="open">Start</dropdown-group>
+                <dropdown-group data-value="background">Start in background</dropdown-group>
             </dropdown>
         </div>
     </div>

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -6,6 +6,7 @@ export let settingsService = ['$rootScope', '$bittorrent', 'notificationService'
 
     var settings: AppSettings<any> = {
         startup: 'default',
+        systemStartup: 'disabled',
         refreshRate: 2000,
         automaticUpdates: true,
         closeToTray: true,

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -2,7 +2,7 @@ export type Unsubscribe = () => void
 
 export type ColorTheme = "light" | "dark"
 export type ThemePreference = ColorTheme | "system"
-export type SystemStartupOption = "disabled" | "open" | "minimized"
+export type SystemStartupOption = "disabled" | "open" | "background"
 
 export interface AppMeta {
     appName: string

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -2,6 +2,7 @@ export type Unsubscribe = () => void
 
 export type ColorTheme = "light" | "dark"
 export type ThemePreference = ColorTheme | "system"
+export type SystemStartupOption = "disabled" | "open" | "minimized"
 
 export interface AppMeta {
     appName: string
@@ -161,6 +162,7 @@ export interface SavedLocationConfig {
 
 export interface AppSettings<TServer = StoredServerConfig> {
     startup: string
+    systemStartup: SystemStartupOption
     refreshRate: number
     automaticUpdates?: boolean
     closeToTray?: boolean

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -392,9 +392,9 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
             await this.app.settingsGotoTab("general")
             const initialSystemStartup = await this.app.getGeneralDropdownValue("System Startup")
-            const nextSystemStartup = initialSystemStartup === "Start Electorrent"
+            const nextSystemStartup = initialSystemStartup === "Start"
               ? "Disabled"
-              : "Start Electorrent"
+              : "Start"
 
             await this.app.selectGeneralDropdownValue("System Startup", nextSystemStartup)
             await this.app.settingsSave()

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -385,6 +385,30 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
             await this.app.torrentsPageIsVisible()
           })
 
+          it("persists system startup preference", async function() {
+            if (process.platform === "linux") {
+              this.skip()
+            }
+
+            await this.app.settingsGotoTab("general")
+            const initialSystemStartup = await this.app.getGeneralDropdownValue("System Startup")
+            const nextSystemStartup = initialSystemStartup === "Start Electorrent"
+              ? "Disabled"
+              : "Start Electorrent"
+
+            await this.app.selectGeneralDropdownValue("System Startup", nextSystemStartup)
+            await this.app.settingsSave()
+            await this.app.torrentsPageIsVisible()
+
+            await this.app.openSettings()
+            await this.app.settingsGotoTab("general")
+            assert.equal(await this.app.getGeneralDropdownValue("System Startup"), nextSystemStartup)
+
+            await this.app.selectGeneralDropdownValue("System Startup", initialSystemStartup)
+            await this.app.settingsSave()
+            await this.app.torrentsPageIsVisible()
+          })
+
         })
 
         describe("server selection page", function() {


### PR DESCRIPTION
## Summary
- Add a general-settings dropdown for system startup with disabled, start at login, and start at login minimized options
- Persist the setting and apply Electron login-item configuration on macOS and Windows
- Start the app minimized when launched from login if that mode is selected
- Add an end-to-end UI check for saving and reloading the new preference

## Testing
- Smoketest passed