### PR TITLE
Fix notification colors for dark theme

### DIFF
--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -786,16 +786,6 @@ html, body {
     margin: 5px;
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
 }
-.ui.negative.message {
-    background-color: #F2B3B3;
-    color: #7A1200;
-    border: none;
-}
-.ui.positive.message {
-    background-color: rgb(199, 236, 179);
-    color: #1F5130;
-    border: none;
-}
 .notification.ng-enter {
     -webkit-animation: notification-show 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.27499);
 }

--- a/src/renderer/styles/themes/dark/collections/message.overrides
+++ b/src/renderer/styles/themes/dark/collections/message.overrides
@@ -3,5 +3,10 @@
     text-decoration: underline;
   }
 
-  border: 1px solid rgba(0,0,0,.1);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.ui.positive.message,
+.ui.negative.message {
+  border: none;
 }

--- a/src/renderer/styles/themes/dark/collections/message.variables
+++ b/src/renderer/styles/themes/dark/collections/message.variables
@@ -1,2 +1,32 @@
-@background: @gray;
+@background: @gray-dark;
 @boxShadow: none;
+
+@positiveBackgroundColor: #304a35;
+@positiveBorderColor: #47634c;
+@positiveHeaderColor: #a9dfa9;
+@positiveTextColor: #9ad69a;
+
+@warningBackgroundColor: #513e27;
+@warningBorderColor: #705936;
+@warningHeaderColor: #ffd084;
+@warningTextColor: #ffc36b;
+
+@negativeBackgroundColor: #512f31;
+@negativeBorderColor: #704347;
+@negativeHeaderColor: #ffaaa7;
+@negativeTextColor: #ff9c99;
+
+@infoBackgroundColor: #2d444d;
+@infoBorderColor: #40616e;
+@infoHeaderColor: #a8dce8;
+@infoTextColor: #98d1df;
+
+@successBackgroundColor: @positiveBackgroundColor;
+@successBorderColor: @positiveBorderColor;
+@successHeaderColor: @positiveHeaderColor;
+@successTextColor: @positiveTextColor;
+
+@errorBackgroundColor: @negativeBackgroundColor;
+@errorBorderColor: @negativeBorderColor;
+@errorHeaderColor: @negativeHeaderColor;
+@errorTextColor: @negativeTextColor;

--- a/src/renderer/styles/themes/light/collections/message.overrides
+++ b/src/renderer/styles/themes/light/collections/message.overrides
@@ -1,0 +1,11 @@
+.ui.negative.message {
+  background-color: #F2B3B3;
+  color: #7A1200;
+  border: none;
+}
+
+.ui.positive.message {
+  background-color: rgb(199, 236, 179);
+  color: #1F5130;
+  border: none;
+}


### PR DESCRIPTION
## Summary
- Move notification message styling out of shared layout CSS and into theme-specific overrides
- Add dark-theme message colors for positive, negative, warning, info, success, and error states
- Keep the light-theme notification colors unchanged

## Testing
- UI smoketest via the existing WebdriverIO suite passed