### PR TITLE
Refine torrent client feature discovery and fixture contracts

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,7 @@
 import request from "request"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData } from "@shared/ipc-contract"
+import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientFeatures } from "@shared/ipc-contract"
 import {
     cleanPath,
     defer,
@@ -197,7 +197,7 @@ export class DelugeRuntime implements BittorrentRuntime {
         return defer<any[]>((done) => this.rpc("web.get_hosts", [], done))
     }
 
-    async connect(server: BittorrentServerConfig): Promise<void> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
         const origin = `${server.proto}://${server.ip}:${server.port}`
 
         this.rpcUrl = `${origin}${buildClientPath(server, "json")}`
@@ -219,8 +219,27 @@ export class DelugeRuntime implements BittorrentRuntime {
 
         await defer((done) => this.rpc("web.connect", [hostId], done))
 
-        const enabledPlugins = await defer<string[]>((done) => this.rpc("core.get_enabled_plugins", [], done))
-        this.supportsLabels = Array.isArray(enabledPlugins) && enabledPlugins.includes("Label")
+        try {
+            const enabledPlugins = await defer<string[]>((done) => this.rpc("core.get_enabled_plugins", [], done))
+            this.supportsLabels = Array.isArray(enabledPlugins) && enabledPlugins.includes("Label")
+        } catch {
+            this.supportsLabels = false
+        }
+
+        return {
+            magnetLinks: String(hosts[0]?.[4] || "").startsWith("2."),
+            labels: this.supportsLabels,
+            torrentDetails: true,
+            uploadOptions: {
+                saveLocation: true,
+                category: this.supportsLabels,
+                startTorrent: true,
+                peerLimit: true,
+                firstAndLastPiecePrio: true,
+                downloadSpeedLimit: true,
+                uploadSpeedLimit: true,
+            },
+        }
     }
 
     async getSnapshot(): Promise<any> {
@@ -235,7 +254,6 @@ export class DelugeRuntime implements BittorrentRuntime {
         return {
             ...snapshot,
             labels: Array.isArray(labels) ? labels : [],
-            supportsLabels: this.supportsLabels,
         }
     }
 

--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -217,7 +217,7 @@ export class DelugeRuntime implements BittorrentRuntime {
             throw new Error("Deluge did not return any hosts")
         }
 
-        await defer((done) => this.rpc("web.connect", [hostId], done))
+        const methods = await defer<string[]>((done) => this.rpc("web.connect", [hostId], done))
 
         try {
             const enabledPlugins = await defer<string[]>((done) => this.rpc("core.get_enabled_plugins", [], done))
@@ -227,7 +227,7 @@ export class DelugeRuntime implements BittorrentRuntime {
         }
 
         return {
-            magnetLinks: String(hosts[0]?.[4] || "").startsWith("2."),
+            magnetLinks: Array.isArray(methods) && methods.includes("core.add_torrent_magnet"),
             labels: this.supportsLabels,
             torrentDetails: true,
             uploadOptions: {

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -2,6 +2,7 @@ import type {
     BittorrentFileSelection,
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
+    TorrentClientFeatures,
 } from "@shared/ipc-contract"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 
@@ -49,7 +50,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
     private files = new Map<string, MockTorrentFile[]>()
     private removedHashes: string[] = []
 
-    async connect(server: BittorrentServerConfig): Promise<void> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
         const count = this.getTorrentCount(server)
         this.torrents.clear()
         this.files.clear()
@@ -88,6 +89,25 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         }
 
         this.connected = true
+
+        return {
+            magnetLinks: true,
+            labels: true,
+            fileSelection: true,
+            setLocation: true,
+            torrentDetails: true,
+            uploadOptions: {
+                saveLocation: true,
+                renameTorrent: true,
+                category: true,
+                startTorrent: true,
+                skipCheck: true,
+                sequentialDownload: true,
+                firstAndLastPiecePrio: true,
+                downloadSpeedLimit: true,
+                uploadSpeedLimit: true,
+            },
+        }
     }
 
     async disconnect(): Promise<void> {

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -4,6 +4,7 @@ import type {
     BittorrentFileSelection,
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
+    TorrentClientFeatures,
 } from "@shared/ipc-contract"
 import { cleanPath, defer, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
@@ -60,10 +61,27 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         return this.api
     }
 
-    connect(server: BittorrentServerConfig): Promise<void> {
+    connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
         return this.selectApi(server).then((api) => {
             this.api = api
-            return defer((done) => api.login(done))
+            return defer((done) => api.login(done)).then(() => ({
+                magnetLinks: true,
+                labels: true,
+                fileSelection: true,
+                setLocation: true,
+                torrentDetails: true,
+                uploadOptions: {
+                    saveLocation: true,
+                    renameTorrent: true,
+                    category: true,
+                    startTorrent: true,
+                    skipCheck: true,
+                    sequentialDownload: true,
+                    firstAndLastPiecePrio: true,
+                    downloadSpeedLimit: true,
+                    uploadSpeedLimit: true,
+                },
+            }))
         })
     }
 

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -1,6 +1,6 @@
 import xmlrpc from "@electorrent/xmlrpc"
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData } from "@shared/ipc-contract"
+import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientFeatures } from "@shared/ipc-contract"
 import { cleanPath, defer, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { doubleArrayToHash, postfix, rtorrentFields, stringsToBooleans, stringsToNumbers, urlHostname } from "./helpers"
@@ -92,7 +92,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         await this.getMulticallHashes(hashes, commands, params)
     }
 
-    connect(server: BittorrentServerConfig): Promise<void> {
+    connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
         const options: Record<string, any> = {
             host: server.ip,
             port: server.port,
@@ -115,7 +115,16 @@ export class RtorrentRuntime implements BittorrentRuntime {
 
         this.client = server.proto === "https" ? xmlrpc.createSecureClient(options) : xmlrpc.createClient(options)
 
-        return this.call("system.client_version", []).then(() => undefined)
+        return this.call("system.client_version", []).then(() => ({
+            magnetLinks: true,
+            labels: true,
+            torrentDetails: true,
+            trackerFilter: true,
+            uploadOptions: {
+                saveLocation: true,
+                startTorrent: true,
+            },
+        }))
     }
 
     async getSnapshot(): Promise<any> {

--- a/src/main/lib/bittorrent/clients/synology.ts
+++ b/src/main/lib/bittorrent/clients/synology.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance, AxiosResponse } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
 
-import type { BittorrentServerConfig } from '@shared/ipc-contract'
+import type { BittorrentServerConfig, TorrentClientFeatures } from '@shared/ipc-contract'
 import {
     createHttpsAgent,
     HTTP_LOGIN_TIMEOUT,
@@ -156,7 +156,7 @@ export class SynologyRuntime implements BittorrentRuntime {
         return !!data?.success
     }
 
-    async connect(server: BittorrentServerConfig): Promise<void> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
         this.server = server
         this.http = axios.create({
             httpsAgent: createHttpsAgent(server),
@@ -187,6 +187,14 @@ export class SynologyRuntime implements BittorrentRuntime {
         this.handleError(authResponse)
         if (!this.isSuccess(authResponse.data)) {
             throw new Error(`Login failed. Error: ${authResponse.data.error}`)
+        }
+
+        return {
+            magnetLinks: true,
+            setLocation: true,
+            uploadOptions: {
+                saveLocation: true,
+            },
         }
     }
 

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData } from '@shared/ipc-contract'
+import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientFeatures } from '@shared/ipc-contract'
 import {
     createHttpsAgent,
     HTTP_LOGIN_TIMEOUT,
@@ -165,7 +165,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
         return http
     }
 
-    async connect(server: BittorrentServerConfig): Promise<void> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
         this.server = server
         this.session = undefined
 
@@ -177,6 +177,23 @@ export class TransmissionRuntime implements BittorrentRuntime {
             },
             validateStatus: (status) => status === 200 || status === 409,
         })
+
+        return {
+            magnetLinks: true,
+            labels: true,
+            setLocation: true,
+            torrentDetails: true,
+            trackerFilter: true,
+            uploadOptions: {
+                saveLocation: true,
+                category: true,
+                startTorrent: true,
+                peerLimit: true,
+                sequentialDownload: true,
+                downloadSpeedLimit: true,
+                uploadSpeedLimit: true,
+            },
+        }
     }
 
     async getSnapshot(): Promise<any> {

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -3,7 +3,7 @@ import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
 import qs from 'qs'
 
-import type { BittorrentServerConfig } from '@shared/ipc-contract'
+import type { BittorrentServerConfig, TorrentClientFeatures } from '@shared/ipc-contract'
 import {
     createHttpsAgent,
     HTTP_LOGIN_TIMEOUT,
@@ -83,7 +83,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
         }
     }
 
-    async connect(server: BittorrentServerConfig): Promise<void> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
         this.server = server
 
         this.http = axios.create({
@@ -138,6 +138,14 @@ export class UtorrentRuntime implements BittorrentRuntime {
         }
 
         this.saveConnection(serverUrl(server), server.user, server.password)
+
+        return {
+            magnetLinks: true,
+            labels: true,
+            uploadOptions: {
+                saveLocation: true,
+            },
+        }
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -6,6 +6,7 @@ import type {
     BittorrentInvokeActionRequest,
     BittorrentServerConfig,
     BittorrentSetTorrentFileSelectionRequest,
+    TorrentClientFeatures,
     BittorrentTorrentDetailsData,
     BittorrentUploadTorrentRequest,
 } from "@shared/ipc-contract"
@@ -16,7 +17,7 @@ import type { BittorrentRuntime } from "./types"
 
 class BittorrentManager {
     private sessions = new Map<number, BittorrentRuntime>()
-    private pendingConnections = new Map<number, Promise<void>>()
+    private pendingConnections = new Map<number, Promise<TorrentClientFeatures>>()
 
     private async getSession(sender: WebContents) {
         const senderId = sender.id
@@ -52,7 +53,7 @@ class BittorrentManager {
         return sourceBasename === filename && sourceBasename.toLowerCase().endsWith(".torrent")
     }
 
-    async connect(sender: WebContents, server: BittorrentServerConfig): Promise<void> {
+    async connect(sender: WebContents, server: BittorrentServerConfig) {
         const senderId = sender.id
         const pendingConnect = (async () => {
             const existing = this.sessions.get(senderId)
@@ -64,13 +65,14 @@ class BittorrentManager {
             }
 
             const runtime = createRuntime(server.client)
-            await runtime.connect(server)
+            const features = await runtime.connect(server)
             this.sessions.set(senderId, runtime)
+            return features
         })()
 
         this.pendingConnections.set(senderId, pendingConnect)
         try {
-            await pendingConnect
+            return await pendingConnect
         } finally {
             if (this.pendingConnections.get(senderId) === pendingConnect) {
                 this.pendingConnections.delete(senderId)

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -1,13 +1,14 @@
 import type {
     BittorrentFileSelection,
     BittorrentServerConfig,
+    TorrentClientFeatures,
     BittorrentTorrentDetailsData,
 } from "@shared/ipc-contract"
 
 export type CallbackFunc<T = any> = (err: any, val: T) => void
 
 export interface BittorrentRuntime {
-    connect(server: BittorrentServerConfig): Promise<void>
+    connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures>
     getSnapshot(fullUpdate?: boolean): Promise<any>
     addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void>
     uploadTorrent(buffer: Uint8Array, filename: string, options?: Record<string, any>): Promise<void>

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -136,9 +136,10 @@ export function registerHandlers({ isDebug, getWindow, consumePendingLaunchPaylo
     })
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }) {
-        await bittorrentManager.connect(event.sender, server)
+        const features = await bittorrentManager.connect(event.sender, server)
         menu.setActiveServer(server)
         await onBittorrentConnected?.()
+        return features
     })
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.disconnect, async function(event: IpcMainInvokeEvent) {

--- a/src/renderer/app/bittorrent/deluge/delugeservice.ts
+++ b/src/renderer/app/bittorrent/deluge/delugeservice.ts
@@ -1,39 +1,16 @@
-import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentUpdates, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@renderer/app/bittorrent/torrentclient";
+import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { DelugeTorrent } from "./torrentd";
-import { addTorrentUrl, connect, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
+import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
 
 export class DelugeClient extends TorrentClient<DelugeTorrent> {
     public name = 'Deluge'
     public id = 'deluge'
-    public supportsTorrentDetails = true
-    public supportsLabels = false
-    public uploadOptionsEnable: TorrentUploadOptionsEnable = {
-        saveLocation: true,
-        category: true,
-        startTorrent: true,
-        peerLimit: true,
-        firstAndLastPiecePrio: true,
-        downloadSpeedLimit: true,
-        uploadSpeedLimit: true,
-    }
-
-    connect(server): Promise<void> {
-        return connect(server)
-    }
-
     async torrents(): Promise<TorrentUpdates> {
         const data: Record<string, any> = await getSnapshot()
-        const supportsLabels = data.supportsLabels === true
-        if (this.supportsLabels !== supportsLabels) {
-            this.supportsLabels = supportsLabels
-            this.updateLabelActions()
-        }
-        this.uploadOptionsEnable.category = this.supportsLabels
 
         return {
             labels: Array.isArray(data.labels) ? data.labels : [],
-            supportsLabels: this.supportsLabels,
             all: Object.keys(data.torrents || {}).map((hash) => new DelugeTorrent(hash, data.torrents[hash])),
             changed: [],
             deleted: [],
@@ -93,19 +70,6 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
         return invokeAction("setLabel", torrents.map((torrent) => torrent.hash), label, create)
     }
 
-    private updateLabelActions() {
-        const labelAction = {
-            label: "Labels",
-            click: this.setLabel,
-            type: "labels" as const,
-        }
-
-        this.actionHeader = [
-            ...this.baseActionHeader,
-            ...(this.supportsLabels ? [labelAction] : []),
-        ]
-    }
-
     deleteTorrents(torrents: DelugeTorrent[]): Promise<void> {
         return this.remove(torrents)
     }
@@ -163,8 +127,6 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
         ])
     }
 
-    enableTrackerFilter = false
-
     extraColumns = []
 
     private baseActionHeader: TorrentActionList<DelugeTorrent> = [
@@ -186,7 +148,16 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
         },
     ]
 
-    actionHeader: TorrentActionList<DelugeTorrent> = this.baseActionHeader
+    get actionHeader(): TorrentActionList<DelugeTorrent> {
+        return [
+            ...this.baseActionHeader,
+            ...(this.features.labels ? [{
+                label: "Labels",
+                click: this.setLabel,
+                type: "labels" as const,
+            }] : []),
+        ]
+    }
 
     contextMenu: ContextActionList<DelugeTorrent> = [
         {

--- a/src/renderer/app/bittorrent/deluge/delugeservice.ts
+++ b/src/renderer/app/bittorrent/deluge/delugeservice.ts
@@ -146,17 +146,17 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
             icon: 'pause',
             role: 'stop'
         },
+        {
+            label: "Labels",
+            click: this.setLabel,
+            type: "labels",
+        },
     ]
 
     get actionHeader(): TorrentActionList<DelugeTorrent> {
-        return [
-            ...this.baseActionHeader,
-            ...(this.features.labels ? [{
-                label: "Labels",
-                click: this.setLabel,
-                type: "labels" as const,
-            }] : []),
-        ]
+        return this.features.labels
+            ? this.baseActionHeader
+            : this.baseActionHeader.filter((action) => action.type !== "labels")
     }
 
     contextMenu: ContextActionList<DelugeTorrent> = [

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -1,9 +1,13 @@
 import type {
     BittorrentTorrentDetailsData,
+    ElectorrentBridge,
     BittorrentFileSelection,
     BittorrentServerConfig,
+    TorrentClientFeatures,
+    TorrentUploadOptions,
 } from "@shared/ipc-contract"
-import type { TorrentUploadOptions } from "./torrentclient"
+
+declare const window: Window & { electorrent: ElectorrentBridge }
 
 function bridge() {
     return window.electorrent.bittorrent
@@ -21,7 +25,7 @@ export function serializeServer(server: any): BittorrentServerConfig {
     }
 }
 
-export function connect(server: any) {
+export function connect(server: any): Promise<TorrentClientFeatures> {
     return bridge().connect(serializeServer(server))
 }
 

--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -5,12 +5,11 @@ import {
   TorrentUpdates,
   ContextActionList,
   TorrentUploadOptions,
-  TorrentUploadOptionsEnable,
   TorrentDetailsInfoSection,
 } from "@renderer/app/bittorrent/torrentclient";
 import { TorrentFile } from "@renderer/app/bittorrent/abstracttorrent";
 import { QBittorrentTorrent } from "./torrentq";
-import { addTorrentUrl, connect, getSnapshot, getTorrentDetails, getTorrentFiles, invokeAction, setTorrentFileSelection, uploadTorrent } from "@renderer/app/bittorrent/ipc";
+import { addTorrentUrl, getSnapshot, getTorrentDetails, getTorrentFiles, invokeAction, setTorrentFileSelection, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
 
 export interface QBittorrentUploadOptions {
@@ -35,14 +34,6 @@ const QBITTORRENT_PRIORITY_SKIP = 0;
 export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
     public name = "qBittorrent"
     public id = "qbittorrent"
-
-    public supportsFileSelection = true
-    public supportsSetLocation = true
-    public supportsTorrentDetails = true
-
-    connect(server): Promise<void> {
-      return connect(server)
-    };
 
     torrents(fullupdate?: boolean): Promise<TorrentUpdates> {
       return getSnapshot(fullupdate).then((data: Record<string, any>) => this.processData(data));
@@ -90,20 +81,6 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
     addTorrentUrl(magnet: string, options?: TorrentUploadOptions): Promise<void> {
       return addTorrentUrl(magnet, options);
     };
-
-    public uploadOptionsEnable: TorrentUploadOptionsEnable = {
-      saveLocation: true,
-      renameTorrent: true,
-      category: true,
-      startTorrent: true,
-      skipCheck: true,
-      sequentialDownload: true,
-      firstAndLastPiecePrio: true,
-      downloadSpeedLimit: true,
-      uploadSpeedLimit: true,
-    }
-
-    enableTrackerFilter = false;
 
     extraColumns = [];
 
@@ -246,7 +223,7 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
       ]);
     }
 
-    actionHeader: TorrentActionList<QBittorrentTorrent> = [
+    private baseActionHeader: TorrentActionList<QBittorrentTorrent> = [
       {
         label: "Start",
         type: "button",
@@ -285,6 +262,12 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
         type: "labels",
       },
     ];
+
+    get actionHeader(): TorrentActionList<QBittorrentTorrent> {
+      return this.features.labels
+        ? this.baseActionHeader
+        : this.baseActionHeader.filter((action) => action.type !== "labels")
+    }
 
     contextMenu: ContextActionList<QBittorrentTorrent> = [
       {

--- a/src/renderer/app/bittorrent/rtorrent/rtorrentservice.ts
+++ b/src/renderer/app/bittorrent/rtorrent/rtorrentservice.ts
@@ -1,22 +1,12 @@
 import { Column } from "@renderer/app/services/column";
 import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { RtorrentTorrent } from "./torrentr";
-import { addTorrentUrl, connect, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
+import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
 
 export class RtorrentClient extends TorrentClient<RtorrentTorrent> {
     public name = "rTorrent"
     public id = "rtorrent"
-    public supportsTorrentDetails = true
-    public uploadOptionsEnable = {
-      saveLocation: true,
-      startTorrent: true,
-    }
-
-    connect(server): Promise<void> {
-        return connect(server)
-    };
-
     defaultPath(): string {
       return "/RPC2";
     };
@@ -128,8 +118,6 @@ export class RtorrentClient extends TorrentClient<RtorrentTorrent> {
       ])
     }
 
-    enableTrackerFilter = true;
-
     extraColumns = [
       new Column({
         name: "Tracker",
@@ -139,7 +127,7 @@ export class RtorrentClient extends TorrentClient<RtorrentTorrent> {
       }),
     ];
 
-    actionHeader: TorrentActionList<RtorrentTorrent> = [
+    private baseActionHeader: TorrentActionList<RtorrentTorrent> = [
       {
         label: "Start",
         type: "button",
@@ -162,6 +150,12 @@ export class RtorrentClient extends TorrentClient<RtorrentTorrent> {
         type: "labels",
       },
     ];
+
+    get actionHeader(): TorrentActionList<RtorrentTorrent> {
+      return this.features.labels
+        ? this.baseActionHeader
+        : this.baseActionHeader.filter((action) => action.type !== "labels")
+    }
 
     contextMenu: ContextActionList<RtorrentTorrent> = [
       {

--- a/src/renderer/app/bittorrent/synology/synologyservice.ts
+++ b/src/renderer/app/bittorrent/synology/synologyservice.ts
@@ -1,19 +1,10 @@
 import { ContextActionList, TorrentActionList, TorrentClient, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { SynologyTorrent } from "./synologytorrent";
-import { addTorrentUrl, connect, getSnapshot, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
+import { addTorrentUrl, getSnapshot, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 
 export class SynologyClient extends TorrentClient<SynologyTorrent> {
     public name = 'Synology Download Station'
     public id = 'downloadstation'
-    public supportsSetLocation = true
-    public uploadOptionsEnable = {
-        saveLocation: true,
-    }
-
-    connect(server): Promise<void> {
-        return connect(server)
-    }
-
     torrents(): Promise<TorrentUpdates> {
         return getSnapshot().then((data) => this.processData(data))
     }
@@ -63,8 +54,6 @@ export class SynologyClient extends TorrentClient<SynologyTorrent> {
     deleteTorrents(torrents: SynologyTorrent[]): Promise<void> {
         return this.remove(torrents)
     }
-
-    enableTrackerFilter = false
 
     extraColumns = []
 

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -2,16 +2,18 @@ import { Torrent, TorrentFile } from "./abstracttorrent"
 import type {
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
+    ResolvedTorrentClientFeatures,
+    TorrentClientFeatures,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
+import { connect } from "./ipc"
 
-export type { TorrentUploadOptions } from "@shared/ipc-contract"
+export type { TorrentUploadOptions, TorrentUploadOptionsEnable } from "@shared/ipc-contract"
 
 export type TorrentActionRole = "resume" | "stop" | "delete"
 
 export interface TorrentUpdates {
     labels?: string[],
-    supportsLabels?: boolean,
     all?: any[],
     changed?: any[],
     deleted?: any[],
@@ -29,7 +31,39 @@ export interface TorrentUpdates {
  * must be supported by the API. Any features that are enabled will have the corrosponding UI
  * components rendered when uploading a torrent
  */
-export type TorrentUploadOptionsEnable = Partial<Record<keyof TorrentUploadOptions, boolean>>
+const DEFAULT_UPLOAD_OPTIONS: ResolvedTorrentClientFeatures["uploadOptions"] = Object.freeze({
+    saveLocation: false,
+    renameTorrent: false,
+    category: false,
+    startTorrent: false,
+    peerLimit: false,
+    skipCheck: false,
+    sequentialDownload: false,
+    firstAndLastPiecePrio: false,
+    downloadSpeedLimit: false,
+    uploadSpeedLimit: false,
+})
+
+const DEFAULT_FEATURES: ResolvedTorrentClientFeatures = Object.freeze({
+    magnetLinks: false,
+    labels: false,
+    fileSelection: false,
+    setLocation: false,
+    torrentDetails: false,
+    trackerFilter: false,
+    uploadOptions: DEFAULT_UPLOAD_OPTIONS,
+})
+
+function resolveFeatures(features: TorrentClientFeatures = {}): ResolvedTorrentClientFeatures {
+    return Object.freeze({
+        ...DEFAULT_FEATURES,
+        ...features,
+        uploadOptions: Object.freeze({
+            ...DEFAULT_UPLOAD_OPTIONS,
+            ...features.uploadOptions,
+        }),
+    })
+}
 
 export interface TorrentActionButton<T extends Torrent> {
     label: string,
@@ -133,6 +167,11 @@ export interface TorrentDetailsPanelData {
 }
 
 export abstract class TorrentClient<T extends Torrent = Torrent> {
+    private resolvedFeatures = DEFAULT_FEATURES
+
+    public get features(): ResolvedTorrentClientFeatures {
+        return this.resolvedFeatures
+    }
 
     /**
      * The semantic name of the torrent service as presented in the UI
@@ -153,7 +192,10 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
      * @param {server} server
      * @return {promise} connection
      */
-    abstract connect(any): Promise<void>
+    async connect(server: any): Promise<void> {
+        this.resolvedFeatures = DEFAULT_FEATURES
+        this.resolvedFeatures = resolveFeatures(await connect(server))
+    }
 
     /**
      * Return any new information about torrents to be rendered in the GUI. Should return a
@@ -208,47 +250,17 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
 
 
     /**
-     * Whether the client supports sorting by trackers or not
-     */
-    public enableTrackerFilter: boolean
-
-    /**
-     * When true, the client supports listing torrent files and setting which files to download
-     * (selective download). When false, the "Files" context menu item and file selection UI are hidden.
-     * Concrete clients that set this flag to true are expected to override
-     * {@link getTorrentFiles} and {@link setTorrentFileSelection}.
-     */
-    public supportsFileSelection: boolean = false
-
-    /**
-     * When true, the client supports changing a torrent's download location after it has been added.
-     * Concrete clients that set this flag to true are expected to override {@link setLocation}.
-     */
-    public supportsSetLocation: boolean = false
-
-    /**
-     * When true, the client supports a torrent details panel with dynamic info
-     * and file details content.
-     */
-    public supportsTorrentDetails: boolean = false
-
-    /**
-     * When true, the client supports listing and assigning torrent labels.
-     */
-    public supportsLabels: boolean = true
-
-    /**
      * Get the list of files for a torrent.
      *
      * Default implementation always throws:
-     * - when {@link supportsFileSelection} is false: Error("File selection not supported for this client")
-     * - when {@link supportsFileSelection} is true but the client did not override this method:
+     * - when {@link features.fileSelection} is false: Error("File selection not supported for this client")
+     * - when {@link features.fileSelection} is true but the client did not override this method:
      *   Error("File selection not implemented for this client")
      *
      * Concrete clients that support file selection must override this method.
      */
     async getTorrentFiles(torrent: T): Promise<TorrentFile[]> {
-        if (!this.supportsFileSelection) {
+        if (!this.features.fileSelection) {
             throw new Error("File selection not supported for this client")
         }
         return Promise.reject(new Error("File selection not implemented for this client"))
@@ -258,14 +270,14 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
      * Apply wanted/unwanted selection for torrent files.
      *
      * Default implementation always throws:
-     * - when {@link supportsFileSelection} is false: Error("File selection not supported for this client")
-     * - when {@link supportsFileSelection} is true but the client did not override this method:
+     * - when {@link features.fileSelection} is false: Error("File selection not supported for this client")
+     * - when {@link features.fileSelection} is true but the client did not override this method:
      *   Error("File selection not implemented for this client")
      *
      * Concrete clients that support file selection must override this method.
      */
     async setTorrentFileSelection(torrent: T, files: TorrentFile[]): Promise<void> {
-        if (!this.supportsFileSelection) {
+        if (!this.features.fileSelection) {
             throw new Error("File selection not supported for this client")
         }
         return Promise.reject(new Error("File selection not implemented for this client"))
@@ -275,19 +287,19 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
      * Change the save location of one or more torrents.
      *
      * Default implementation always throws:
-     * - when {@link supportsSetLocation} is false: Error("Set location not supported for this client")
-     * - when {@link supportsSetLocation} is true but the client did not override this method:
+     * - when {@link features.setLocation} is false: Error("Set location not supported for this client")
+     * - when {@link features.setLocation} is true but the client did not override this method:
      *   Error("Set location not implemented for this client")
      */
     async setLocation(_torrents: T[], _location: string): Promise<void> {
-        if (!this.supportsSetLocation) {
+        if (!this.features.setLocation) {
             throw new Error("Set location not supported for this client")
         }
         return Promise.reject(new Error("Set location not implemented for this client"))
     }
 
     async getTorrentDetails(torrent: T): Promise<TorrentDetailsPanelData> {
-        if (!this.supportsTorrentDetails) {
+        if (!this.features.torrentDetails) {
             throw new Error("Torrent details not supported for this client")
         }
 
@@ -305,7 +317,7 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
     }
 
     protected async getTorrentDetailsData(_torrent: T): Promise<BittorrentTorrentDetailsData> {
-        if (!this.supportsTorrentDetails) {
+        if (!this.features.torrentDetails) {
             throw new Error("Torrent details not supported for this client")
         }
 
@@ -405,8 +417,6 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
      * or links). The set of supported options will effect how UI is rendered. If "undefined", then
      * the client API does not support any upload options.
      */
-    public uploadOptionsEnable: TorrentUploadOptionsEnable
-
     /**
      * Provides the option to include extra columns for displaying data. This may concern columns
      * which are specific to this client. The extra columns will be merged with the default columns.

--- a/src/renderer/app/bittorrent/transmission/transmissionservice.ts
+++ b/src/renderer/app/bittorrent/transmission/transmissionservice.ts
@@ -1,7 +1,7 @@
-import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentUpdates, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@renderer/app/bittorrent/torrentclient";
+import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { TransmissionTorrent } from "./torrentt";
 import _ from "underscore"
-import { addTorrentUrl, connect, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
+import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
 
 const URL_REGEX = /^[a-z]+:\/\/(?:[a-z0-9-]+\.)*((?:[a-z0-9-]+\.)[a-z]+)/;
@@ -9,23 +9,6 @@ const URL_REGEX = /^[a-z]+:\/\/(?:[a-z0-9-]+\.)*((?:[a-z0-9-]+\.)[a-z]+)/;
 export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
     public name = "Transmission";
     public id = "transmission"
-    public supportsSetLocation = true
-    public supportsTorrentDetails = true
-
-    public uploadOptionsEnable: TorrentUploadOptionsEnable = {
-      saveLocation: true,
-      category: true,
-      startTorrent: true,
-      peerLimit: true,
-      sequentialDownload: true,
-      downloadSpeedLimit: true,
-      uploadSpeedLimit: true,
-    }
-
-    connect(server): Promise<void> {
-      return connect(server)
-    };
-
     defaultPath(): string {
       return "/transmission/rpc";
     };
@@ -176,9 +159,7 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
       ]);
     }
 
-    enableTrackerFilter = true;
-
-    actionHeader: TorrentActionList<TransmissionTorrent> = [
+    private baseActionHeader: TorrentActionList<TransmissionTorrent> = [
       {
         label: "Start",
         type: "button",
@@ -217,6 +198,12 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
         type: "labels",
       },
     ];
+
+    get actionHeader(): TorrentActionList<TransmissionTorrent> {
+      return this.features.labels
+        ? this.baseActionHeader
+        : this.baseActionHeader.filter((action) => action.type !== "labels")
+    }
 
     contextMenu: ContextActionList<TransmissionTorrent> = [
       {

--- a/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
+++ b/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
@@ -1,24 +1,16 @@
 import { ContextActionList, TorrentActionList, TorrentClient, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { UtorrentTorrent } from "./torrentu";
-import { addTorrentUrl, connect, getSnapshot, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
+import { addTorrentUrl, getSnapshot, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 
 export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
   public name = "µTorrent"
   public id = "utorrent"
-  public uploadOptionsEnable = {
-    saveLocation: true,
-  }
-
   build(array: Array<any>): UtorrentTorrent {
     return UtorrentTorrent.fromArray(array)
   }
 
   defaultPath(): string {
     return "/gui";
-  };
-
-  connect(server): Promise<void> {
-    return connect(server)
   };
 
   addTorrentUrl(url: string, options?: TorrentUploadOptions) {
@@ -100,7 +92,7 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
     return invokeAction("setLabel", torrents.map((torrent) => torrent.hash), label);
   };
 
-  actionHeader: TorrentActionList<UtorrentTorrent> = [
+  private baseActionHeader: TorrentActionList<UtorrentTorrent> = [
     {
       label: "Start",
       type: "button",
@@ -130,6 +122,12 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
       type: "labels",
     },
   ];
+
+  get actionHeader(): TorrentActionList<UtorrentTorrent> {
+    return this.features.labels
+      ? this.baseActionHeader
+      : this.baseActionHeader.filter((action) => action.type !== "labels")
+  }
 
   contextMenu: ContextActionList<UtorrentTorrent> = [
     {

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
@@ -65,7 +65,7 @@ export class AddTorrentModalController {
     }
 
     supportsSavedLocations() {
-        return !!this.rootScope.$btclient?.uploadOptionsEnable?.saveLocation
+        return !!this.rootScope.$btclient?.features.uploadOptions.saveLocation
     }
 
     getCurrentTorrentUpload() {

--- a/src/renderer/app/directives/context-menu/context-menu.directive.ts
+++ b/src/renderer/app/directives/context-menu/context-menu.directive.ts
@@ -158,14 +158,14 @@ export class ContextMenuDirective implements IDirective {
 
                 if (
                     item.id === "torrent-details"
-                    && (!this.$rootScope.$btclient || !this.$rootScope.$btclient.supportsTorrentDetails)
+                    && (!this.$rootScope.$btclient || !this.$rootScope.$btclient.features.torrentDetails)
                 ) {
                     return;
                 }
 
                 if (
                     item.id === "torrent-files"
-                    && (!this.$rootScope.$btclient || !this.$rootScope.$btclient.supportsFileSelection)
+                    && (!this.$rootScope.$btclient || !this.$rootScope.$btclient.features.fileSelection)
                 ) {
                     return;
                 }

--- a/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.controller.ts
+++ b/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.controller.ts
@@ -63,7 +63,7 @@ export class TorrentFilesModalController {
 
   loadFiles(): Promise<TorrentFile[] | void> {
     const torrent = this.scope.torrent;
-    if (!torrent || !this.rootScope.$btclient || !this.rootScope.$btclient.supportsFileSelection) {
+    if (!torrent || !this.rootScope.$btclient || !this.rootScope.$btclient.features.fileSelection) {
       return Promise.resolve();
     }
     this.scope.loading = true;

--- a/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.controller.ts
+++ b/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.controller.ts
@@ -53,7 +53,7 @@ export class TorrentUploadFormController {
     }
 
     refreshFormState() {
-        this.optionsEnabled = this.rootScope?.$btclient?.uploadOptionsEnable || {}
+        this.optionsEnabled = this.rootScope?.$btclient?.features.uploadOptions || {}
         this.refreshSavedLocations()
     }
 

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -143,9 +143,10 @@ export class TorrentsPageController {
         };
 
         const supportsMagnetUploadOptions = () => {
-            const uploadOptionsEnable = $rootScope.$btclient?.uploadOptionsEnable;
-            return uploadOptionsEnable !== null && uploadOptionsEnable !== undefined;
+            return Object.values($rootScope.$btclient?.features.uploadOptions || {}).some(Boolean);
         };
+
+        $scope.supportsUploadOptions = supportsMagnetUploadOptions;
 
         const shouldPromptForUploadOptions = (item: PendingTorrentUploadItem, askUploadOptions: boolean) => {
             const wantsPrompt = settings.alwaysPromptUploadOptions === true || askUploadOptions === true;

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -53,7 +53,7 @@
                 <div class="ui torrent sort label">{{numInFilter('error')}}</div>
             </li>
             </ul>
-            <div id="torrent-sidebar-labels" ng-if="$btclient.supportsLabels && !isSidebarCollapsed()">
+            <div id="torrent-sidebar-labels" ng-if="$btclient.features.labels && !isSidebarCollapsed()">
                 <div class="section">
                     <span>Labels</span>
                     <a data-role="labels-clear" class="ui gray basic mini clear button" ng-click="filterByLabel()">Clear</a>
@@ -67,7 +67,7 @@
                     </li>
                 </ul>
             </div>
-            <div id="torrent-sidebar-trackers" ng-if="$btclient.enableTrackerFilter && !isSidebarCollapsed()">
+            <div id="torrent-sidebar-trackers" ng-if="$btclient.features.trackerFilter && !isSidebarCollapsed()">
                 <div class="section">
                     <span>Trackers</span>
                     <a data-role="trackers-clear" class="ui gray basic mini clear button" ng-click="filterByTracker()">Clear</a>
@@ -87,7 +87,7 @@
             </div>
         </div>
         <div class="sidebar-collapsed-sections" ng-if="isSidebarCollapsed()">
-            <div class="sidebar-collapsed-section" ng-if="$btclient.supportsLabels">
+            <div class="sidebar-collapsed-section" ng-if="$btclient.features.labels">
             <div class="torrent-sidebar-section-trigger" data-role="torrent-sidebar-labels-toggle" title="Labels">
                 <i class="tags icon"></i>
             </div>
@@ -106,7 +106,7 @@
                     </ul>
                 </div>
             </div>
-            <div class="sidebar-collapsed-section" ng-if="$btclient.enableTrackerFilter">
+            <div class="sidebar-collapsed-section" ng-if="$btclient.features.trackerFilter">
                 <div class="torrent-sidebar-section-trigger" data-role="torrent-sidebar-trackers-toggle" title="Trackers">
                     <i class="sitemap icon"></i>
                 </div>
@@ -177,7 +177,7 @@
                     <h2 class="ui center aligned icon header">
                         <i class="add circle icon"></i>
                         Upload Torrent Files
-                        <div class="sub header" ng-if="!settings.alwaysPromptUploadOptions && $btclient.uploadOptionsEnable">
+                        <div class="sub header" ng-if="!settings.alwaysPromptUploadOptions && supportsUploadOptions()">
                             Hold down <div class="ui label">{{ uploadAdvancedOptionsKey }}</div> key for advanced options
                         </div>
                     </h2>

--- a/src/shared/client-metadata.ts
+++ b/src/shared/client-metadata.ts
@@ -4,7 +4,7 @@ export interface ClientMetadata {
     showAdvancedUploadMenu: boolean
 }
 
-export const CLIENT_METADATA: Record<string, ClientMetadata> = {
+export const CLIENT_METADATA = {
     utorrent: {
         name: 'µTorrent',
         icon: 'utorrent',
@@ -40,4 +40,6 @@ export const CLIENT_METADATA: Record<string, ClientMetadata> = {
         icon: 'deluge',
         showAdvancedUploadMenu: true,
     },
-}
+} as const satisfies Record<string, ClientMetadata>
+
+export type ClientId = keyof typeof CLIENT_METADATA

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -175,6 +175,28 @@ export interface TorrentUploadOptions {
     uploadSpeedLimit?: number
 }
 
+export type TorrentUploadOptionsEnable = Partial<Record<keyof TorrentUploadOptions, boolean>>
+
+export interface TorrentClientFeatures {
+    readonly magnetLinks?: boolean
+    readonly labels?: boolean
+    readonly fileSelection?: boolean
+    readonly setLocation?: boolean
+    readonly torrentDetails?: boolean
+    readonly trackerFilter?: boolean
+    readonly uploadOptions?: Readonly<TorrentUploadOptionsEnable>
+}
+
+export interface ResolvedTorrentClientFeatures {
+    readonly magnetLinks: boolean
+    readonly labels: boolean
+    readonly fileSelection: boolean
+    readonly setLocation: boolean
+    readonly torrentDetails: boolean
+    readonly trackerFilter: boolean
+    readonly uploadOptions: Readonly<Required<Record<keyof TorrentUploadOptions, boolean>>>
+}
+
 export interface AppSettings<TServer = StoredServerConfig> {
     startup: string
     systemStartup: SystemStartupOption
@@ -290,7 +312,7 @@ export interface ElectorrentBridge {
         getPathForFile(file: unknown): string
     }
     bittorrent: {
-        connect(server: BittorrentServerConfig): Promise<void>
+        connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures>
         disconnect(): Promise<void>
         getSnapshot(request?: BittorrentSnapshotRequest): Promise<any>
         addTorrentUrl(request: BittorrentAddTorrentUrlRequest): Promise<void>

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -4,7 +4,7 @@ import magnet from "magnet-uri"
 import { Torrent } from "./e2e_torrent";
 import parseTorrent from "parse-torrent"
 import { browser, $, $$, expect } from '@wdio/globals'
-import { TorrentClient } from "../../src/renderer/app/bittorrent"
+import type { ClientId } from "../../src/shared/client-metadata"
 import { waitForModalClose, waitForModalOpen } from "./modal"
 
 /**
@@ -15,7 +15,7 @@ export interface LoginOptions {
   username: string
   password: string
   port: number
-  client: TorrentClient
+  clientId: ClientId
   https?: boolean
 }
 
@@ -60,7 +60,7 @@ export class App {
     await clientForm.waitForClickable()
     await clientForm.click();
 
-    const clientFormSelect = $(`#connection-client-${options.client.id}`)
+    const clientFormSelect = $(`#connection-client-${options.clientId}`)
     await clientFormSelect.waitForDisplayed()
     await clientFormSelect.waitForClickable()
     await clientFormSelect.click()

--- a/test/fixtures/deluge/deluge-1.spec.ts
+++ b/test/fixtures/deluge/deluge-1.spec.ts
@@ -1,16 +1,24 @@
 import { createTestSuite } from "../../testlib";
-import { FeatureSet } from "../../testutil";
-import { DelugeClient } from "../../../src/renderer/app/bittorrent"
 
 createTestSuite({
-  client: new DelugeClient(),
+  clientId: "deluge",
+  features: {
+    labels: true,
+    torrentDetails: true,
+    uploadOptions: {
+      saveLocation: true,
+      category: true,
+      startTorrent: true,
+      peerLimit: true,
+      firstAndLastPiecePrio: true,
+      downloadSpeedLimit: true,
+      uploadSpeedLimit: true,
+    },
+  },
   fixture: "fixtures/deluge",
   version: "5b398f77-ls22",
   port: 8112,
   username: "admin",
   password: "deluge",
   stopLabel: "Paused",
-  unsupportedFeatures: [
-    FeatureSet.MagnetLinks,
-  ],
 });

--- a/test/fixtures/deluge/deluge-2.spec.ts
+++ b/test/fixtures/deluge/deluge-2.spec.ts
@@ -1,13 +1,25 @@
 import { createTestSuite } from "../../testlib";
-import { DelugeClient } from "../../../src/renderer/app/bittorrent"
 
 createTestSuite({
-  client: new DelugeClient(),
+  clientId: "deluge",
+  features: {
+    magnetLinks: true,
+    labels: true,
+    torrentDetails: true,
+    uploadOptions: {
+      saveLocation: true,
+      category: true,
+      startTorrent: true,
+      peerLimit: true,
+      firstAndLastPiecePrio: true,
+      downloadSpeedLimit: true,
+      uploadSpeedLimit: true,
+    },
+  },
   fixture: "fixtures/deluge",
   version: "2.2.0",
   port: 8112,
   username: "admin",
   password: "deluge",
   stopLabel: "Paused",
-  unsupportedFeatures: [],
 });

--- a/test/fixtures/mock/mock.spec.ts
+++ b/test/fixtures/mock/mock.spec.ts
@@ -1,7 +1,6 @@
 import chai from "chai"
 import { $, $$, browser } from "@wdio/globals"
 import { before, describe, it } from "mocha"
-import { MockBittorrentClient } from "../../../src/renderer/app/bittorrent"
 import { App } from "../../e2e"
 import { startApplicationHooks } from "../../shared"
 import { setupMochaHooks } from "../../testutil"
@@ -22,7 +21,7 @@ describe("given mocked bittorrent backend is running", function () {
     this.app = this.app || new App()
 
     await this.app.login({
-      client: new MockBittorrentClient(),
+      clientId: "mock",
       host: "mock",
       username: "mock",
       password: "mock",

--- a/test/fixtures/qbittorrent/qbittorrent-4.spec.ts
+++ b/test/fixtures/qbittorrent/qbittorrent-4.spec.ts
@@ -1,13 +1,28 @@
 import { createTestSuite } from "../../testlib";
 
-import { QBittorrentClient } from "../../../src/renderer/app/bittorrent"
-
 createTestSuite({
-  client: new QBittorrentClient(),
+  clientId: "qbittorrent",
+  features: {
+    magnetLinks: true,
+    labels: true,
+    fileSelection: true,
+    setLocation: true,
+    torrentDetails: true,
+    uploadOptions: {
+      saveLocation: true,
+      renameTorrent: true,
+      category: true,
+      startTorrent: true,
+      skipCheck: true,
+      sequentialDownload: true,
+      firstAndLastPiecePrio: true,
+      downloadSpeedLimit: true,
+      uploadSpeedLimit: true,
+    },
+  },
   fixture: "fixtures/qbittorrent",
   version: "4.6.7",
   port: 8080,
   username: "admin",
   password: "adminadmin",
-  unsupportedFeatures: [],
 });

--- a/test/fixtures/qbittorrent/qbittorrent-5.spec.ts
+++ b/test/fixtures/qbittorrent/qbittorrent-5.spec.ts
@@ -1,13 +1,28 @@
 import { createTestSuite } from "../../testlib";
 
-import { QBittorrentClient } from "../../../src/renderer/app/bittorrent"
-
 createTestSuite({
-  client: new QBittorrentClient(),
+  clientId: "qbittorrent",
+  features: {
+    magnetLinks: true,
+    labels: true,
+    fileSelection: true,
+    setLocation: true,
+    torrentDetails: true,
+    uploadOptions: {
+      saveLocation: true,
+      renameTorrent: true,
+      category: true,
+      startTorrent: true,
+      skipCheck: true,
+      sequentialDownload: true,
+      firstAndLastPiecePrio: true,
+      downloadSpeedLimit: true,
+      uploadSpeedLimit: true,
+    },
+  },
   fixture: "fixtures/qbittorrent",
   version: "5.1.0",
   port: 8080,
   username: "admin",
   password: "adminadmin",
-  unsupportedFeatures: [],
 });

--- a/test/fixtures/qbittorrent/qbittorrent-latest.spec.ts
+++ b/test/fixtures/qbittorrent/qbittorrent-latest.spec.ts
@@ -1,13 +1,28 @@
 import { createTestSuite } from "../../testlib";
 
-import { QBittorrentClient } from "../../../src/renderer/app/bittorrent"
-
 createTestSuite({
-  client: new QBittorrentClient(),
+  clientId: "qbittorrent",
+  features: {
+    magnetLinks: true,
+    labels: true,
+    fileSelection: true,
+    setLocation: true,
+    torrentDetails: true,
+    uploadOptions: {
+      saveLocation: true,
+      renameTorrent: true,
+      category: true,
+      startTorrent: true,
+      skipCheck: true,
+      sequentialDownload: true,
+      firstAndLastPiecePrio: true,
+      downloadSpeedLimit: true,
+      uploadSpeedLimit: true,
+    },
+  },
   fixture: "fixtures/qbittorrent",
   version: "latest",
   port: 8080,
   username: "admin",
   password: "adminadmin",
-  unsupportedFeatures: [],
 });

--- a/test/fixtures/rtorrent/rtorrent.spec.ts
+++ b/test/fixtures/rtorrent/rtorrent.spec.ts
@@ -1,8 +1,17 @@
 import { createTestSuite } from "../../testlib";
-import { RtorrentClient } from "../../../src/renderer/app/bittorrent"
 
 createTestSuite({
-  client: new RtorrentClient(),
+  clientId: "rtorrent",
+  features: {
+    magnetLinks: true,
+    labels: true,
+    torrentDetails: true,
+    trackerFilter: true,
+    uploadOptions: {
+      saveLocation: true,
+      startTorrent: true,
+    },
+  },
   fixture: "fixtures/rtorrent",
   port: 8080,
   proxyPort: 80,
@@ -10,5 +19,4 @@ createTestSuite({
   username: "admin",
   password: "admin",
   saveLocation: "/downloads/custom/save/location",
-  unsupportedFeatures: [],
 });

--- a/test/fixtures/transmission/transmission.spec.ts
+++ b/test/fixtures/transmission/transmission.spec.ts
@@ -1,12 +1,26 @@
 import { createTestSuite } from "../../testlib";
-import { TransmissionClient } from "../../../src/renderer/app/bittorrent"
 
 createTestSuite({
-  client: new TransmissionClient(),
+  clientId: "transmission",
+  features: {
+    magnetLinks: true,
+    labels: true,
+    setLocation: true,
+    torrentDetails: true,
+    trackerFilter: true,
+    uploadOptions: {
+      saveLocation: true,
+      category: true,
+      startTorrent: true,
+      peerLimit: true,
+      sequentialDownload: true,
+      downloadSpeedLimit: true,
+      uploadSpeedLimit: true,
+    },
+  },
   fixture: "fixtures/transmission",
   port: 9091,
   username: "username",
   password: "password",
   acceptHttpStatus: 401,
-  unsupportedFeatures: [],
 });

--- a/test/fixtures/utorrent/utorrent.spec.ts
+++ b/test/fixtures/utorrent/utorrent.spec.ts
@@ -1,13 +1,18 @@
 import { createTestSuite } from "../../testlib";
-import { UtorrentClient } from "../../../src/renderer/app/bittorrent"
 
 createTestSuite({
-  client: new UtorrentClient(),
+  clientId: "utorrent",
+  features: {
+    magnetLinks: true,
+    labels: true,
+    uploadOptions: {
+      saveLocation: true,
+    },
+  },
   fixture: "fixtures/utorrent",
   port: 8080,
   username: "admin",
   password: "",
   acceptHttpStatus: 400,
   saveLocation: "/utorrent/custom/save/location",
-  unsupportedFeatures: [],
 });

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -6,19 +6,21 @@ import { fileURLToPath } from "url";
 import chaiAsPromised from "chai-as-promised";
 import parseTorrent from "parse-torrent"
 import * as e2e from "./e2e";
-import { FeatureSet, setupMochaHooks, waitForHttp } from "./testutil"
+import { setupMochaHooks, waitForHttp } from "./testutil"
 import { dockerComposeHooks, startApplicationHooks, restartApplication } from "./shared"
-import { TorrentClient } from "../src/renderer/app/bittorrent"
 import { browser, $ } from '@wdio/globals'
 import { createTorrentFile } from "./torrent";
 import { waitForModalClose, waitForModalOpen } from "./e2e/modal"
+import type { ClientId } from "../src/shared/client-metadata"
+import type { TorrentClientFeatures } from "../src/shared/ipc-contract"
 
 const { assert } = chai
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 
 interface TestSuiteOptionsOptional {
-  client: TorrentClient
+  clientId: ClientId
+  features: TorrentClientFeatures
   fixture: string,
   version?: string,
   username: string,
@@ -31,7 +33,6 @@ interface TestSuiteOptionsOptional {
   stopLabel?: string,
   downloadLabel?: string,
   saveLocation?: string,
-  unsupportedFeatures: FeatureSet[]
 }
 
 const TEST_SUITE_OPTIONS_DEFAULTS = {
@@ -75,11 +76,24 @@ export type TestSuiteOptions = TestSuiteOptionsOptional & (typeof TEST_SUITE_OPT
  * @param options test suite options
  * @param feature the feature that is required to continue
  */
-function requireFeatureHook(options: TestSuiteOptions, feature: FeatureSet) {
+function requireFeatureHook(options: TestSuiteOptions, isSupported: (features: TorrentClientFeatures) => boolean) {
   before(function() {
-    if (options.unsupportedFeatures.includes(feature)) {
+    if (!isSupported(options.features)) {
       this.skip()
     }
+  })
+}
+
+function enabledFeaturePaths(features: Record<string, unknown>, prefix = ""): string[] {
+  return Object.entries(features).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (value === true) {
+      return [path]
+    }
+    if (value && typeof value === "object") {
+      return enabledFeaturePaths(value as Record<string, unknown>, path)
+    }
+    return []
   })
 }
 
@@ -93,7 +107,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
     chai.use(chaiAsPromised);
   });
 
-  describe(`given ${options.client.id}-${options.version} service is running (docker-compose)`, function () {
+  describe(`given ${options.clientId}-${options.version} service is running (docker-compose)`, function () {
 
     // start up opentracker docker-compose services
     const tracker = dockerComposeHooks([__dirname, "shared", "opentracker"], {}, { serviceName: "peer" })
@@ -149,6 +163,17 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           await this.app.torrentsPageIsVisible()
         })
 
+        it("reports expected client features", async function() {
+          const actualFeatures = await browser.execute(() => {
+            const angular = (window as any).angular
+            return angular.element(document.documentElement).injector().get("$rootScope").$btclient.features
+          })
+          const missingFeatures = enabledFeaturePaths(options.features as Record<string, unknown>)
+            .filter((path) => path.split(".").reduce((value, key) => value?.[key], actualFeatures) !== true)
+
+          assert.deepEqual(missingFeatures, [], `Missing enabled client features: ${missingFeatures.join(", ")}`)
+        })
+
         it("automatically connect when restarting app", async function() {
           await restartApplication(this)
           await this.app.torrentsPageIsVisible()
@@ -180,7 +205,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           await this.app.torrentsPageIsVisible()
         })
 
-        if (options.client.id === "qbittorrent") {
+        if (options.clientId === "qbittorrent") {
           it("shows qBittorrent free space in the footer", async function() {
             await browser.waitUntil(async () => {
               const footerText = await this.app.getTorrentsFooterText();
@@ -549,7 +574,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
         describe("when a magnet link is uploaded", async function() {
           let torrent: e2e.Torrent
-          requireFeatureHook(options, FeatureSet.MagnetLinks)
+          requireFeatureHook(options, (features) => features.magnetLinks === true)
 
           before(async function() {
             await restartApplication(this)
@@ -625,7 +650,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
           describe("given file selection is supported", function () {
             before(function () {
-              if (!(options.client as any).supportsFileSelection) {
+              if (options.features.fileSelection !== true) {
                 this.skip()
               }
             })
@@ -680,7 +705,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
           describe("given torrent details are supported", function () {
             before(function () {
-              if (!(options.client as any).supportsTorrentDetails) {
+              if (options.features.torrentDetails !== true) {
                 this.skip()
               }
             })
@@ -770,7 +795,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           })
 
           describe("given labels are supported", function () {
-            requireFeatureHook(options, FeatureSet.Labels)
+            requireFeatureHook(options, (features) => features.labels === true)
             const firstLabel = createUniqueLabel("testlabel")
             const secondLabel = createUniqueLabel("someotherlabel")
             let initialLabelCount = 0
@@ -805,7 +830,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
           describe("given set location is supported", function () {
             before(function () {
-              if (!(options.client as any).supportsSetLocation) {
+              if (options.features.setLocation !== true) {
                 this.skip()
               }
             })
@@ -850,7 +875,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
     })
 
     describe("given advanced upload options are supported", async function() {
-      requireFeatureHook(options, FeatureSet.AdvancedUploadOptions)
+      requireFeatureHook(options, (features) => Object.values(features.uploadOptions || {}).some((enabled) => enabled === true))
 
       describe("given application is running", function() {
         startApplicationHooks()
@@ -879,7 +904,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           })
 
           it("add torrent dialog uses current server default upload options", async function() {
-            if (!options.client.uploadOptionsEnable?.startTorrent) return this.skip()
+            if (options.features.uploadOptions?.startTorrent !== true) return this.skip()
 
             let torrent: e2e.Torrent | undefined
 
@@ -920,7 +945,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           })
 
           it("torent uploaded with preexisting label", async function() {
-            if (!options.client.uploadOptionsEnable?.category) return this.skip()
+            if (options.features.uploadOptions?.category !== true) return this.skip()
             const labelName = createUniqueLabel("mylabel")
             let torrent = await this.app.uploadTorrent({ filename: this.torrentPath });
             await torrent.newLabel(labelName)
@@ -935,7 +960,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
           it("torrent uploaded in stopped state", async function() {
             this.timeout(30 * 1000)
-            if (!options.client.uploadOptionsEnable?.startTorrent) return this.skip()
+            if (options.features.uploadOptions?.startTorrent !== true) return this.skip()
             const torrent = await this.app.uploadTorrent({ filename: this.torrentPath, askUploadOptions: true });
             await this.app.uploadTorrentModalSubmit({ start: false })
             await torrent.isExisting()
@@ -945,7 +970,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
           it("torrent uploaded with peer limit", async function() {
             this.timeout(30 * 1000)
-            if (!options.client.uploadOptionsEnable?.peerLimit) return this.skip()
+            if (options.features.uploadOptions?.peerLimit !== true) return this.skip()
             const peerLimit = 8
             const torrent = await this.app.uploadTorrent({ filename: this.torrentPath, askUploadOptions: true });
             await this.app.uploadTorrentModalSubmit({ peerLimit })
@@ -962,24 +987,24 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
           it("torrent uploaded with speed limits", async function() {
             this.timeout(30 * 1000)
-            if (!options.client.uploadOptionsEnable?.downloadSpeedLimit && !options.client.uploadOptionsEnable?.uploadSpeedLimit) return this.skip()
+            if (options.features.uploadOptions?.downloadSpeedLimit !== true && options.features.uploadOptions?.uploadSpeedLimit !== true) return this.skip()
             const downloadSpeedLimit = 111
             const uploadSpeedLimit = 37
             const torrent = await this.app.uploadTorrent({ filename: this.torrentPath, askUploadOptions: true });
             await this.app.uploadTorrentModalSubmit({
-              downloadSpeedLimit: options.client.uploadOptionsEnable?.downloadSpeedLimit ? downloadSpeedLimit : undefined,
-              uploadSpeedLimit: options.client.uploadOptionsEnable?.uploadSpeedLimit ? uploadSpeedLimit : undefined,
+              downloadSpeedLimit: options.features.uploadOptions?.downloadSpeedLimit === true ? downloadSpeedLimit : undefined,
+              uploadSpeedLimit: options.features.uploadOptions?.uploadSpeedLimit === true ? uploadSpeedLimit : undefined,
             })
             await torrent.waitForExist({ timeout: 20 * 1000 })
             await torrent.waitForStates([options.downloadLabel, "Seeding"], { timeout: 20 * 1000 })
             await torrent.openDetailsPanel()
-            if (options.client.uploadOptionsEnable?.downloadSpeedLimit) {
+            if (options.features.uploadOptions?.downloadSpeedLimit === true) {
               await browser.waitUntil(async () => (await torrent.getDetailsFieldValue("download-limit")) === String(downloadSpeedLimit), {
                 timeout: 10 * 1000,
                 timeoutMsg: `Expected download limit to become ${downloadSpeedLimit}`,
               })
             }
-            if (options.client.uploadOptionsEnable?.uploadSpeedLimit) {
+            if (options.features.uploadOptions?.uploadSpeedLimit === true) {
               await browser.waitUntil(async () => (await torrent.getDetailsFieldValue("upload-limit")) === String(uploadSpeedLimit), {
                 timeout: 10 * 1000,
                 timeoutMsg: `Expected upload limit to become ${uploadSpeedLimit}`,
@@ -991,7 +1016,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
           it("torrent uploaded with sequential download", async function() {
             this.timeout(30 * 1000)
-            if (!options.client.uploadOptionsEnable?.sequentialDownload) return this.skip()
+            if (options.features.uploadOptions?.sequentialDownload !== true) return this.skip()
             const torrent = await this.app.uploadTorrent({ filename: this.torrentPath, askUploadOptions: true });
             await this.app.uploadTorrentModalSubmit({ sequentialDownload: true })
             await torrent.waitForExist({ timeout: 20 * 1000 })
@@ -1006,7 +1031,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           })
 
           it("torrent uploaded with name", async function() {
-            if (!options.client.uploadOptionsEnable?.renameTorrent) return this.skip()
+            if (options.features.uploadOptions?.renameTorrent !== true) return this.skip()
             const torrentName = "my awesome torrent"
             const torrent = await this.app.uploadTorrent({ filename: this.torrentPath, askUploadOptions: true });
             await this.app.uploadTorrentModalSubmit({ name: torrentName })
@@ -1017,7 +1042,7 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
 
           it("saved location added from upload modal persists", async function() {
             this.timeout(300 * 1000)
-            if (!options.client.uploadOptionsEnable?.saveLocation) return this.skip()
+            if (options.features.uploadOptions?.saveLocation !== true) return this.skip()
 
             const saveLocation = `${options.saveLocation || "/tmp/custom/save/location"}-saved`
             await backend.exec(["rm", "-rf", saveLocation])

--- a/test/testutil.ts
+++ b/test/testutil.ts
@@ -3,15 +3,6 @@ import readline from "readline"
 import { afterEach } from "mocha";
 
 /**
- * Enum representing the different features of a bittorrent client to be tested
- */
-export enum FeatureSet {
-  Labels,
-  MagnetLinks,
-  AdvancedUploadOptions,
-}
-
-/**
  * Asks for a qestion is console and wait for answer
  * @param query Question to be asked
  */


### PR DESCRIPTION
## Summary
- Move torrent client capability discovery into a shared `TorrentClientFeatures` contract, including `magnetLinks`
- Replace test fixture `FeatureSet` flags and renderer client instances with explicit `clientId` plus expected feature profiles
- Add a dedicated post-login feature assertion and keep test gating driven by fixture-declared enabled fields
- Preserve Deluge label detection as connection-scoped discovery and derive renderer UI from the resolved feature profile

## Testing
- `npm run lint`
- `npm run build`
- `npm run smoketest`