### PR TITLE
fix(timeouts): standardize bittorrent HTTP timeouts

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,12 @@
 import request from "request"
 
 import type { BittorrentServerConfig, BittorrentTorrentDetailsData } from "@shared/ipc-contract"
-import { cleanPath, defer } from "@main/lib/bittorrent/helpers"
+import {
+    cleanPath,
+    defer,
+    HTTP_LOGIN_TIMEOUT,
+    HTTP_REQUEST_TIMEOUT,
+} from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 
 const DELUGE_TORRENT_FIELDS = [
@@ -83,9 +88,10 @@ export class DelugeRuntime implements BittorrentRuntime {
         )
     }
 
-    private rpc(method: string, params: any[], cb: (err: any, value?: any) => void) {
+    private rpc(method: string, params: any[], cb: (err: any, value?: any) => void, timeout = HTTP_REQUEST_TIMEOUT) {
         request({
             ...this.requestOptions,
+            timeout,
             method: "POST",
             json: true,
             gzip: true,
@@ -116,10 +122,8 @@ export class DelugeRuntime implements BittorrentRuntime {
     }
 
     private uploadTorrentPayload(torrent: Uint8Array | Buffer, cb: (err: any, body?: any) => void) {
-        const uploadRequestOptions = { ...this.requestOptions }
-        delete uploadRequestOptions.timeout
         const uploadRequest = request({
-            ...uploadRequestOptions,
+            ...this.requestOptions,
             method: "POST",
             url: this.uploadUrl,
             json: true,
@@ -182,12 +186,12 @@ export class DelugeRuntime implements BittorrentRuntime {
         this.uploadUrl = `${origin}${buildClientPath(server, "upload")}`
         this.requestId = 0
         this.requestOptions = {
-            timeout: 5000,
+            timeout: HTTP_REQUEST_TIMEOUT,
             ca: server.certificateData,
             jar: request.jar(),
         }
 
-        await defer((done) => this.rpc("auth.login", [server.password], done))
+        await defer((done) => this.rpc("auth.login", [server.password], done, HTTP_LOGIN_TIMEOUT))
 
         const hosts = await this.getHosts()
         const hostId = hosts[0]?.[0]

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
@@ -7,12 +7,12 @@ export class QBittorrentApiV1 extends QBittorrentBaseApi {
     }
 
     login(cb: (err?: any, body?: any) => void) {
-        this.post("login", {
+        this.post("login", this.loginRequestOptions({
             form: {
                 username: this.user,
                 password: this.pass,
             },
-        }, (err, res, body) => {
+        }), (err, res, body) => {
             if (!err && res && !Object.prototype.hasOwnProperty.call(res.headers || {}, "set-cookie")) {
                 cb(new Error("Invalid login"), body)
                 return

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
@@ -10,12 +10,12 @@ export class QBittorrentApiV2 extends QBittorrentBaseApi {
     }
 
     login(cb: (err?: any, body?: any) => void) {
-        this.post("auth/login", {
+        this.post("auth/login", this.loginRequestOptions({
             form: {
                 username: this.user,
                 password: this.pass,
             },
-        }, (err, res, body) => {
+        }), (err, res, body) => {
             if (!err && res && !Object.prototype.hasOwnProperty.call(res.headers || {}, "set-cookie")) {
                 cb(new Error("Invalid login"), body)
                 return

--- a/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
@@ -3,6 +3,8 @@ import path from "path"
 
 import request from "request"
 
+import { HTTP_LOGIN_TIMEOUT, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
+
 export const AUTH_ERRORS: Record<number, Error> = {
     403: new Error("User's IP is banned for too many failed login attempts"),
 }
@@ -40,7 +42,7 @@ export abstract class QBittorrentBaseApi {
         this.user = options.user
         this.pass = options.pass
         this.origin = options.origin
-        this.timeout = options.timeout || 5000
+        this.timeout = options.timeout || HTTP_REQUEST_TIMEOUT
 
         this.options = {
             timeout: this.timeout,
@@ -102,6 +104,13 @@ export abstract class QBittorrentBaseApi {
 
     protected isSuccessfulStatusCode(statusCode: number) {
         return statusCode >= 200 && statusCode < 300
+    }
+
+    protected loginRequestOptions(requestOptions: Record<string, any>) {
+        return {
+            ...requestOptions,
+            timeout: HTTP_LOGIN_TIMEOUT,
+        }
     }
 
     get(apiPath: string, requestOptions: Record<string, any>, cb: (err: any, res?: any, body?: any) => void) {

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -5,7 +5,7 @@ import type {
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
 } from "@shared/ipc-contract"
-import { cleanPath, defer } from "@main/lib/bittorrent/helpers"
+import { cleanPath, defer, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { QBittorrentApiV1 } from "./api-v1"
 import { QBittorrentApiV2 } from "./api-v2"
@@ -27,7 +27,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
     private async selectApi(server: BittorrentServerConfig) {
         const origin = `${server.proto}://${server.ip}:${server.port}`
         const requestOptions = {
-            timeout: 5000,
+            timeout: HTTP_REQUEST_TIMEOUT,
             ca: server.certificateData,
             method: "GET",
             headers: {
@@ -46,7 +46,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
             user: server.user,
             pass: server.password,
             ca: server.certificateData,
-            timeout: 5000,
+            timeout: HTTP_REQUEST_TIMEOUT,
         }
 
         return hasLegacyApi ? new QBittorrentApiV1(options) : new QBittorrentApiV2(options)

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -1,7 +1,7 @@
 import xmlrpc from "@electorrent/xmlrpc"
 
 import type { BittorrentServerConfig, BittorrentTorrentDetailsData } from "@shared/ipc-contract"
-import { cleanPath, defer } from "@main/lib/bittorrent/helpers"
+import { cleanPath, defer, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { doubleArrayToHash, postfix, rtorrentFields, stringsToBooleans, stringsToNumbers, urlHostname } from "./helpers"
 
@@ -105,7 +105,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
                 Connection: "Close",
             },
             ca: server.certificateData,
-            timeout: 5000,
+            timeout: HTTP_REQUEST_TIMEOUT,
         }
 
         if (server.user && server.password) {

--- a/src/main/lib/bittorrent/clients/synology.ts
+++ b/src/main/lib/bittorrent/clients/synology.ts
@@ -3,7 +3,12 @@ import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
 
 import type { BittorrentServerConfig } from '@shared/ipc-contract'
-import { createHttpsAgent, serverUrl } from '@main/lib/bittorrent/helpers'
+import {
+    createHttpsAgent,
+    HTTP_LOGIN_TIMEOUT,
+    HTTP_REQUEST_TIMEOUT,
+    serverUrl,
+} from '@main/lib/bittorrent/helpers'
 import type { BittorrentRuntime } from '@main/lib/bittorrent/types'
 
 const API_INFO = 'SYNO.API.Info'
@@ -49,8 +54,6 @@ export class SynologyRuntime implements BittorrentRuntime {
     private dlPath = ''
     private dlVersion = ''
     private taskPath = '/DownloadStation/task.cgi'
-    private timeout = 6000
-
     private config(choice: string, args: any[] = []) {
         switch (choice) {
             case 'query':
@@ -61,7 +64,7 @@ export class SynologyRuntime implements BittorrentRuntime {
                         method: 'query',
                         query: 'SYNO.API.Auth,SYNO.DownloadStation.Task',
                     },
-                    timeout: this.timeout,
+                    timeout: HTTP_REQUEST_TIMEOUT,
                 }
             case 'auth':
                 return {
@@ -73,7 +76,7 @@ export class SynologyRuntime implements BittorrentRuntime {
                         passwd: args[1],
                         session: 'DownloadStation',
                     },
-                    timeout: this.timeout,
+                    timeout: HTTP_LOGIN_TIMEOUT,
                 }
             case 'torrents':
                 return {
@@ -83,7 +86,7 @@ export class SynologyRuntime implements BittorrentRuntime {
                         method: 'list',
                         additional: 'detail,transfer,tracker',
                     },
-                    timeout: this.timeout,
+                    timeout: HTTP_REQUEST_TIMEOUT,
                 }
             case 'tUrl':
                 return {
@@ -94,7 +97,7 @@ export class SynologyRuntime implements BittorrentRuntime {
                         uri: args[0],
                         destination: args[1],
                     },
-                    timeout: this.timeout,
+                    timeout: HTTP_REQUEST_TIMEOUT,
                 }
             case 'action':
                 return {
@@ -104,7 +107,7 @@ export class SynologyRuntime implements BittorrentRuntime {
                         method: args[0],
                         id: args[1],
                     },
-                    timeout: this.timeout,
+                    timeout: HTTP_REQUEST_TIMEOUT,
                 }
             case 'setLocation':
                 return {
@@ -115,7 +118,7 @@ export class SynologyRuntime implements BittorrentRuntime {
                         id: args[0],
                         destination: args[1],
                     },
-                    timeout: this.timeout,
+                    timeout: HTTP_REQUEST_TIMEOUT,
                 }
             default:
                 return {}
@@ -158,6 +161,7 @@ export class SynologyRuntime implements BittorrentRuntime {
         this.http = axios.create({
             httpsAgent: createHttpsAgent(server),
             adapter: httpAdapter,
+            timeout: HTTP_REQUEST_TIMEOUT,
         })
 
         this.http.interceptors.response.use((res) => {

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -2,7 +2,12 @@ import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 
 import type { BittorrentServerConfig, BittorrentTorrentDetailsData } from '@shared/ipc-contract'
-import { createHttpsAgent, serverUrl } from '@main/lib/bittorrent/helpers'
+import {
+    createHttpsAgent,
+    HTTP_LOGIN_TIMEOUT,
+    HTTP_REQUEST_TIMEOUT,
+    serverUrl,
+} from '@main/lib/bittorrent/helpers'
 import type { BittorrentRuntime } from '@main/lib/bittorrent/types'
 
 const SESSION_ID_HEADER = 'X-Transmission-Session-Id'
@@ -128,6 +133,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
             },
             httpsAgent: createHttpsAgent(this.server),
             adapter: httpAdapter,
+            timeout: HTTP_REQUEST_TIMEOUT,
         })
 
         http.interceptors.response.use(
@@ -164,7 +170,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
         this.session = undefined
 
         await this.getHttpClient().post(this.url(), { method: 'session-get' }, {
-            timeout: 5000,
+            timeout: HTTP_LOGIN_TIMEOUT,
             auth: {
                 username: server.user,
                 password: server.password,

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -4,7 +4,12 @@ import FormData from 'form-data'
 import qs from 'qs'
 
 import type { BittorrentServerConfig } from '@shared/ipc-contract'
-import { createHttpsAgent, serverUrl } from '@main/lib/bittorrent/helpers'
+import {
+    createHttpsAgent,
+    HTTP_LOGIN_TIMEOUT,
+    HTTP_REQUEST_TIMEOUT,
+    serverUrl,
+} from '@main/lib/bittorrent/helpers'
 import type { BittorrentRuntime } from '@main/lib/bittorrent/types'
 
 export class UtorrentRuntime implements BittorrentRuntime {
@@ -89,6 +94,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
             httpsAgent: createHttpsAgent(server),
             paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
             adapter: httpAdapter,
+            timeout: HTTP_REQUEST_TIMEOUT,
         })
 
         this.http.interceptors.response.use((res) => {
@@ -115,7 +121,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
         })
 
         const res = await this.http.get(`${this.url()}/token.html`, {
-            timeout: 5000,
+            timeout: HTTP_LOGIN_TIMEOUT,
             params: {
                 t: Date.now(),
             },

--- a/src/main/lib/bittorrent/helpers.ts
+++ b/src/main/lib/bittorrent/helpers.ts
@@ -2,6 +2,9 @@ import https from "https"
 import type { BittorrentServerConfig } from "@shared/ipc-contract"
 import type { CallbackFunc } from "./types"
 
+export const HTTP_LOGIN_TIMEOUT = 5000
+export const HTTP_REQUEST_TIMEOUT = 30000
+
 export function defer<T>(fn: (f: CallbackFunc<T>) => void): Promise<T> {
     return new Promise((resolve, reject) => {
         fn((err, val) => {


### PR DESCRIPTION
## Summary
- Set login HTTP requests to `5000 ms` across all bittorrent backends
- Set all other HTTP requests to `30000 ms`
- Keep rTorrent on `30000 ms` for all XML-RPC requests per the timeout rule
- Add shared timeout constants in bittorrent helpers

## Testing
- Not run (not requested)