### PR TITLE
feat: support labels for deluge

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,4 +1,5 @@
 import request from "request"
+import parseTorrent from "parse-torrent"
 
 import type { BittorrentServerConfig, BittorrentTorrentDetailsData } from "@shared/ipc-contract"
 import { cleanPath, defer } from "@main/lib/bittorrent/helpers"
@@ -9,6 +10,7 @@ const DELUGE_TORRENT_FIELDS = [
     "download_payload_rate",
     "eta",
     "is_auto_managed",
+    "label",
     "max_connections",
     "max_download_speed",
     "max_upload_speed",
@@ -66,6 +68,8 @@ export class DelugeRuntime implements BittorrentRuntime {
 
     private requestOptions: Record<string, any> = {}
 
+    private supportsLabels = false
+
     private getUploadOptions(options?: Record<string, any>) {
         if (!options) {
             return {}
@@ -79,6 +83,7 @@ export class DelugeRuntime implements BittorrentRuntime {
                 max_download_speed: options.downloadSpeedLimit,
                 max_upload_speed: options.uploadSpeedLimit,
                 prioritize_first_last_pieces: options.firstAndLastPiecePrio,
+                label: options.category,
             }).filter(([, value]) => value !== undefined && value !== null),
         )
     }
@@ -132,7 +137,7 @@ export class DelugeRuntime implements BittorrentRuntime {
     }
 
     private addUploadedTorrent(path: string, config: Record<string, any> | undefined, cb: (err: any, value?: any) => void) {
-        const options = {
+        const options: Record<string, any> = {
             file_priorities: [],
             add_paused: false,
             compact_allocation: false,
@@ -143,8 +148,21 @@ export class DelugeRuntime implements BittorrentRuntime {
             prioritize_first_last_pieces: false,
             ...config,
         }
+        delete options.label
 
         this.rpc("web.add_torrents", [[{ path, options }]], cb)
+    }
+
+    private async applyUploadedTorrentLabel(hash: string | undefined, label?: string) {
+        if (!label) {
+            return
+        }
+
+        if (!hash) {
+            throw new Error("Unable to determine the uploaded torrent hash")
+        }
+
+        await this.setLabel([hash], label)
     }
 
     private isMagnetUrl(uri: string) {
@@ -196,10 +214,25 @@ export class DelugeRuntime implements BittorrentRuntime {
         }
 
         await defer((done) => this.rpc("web.connect", [hostId], done))
+
+        const enabledPlugins = await defer<string[]>((done) => this.rpc("core.get_enabled_plugins", [], done))
+        this.supportsLabels = Array.isArray(enabledPlugins) && enabledPlugins.includes("Label")
     }
 
-    getSnapshot(): Promise<any> {
-        return defer((done) => this.rpc("web.update_ui", [DELUGE_TORRENT_FIELDS, {}], done))
+    async getSnapshot(): Promise<any> {
+        const fields = this.supportsLabels
+            ? DELUGE_TORRENT_FIELDS
+            : DELUGE_TORRENT_FIELDS.filter((field) => field !== "label")
+        const snapshot = await defer<Record<string, any>>((done) => this.rpc("web.update_ui", [fields, {}], done))
+        const labels = this.supportsLabels
+            ? await defer<string[]>((done) => this.rpc("label.get_labels", [], done))
+            : []
+
+        return {
+            ...snapshot,
+            labels: Array.isArray(labels) ? labels : [],
+            supportsLabels: this.supportsLabels,
+        }
     }
 
     async getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {
@@ -265,12 +298,16 @@ export class DelugeRuntime implements BittorrentRuntime {
 
         if (this.isMagnetUrl(uri)) {
             const magnetOptions = await this.resolveMagnetConfig(uploadOptions)
+            const hash = parseTorrent(uri).infoHash
             await defer((done) => this.addUploadedTorrent(uri, magnetOptions, done))
+            await this.applyUploadedTorrentLabel(hash, magnetOptions.label)
             return
         }
 
         const uploadPath = await defer<string>((done) => this.rpc("web.download_torrent_from_url", [uri, ""], done))
+        const torrentInfo = await defer<Record<string, any>>((done) => this.rpc("web.get_torrent_info", [uploadPath], done))
         await defer((done) => this.addUploadedTorrent(uploadPath, uploadOptions, done))
+        await this.applyUploadedTorrentLabel(torrentInfo?.info_hash, uploadOptions.label)
     }
 
     async uploadTorrent(buffer: Uint8Array, _filename: string, options?: Record<string, any>): Promise<void> {
@@ -281,7 +318,10 @@ export class DelugeRuntime implements BittorrentRuntime {
             throw new Error("Deluge upload did not return a torrent path")
         }
 
-        await defer((done) => this.addUploadedTorrent(uploadPath, this.getUploadOptions(options), done))
+        const uploadOptions = this.getUploadOptions(options)
+        const hash = parseTorrent(Buffer.from(buffer)).infoHash
+        await defer((done) => this.addUploadedTorrent(uploadPath, uploadOptions, done))
+        await this.applyUploadedTorrentLabel(hash, uploadOptions.label)
     }
 
     resume(hashes: string[]): Promise<void> {
@@ -318,5 +358,17 @@ export class DelugeRuntime implements BittorrentRuntime {
 
     queueBottom(hashes: string[]): Promise<void> {
         return defer((done) => this.rpc("core.queue_bottom", [hashes], done))
+    }
+
+    async setLabel(hashes: string[], label: string, create?: boolean): Promise<void> {
+        if (!this.supportsLabels) {
+            throw new Error("Deluge labels require the Label plugin to be enabled")
+        }
+
+        if (create === true) {
+            await defer((done) => this.rpc("label.add", [label], done))
+        }
+
+        await Promise.all(hashes.map((hash) => defer((done) => this.rpc("label.set_torrent", [hash, label], done))))
     }
 }

--- a/src/renderer/app/bittorrent/deluge/delugeservice.ts
+++ b/src/renderer/app/bittorrent/deluge/delugeservice.ts
@@ -1,4 +1,4 @@
-import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
+import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentUpdates, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@renderer/app/bittorrent/torrentclient";
 import { DelugeTorrent } from "./torrentd";
 import { addTorrentUrl, connect, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
@@ -7,8 +7,10 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
     public name = 'Deluge'
     public id = 'deluge'
     public supportsTorrentDetails = true
-    public uploadOptionsEnable = {
+    public supportsLabels = false
+    public uploadOptionsEnable: TorrentUploadOptionsEnable = {
         saveLocation: true,
+        category: true,
         startTorrent: true,
         peerLimit: true,
         firstAndLastPiecePrio: true,
@@ -22,9 +24,16 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
 
     async torrents(): Promise<TorrentUpdates> {
         const data: Record<string, any> = await getSnapshot()
+        const supportsLabels = data.supportsLabels === true
+        if (this.supportsLabels !== supportsLabels) {
+            this.supportsLabels = supportsLabels
+            this.updateLabelActions()
+        }
+        this.uploadOptionsEnable.category = this.supportsLabels
 
         return {
-            labels: [],
+            labels: Array.isArray(data.labels) ? data.labels : [],
+            supportsLabels: this.supportsLabels,
             all: Object.keys(data.torrents || {}).map((hash) => new DelugeTorrent(hash, data.torrents[hash])),
             changed: [],
             deleted: [],
@@ -78,6 +87,23 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
 
     queueBottom(torrents: DelugeTorrent[]): Promise<void> {
         return invokeAction("queueBottom", torrents.map((torrent) => torrent.hash))
+    }
+
+    setLabel(torrents: DelugeTorrent[], label: string, create?: boolean): Promise<void> {
+        return invokeAction("setLabel", torrents.map((torrent) => torrent.hash), label, create)
+    }
+
+    private updateLabelActions() {
+        const labelAction = {
+            label: "Labels",
+            click: this.setLabel,
+            type: "labels" as const,
+        }
+
+        this.actionHeader = [
+            ...this.baseActionHeader,
+            ...(this.supportsLabels ? [labelAction] : []),
+        ]
     }
 
     deleteTorrents(torrents: DelugeTorrent[]): Promise<void> {
@@ -141,7 +167,7 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
 
     extraColumns = []
 
-    actionHeader: TorrentActionList<DelugeTorrent> = [
+    private baseActionHeader: TorrentActionList<DelugeTorrent> = [
         {
             label: 'Start',
             type: 'button',
@@ -159,6 +185,8 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
             role: 'stop'
         },
     ]
+
+    actionHeader: TorrentActionList<DelugeTorrent> = this.baseActionHeader
 
     contextMenu: ContextActionList<DelugeTorrent> = [
         {
@@ -205,4 +233,5 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
             role: 'delete'
         },
     ];
+
 }

--- a/src/renderer/app/bittorrent/deluge/torrentd.ts
+++ b/src/renderer/app/bittorrent/deluge/torrentd.ts
@@ -16,7 +16,7 @@ export class DelugeTorrent extends Torrent {
             uploadSpeed: data.upload_payload_rate,  /* Upload Speed (integer): bytes per second */
             downloadSpeed: data.download_payload_rate, /* Download Speed (integer): bytes per second */
             eta: data.eta, /* ETA (integer): second to completion */
-            label: undefined, /* Label (string): group/category identification */
+            label: data.label || "", /* Label (string): group/category identification */
             peersConnected: data.num_peers, /* Peers Connected (integer): number of peers connected */
             peersInSwarm: data.total_peers, /* Peers In Swarm (integer): number of peers in the swarm */
             seedsConnected: data.num_seeds, /* Seeds Connected (integer): number of connected seeds */

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -11,6 +11,7 @@ export type TorrentActionRole = "resume" | "stop" | "delete"
 
 export interface TorrentUpdates {
     labels?: string[],
+    supportsLabels?: boolean,
     all?: any[],
     changed?: any[],
     deleted?: any[],
@@ -230,6 +231,11 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
      * and file details content.
      */
     public supportsTorrentDetails: boolean = false
+
+    /**
+     * When true, the client supports listing and assigning torrent labels.
+     */
+    public supportsLabels: boolean = true
 
     /**
      * Get the list of files for a torrent.

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -53,7 +53,7 @@
                 <div class="ui torrent sort label">{{numInFilter('error')}}</div>
             </li>
             </ul>
-            <div id="torrent-sidebar-labels" ng-if="!isSidebarCollapsed()">
+            <div id="torrent-sidebar-labels" ng-if="$btclient.supportsLabels && !isSidebarCollapsed()">
                 <div class="section">
                     <span>Labels</span>
                     <a data-role="labels-clear" class="ui gray basic mini clear button" ng-click="filterByLabel()">Clear</a>
@@ -87,7 +87,7 @@
             </div>
         </div>
         <div class="sidebar-collapsed-sections" ng-if="isSidebarCollapsed()">
-            <div class="sidebar-collapsed-section">
+            <div class="sidebar-collapsed-section" ng-if="$btclient.supportsLabels">
             <div class="torrent-sidebar-section-trigger" data-role="torrent-sidebar-labels-toggle" title="Labels">
                 <i class="tags icon"></i>
             </div>

--- a/test/fixtures/deluge/core.conf
+++ b/test/fixtures/deluge/core.conf
@@ -3,6 +3,7 @@
   "move_completed": false,
   "move_completed_path": "/downloads",
   "autoadd_location": "/downloads",
+  "enabled_plugins": ["Label"],
   "torrentfiles_location": "/downloads",
   "plugins_location": "/config/plugins"
 }

--- a/test/fixtures/deluge/deluge-1.spec.ts
+++ b/test/fixtures/deluge/deluge-1.spec.ts
@@ -11,7 +11,6 @@ createTestSuite({
   password: "deluge",
   stopLabel: "Paused",
   unsupportedFeatures: [
-    FeatureSet.Labels,
     FeatureSet.MagnetLinks,
   ],
 });

--- a/test/fixtures/deluge/deluge-2.spec.ts
+++ b/test/fixtures/deluge/deluge-2.spec.ts
@@ -1,5 +1,4 @@
 import { createTestSuite } from "../../testlib";
-import { FeatureSet } from "../../testutil";
 import { DelugeClient } from "../../../src/renderer/app/bittorrent"
 
 createTestSuite({
@@ -10,7 +9,5 @@ createTestSuite({
   username: "admin",
   password: "deluge",
   stopLabel: "Paused",
-  unsupportedFeatures: [
-    FeatureSet.Labels,
-  ],
+  unsupportedFeatures: [],
 });


### PR DESCRIPTION
### Summary
- Detect Deluge’s `Label` plugin at connection time and expose labels in the torrent list and sidebar only when supported.
- Add Deluge label assignment for the action header and advanced upload options, including post-upload label application.
- Update Deluge fixtures so the label feature set is enabled in test coverage.

### Testing
- Not run (not requested).