### PR TITLE
fix: show torrent progress with fixed tenths precision

### DIFF
--- a/src/renderer/app/bittorrent/abstracttorrent.ts
+++ b/src/renderer/app/bittorrent/abstracttorrent.ts
@@ -135,7 +135,8 @@ export abstract class Torrent implements TorrentProps {
     abstract isStatusStopped(): boolean;
 
     getPercentStr(): string {
-        return(Number((this.percent || 0) / 10)).toFixed(0) + '%';
+        const percent = Math.floor(Math.min(this.percent || 0, 1000)) / 10;
+        return percent.toFixed(1) + '%';
     };
 
     statusColor(): string {
@@ -343,4 +344,3 @@ export abstract class Torrent implements TorrentProps {
         return a - b
     }
 }
-


### PR DESCRIPTION
## Summary
- Update torrent progress formatting to always show one decimal place
- Truncate per-mille values before formatting so `99.99%` stays `99.9%` until completion
- Keep completed torrents rendering as `100.0%`

## Testing
- Lint passed
- Build passed
- Targeted `qbittorrent:latest` UI test passed