### PR TITLE
Add per-server default upload options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8533,18 +8533,6 @@
         }
       }
     },
-    "node_modules/create-wdio/node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
     "node_modules/create-wdio/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -8903,15 +8891,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/create-wdio/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/create-wdio/node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -73,7 +73,7 @@ export class DelugeRuntime implements BittorrentRuntime {
 
         return Object.fromEntries(
             Object.entries({
-                download_location: options.saveLocation,
+                download_location: options.saveLocation || undefined,
                 add_paused: options.startTorrent === undefined ? undefined : !options.startTorrent,
                 max_connections: options.peerLimit,
                 max_download_speed: options.downloadSpeedLimit,

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -281,7 +281,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
         }
 
         return this.removeEmpty({
-            'download-dir': uploadOptions.saveLocation,
+            'download-dir': uploadOptions.saveLocation || undefined,
             labels: uploadOptions.category ? [uploadOptions.category] : undefined,
             paused: uploadOptions.startTorrent === undefined ? undefined : !uploadOptions.startTorrent,
         })

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -2,7 +2,10 @@ import { Torrent, TorrentFile } from "./abstracttorrent"
 import type {
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
+    TorrentUploadOptions,
 } from "@shared/ipc-contract"
+
+export type { TorrentUploadOptions } from "@shared/ipc-contract"
 
 export type TorrentActionRole = "resume" | "stop" | "delete"
 
@@ -20,19 +23,6 @@ export interface TorrentUpdates {
  * Options to apply to a torrent upon uploading a new torrent to the client.
  * The torrent API may accept any subset of the interface below.
  */
-export interface TorrentUploadOptions {
-    saveLocation?: string
-    renameTorrent?: string
-    category?: string
-    startTorrent?: boolean
-    peerLimit?: number
-    skipCheck?: boolean
-    sequentialDownload?: boolean
-    firstAndLastPiecePrio?: boolean
-    downloadSpeedLimit?: number
-    uploadSpeedLimit?: number
-}
-
 /**
  * A record of which upload options to enable for a torrent client. The options you enable
  * must be supported by the API. Any features that are enabled will have the corrosponding UI

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
@@ -45,8 +45,15 @@ export class AddTorrentModalController {
             return
         }
 
-        this.uploadOptions = Object.assign({},
-            AddTorrentModalController.defaultTorrentUploadOptions
+        const server = this.rootScope.$server
+        const configuredOptions = server?.defaultUploadOptionsEnabled
+            ? server.defaultUploadOptions
+            : undefined
+
+        this.uploadOptions = Object.assign(
+            {},
+            AddTorrentModalController.defaultTorrentUploadOptions,
+            configuredOptions || {},
         )
     }
 

--- a/src/renderer/app/directives/settings-advanced/settings-advanced.controller.ts
+++ b/src/renderer/app/directives/settings-advanced/settings-advanced.controller.ts
@@ -1,10 +1,13 @@
 import { IScope } from "angular";
-import type { SavedLocationConfig } from "@shared/ipc-contract";
+import type { SavedLocationConfig, TorrentUploadOptions } from "@shared/ipc-contract";
 import { SavedLocationModalController } from "@renderer/app/directives/saved-location-modal/saved-location-modal.controller";
 
 interface SettingsAdvancedScope extends IScope {
     server?: {
+        id?: string
         savedLocations?: SavedLocationConfig[]
+        defaultUploadOptionsEnabled?: boolean
+        defaultUploadOptions?: TorrentUploadOptions
         getDisplayName?: () => string
     }
 }
@@ -17,7 +20,7 @@ export class SettingsAdvancedController {
     constructor(private readonly scope: SettingsAdvancedScope) {}
 
     hasServer() {
-        return !!this.scope.server;
+        return !!this.scope.server?.id;
     }
 
     getServerName() {

--- a/src/renderer/app/directives/settings-advanced/settings-advanced.template.html
+++ b/src/renderer/app/directives/settings-advanced/settings-advanced.template.html
@@ -33,6 +33,30 @@
 
     <div class="ui divider"></div>
 
+    <div data-role="advanced-default-upload-options-row">
+        <div class="ui small header">Default upload options</div>
+        <p>Choose initial values for the Add Torrent dialog on <strong>{{ ctl.getServerName() }}</strong>.</p>
+        <div style="margin-left: 2rem;">
+            <toggle
+                data-role="settings-default-upload-options-toggle"
+                ng-model="server.defaultUploadOptionsEnabled"
+                ng-disabled="!ctl.hasServer()">
+                Use default upload options
+            </toggle>
+
+            <div
+                data-role="settings-default-upload-options-form"
+                ng-if="ctl.hasServer() && server.defaultUploadOptionsEnabled"
+                style="margin-top: 1rem;">
+                <torrent-upload-form
+                    options="server.defaultUploadOptions"
+                    labels="labels"></torrent-upload-form>
+            </div>
+        </div>
+    </div>
+
+    <div class="ui divider"></div>
+
     <div data-role="advanced-saved-locations-row">
         <div class="ui small header">Saved locations</div>
         <p>Save reusable upload locations for <strong>{{ ctl.getServerName() }}</strong>. These locations appear in the upload modal for this server.</p>

--- a/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.template.html
+++ b/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.template.html
@@ -1,7 +1,7 @@
 <div>
     <div class="ui form" ng-class="{'loading': loading}">
         <div class="fields" ng-if="ctl.optionsEnabled.saveLocation">
-            <div class="thirteen wide field">
+            <div class="field upload-location-field">
                 <dropdown
                     title="Default location"
                     id="upload-options-saved-location"

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -1,7 +1,7 @@
 import _ from "underscore"
 import { Torrent } from "@renderer/app/bittorrent"
 import type { CertificateResponseService } from "@renderer/app/services/certificate-response"
-import type { SavedLocationConfig, StoredServerConfig } from "@shared/ipc-contract"
+import type { SavedLocationConfig, StoredServerConfig, TorrentUploadOptions } from "@shared/ipc-contract"
 
 export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclients', 'certificateResponseService',
     function($q, $notify, $bittorrent, $btclients, certificateResponseService: CertificateResponseService) {
@@ -44,6 +44,8 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                 this.lastused = -1
                 this.columns = this.defaultColumns()
                 this.savedLocations = []
+                this.defaultUploadOptionsEnabled = false
+                this.defaultUploadOptions = normalizeDefaultUploadOptions()
             }
             this.isConnected = false
         }
@@ -59,6 +61,10 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                     path: savedLocation.path,
                     icon: savedLocation.icon,
                 }))
+        }
+
+        function normalizeDefaultUploadOptions(options?: TorrentUploadOptions) {
+            return Object.assign({ startTorrent: true }, options || {})
         }
 
         Server.prototype.fromJson = function(data) {
@@ -77,6 +83,8 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
             this.certificateData = data.certificateData ? new Uint8Array(data.certificateData) : undefined
             this.columns = this.parseColumns(data.columns)
             this.savedLocations = normalizeSavedLocations(data.savedLocations)
+            this.defaultUploadOptionsEnabled = data.defaultUploadOptionsEnabled === true
+            this.defaultUploadOptions = normalizeDefaultUploadOptions(data.defaultUploadOptions)
         };
 
         Server.prototype.json = function() {
@@ -95,6 +103,8 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                 certificate: this.certificate,
                 columns: this.columns.filter((column) => column.enabled).map((column) => column.name),
                 savedLocations: normalizeSavedLocations(this.savedLocations),
+                defaultUploadOptionsEnabled: this.defaultUploadOptionsEnabled === true,
+                defaultUploadOptions: normalizeDefaultUploadOptions(this.defaultUploadOptions),
             }
         };
 

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -3,6 +3,10 @@ html, body {
     -webkit-user-select: none;
     color: @textColor;
 }
+.ui.form .fields > .field.upload-location-field {
+    flex: 1 1 0;
+    min-width: 0;
+}
 .title-bar {
     position: absolute;
     top: 0;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -152,11 +152,26 @@ export interface StoredServerConfig {
     certificate?: string
     columns: string[]
     savedLocations?: SavedLocationConfig[]
+    defaultUploadOptionsEnabled?: boolean
+    defaultUploadOptions?: TorrentUploadOptions
 }
 
 export interface SavedLocationConfig {
     path: string
     icon: string
+}
+
+export interface TorrentUploadOptions {
+    saveLocation?: string
+    renameTorrent?: string
+    category?: string
+    startTorrent?: boolean
+    peerLimit?: number
+    skipCheck?: boolean
+    sequentialDownload?: boolean
+    firstAndLastPiecePrio?: boolean
+    downloadSpeedLimit?: number
+    uploadSpeedLimit?: number
 }
 
 export interface AppSettings<TServer = StoredServerConfig> {

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -631,6 +631,20 @@ export class App {
     }
   }
 
+  async setDefaultUploadOptions({ enabled, start }: { enabled: boolean, start?: boolean }) {
+    const toggle = $("#page-settings-advanced [data-role='settings-default-upload-options-toggle'] input")
+    await toggle.waitForExist()
+    if (await toggle.isSelected() !== enabled) {
+      await toggle.click()
+    }
+
+    if (enabled && start !== undefined) {
+      const form = $("#page-settings-advanced [data-role='settings-default-upload-options-form']")
+      await form.waitForDisplayed()
+      await this.setUploadToggle(form, "start-torrent", start)
+    }
+  }
+
   async addSettingsSavedLocation({ path, icon }: { path: string, icon: string }) {
     const addButton = $("#page-settings-advanced [data-role='settings-saved-location-add']")
     await addButton.waitForDisplayed()

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -854,6 +854,35 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
             await torrent.delete()
           })
 
+          it("add torrent dialog uses current server default upload options", async function() {
+            if (!options.client.uploadOptionsEnable?.startTorrent) return this.skip()
+
+            let torrent: e2e.Torrent | undefined
+
+            try {
+              await this.app.openSettings()
+              await this.app.settingsGotoTab("advanced")
+              await this.app.setDefaultUploadOptions({ enabled: true, start: false })
+              await this.app.settingsSave()
+              await this.app.torrentsPageIsVisible()
+
+              torrent = await this.app.uploadTorrent({ filename: this.torrentPath, askUploadOptions: true })
+              await this.app.uploadTorrentModalSubmit()
+              await torrent.waitForExist()
+              await torrent.waitForState(options.stopLabel, { timeout: 20 * 1000 })
+            } finally {
+              if (torrent && await torrent.isExisting()) {
+                await torrent.delete()
+              }
+
+              await this.app.openSettings()
+              await this.app.settingsGotoTab("advanced")
+              await this.app.setDefaultUploadOptions({ enabled: false })
+              await this.app.settingsSave()
+              await this.app.torrentsPageIsVisible()
+            }
+          })
+
           it("magnet link opens upload options", async function() {
             const torrent = await this.app.uploadMagnetLink({ filename: this.torrentPath, askUploadOptions: true });
             const torrentMetadata = parseTorrent(fs.readFileSync(this.torrentPath))


### PR DESCRIPTION
## Summary
- Store default upload options on each server config instead of global app settings
- Apply those defaults when opening the Add Torrent dialog for the active server
- Keep saved-location dropdown layout fluid when the add button is absent
- Add an e2e case covering the server-scoped default upload flow

## Testing
- UI testing added for the active-server default upload behavior
- No manual validation run in this pass