### PR TITLE
fix: align context menu with cursor position

### DIFF
--- a/src/renderer/app/directives/context-menu/context-menu.directive.ts
+++ b/src/renderer/app/directives/context-menu/context-menu.directive.ts
@@ -202,8 +202,8 @@ export class ContextMenuDirective implements IDirective {
                 const menuWidth = $(element).width() || 0;
                 const menuHeight = $(element).height() || 0;
 
-                const menuX = event.pageX + menuWidth >= totalWidth ? event.pageX - menuWidth : event.pageX;
-                const menuY = event.pageY + menuHeight >= totalHeight ? event.pageY - menuHeight : event.pageY;
+                const menuX = event.clientX + menuWidth >= totalWidth ? event.clientX - menuWidth : event.clientX;
+                const menuY = event.clientY + menuHeight >= totalHeight ? event.clientY - menuHeight : event.clientY;
 
                 $(element).css({
                     left: menuX,

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -677,7 +677,7 @@ html, body {
 }
 .torrent.context.menu {
     display: none;
-    position: absolute;
+    position: fixed;
 }
 .torrent.context.menu .ui.vertical.menu {
     box-shadow: 0 0 50px rgba(0, 0, 0, 0.15);

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -235,11 +235,11 @@ export class Torrent {
     await elem.click(options)
   }
 
-  async openContextMenu() {
+  async openContextMenu(options: Partial<ClickOptions> = { button: "right" }) {
     const elem = $(this.query)
     await elem.waitForExist()
     await elem.waitForDisplayed()
-    await elem.click({ button: "right" })
+    await elem.click(options)
 
     const contextMeny = $("#contextmenu")
     await contextMeny.waitForDisplayed()

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -622,6 +622,27 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
             return torrent.waitForState(options.downloadLabel);
           });
 
+          it("opens the context menu at the mouse position", async function () {
+            const torrentRow = $(torrent.query)
+            const rowLocation = await torrentRow.getLocation()
+            const rowSize = await torrentRow.getSize()
+            const clickOffset = {
+              x: -Math.floor(rowSize.width / 4),
+              y: 0,
+            }
+            const expectedMenuLocation = {
+              x: rowLocation.x + Math.floor(rowSize.width / 2) + clickOffset.x,
+              y: rowLocation.y + Math.floor(rowSize.height / 2) + clickOffset.y,
+            }
+
+            await torrent.openContextMenu({ button: "right", ...clickOffset })
+
+            const contextMenuLocation = await $("#contextmenu").getLocation()
+            const tolerance = 2
+            assert.closeTo(contextMenuLocation.x, expectedMenuLocation.x, tolerance)
+            assert.closeTo(contextMenuLocation.y, expectedMenuLocation.y, tolerance)
+          })
+
           it("delete action shows a confirmation modal", async function () {
             const modal = await torrent.openDeleteConfirmation()
             await modal.$(".content").getText().should.eventually.contain("Are you sure")


### PR DESCRIPTION
## Summary
- Position the torrent context menu with viewport coordinates so it opens where the right-click occurred.
- Switch the menu to `position: fixed` to match the coordinate system used for placement.
- Extend the torrent E2E helper to support offset clicks and add a regression test that checks the menu opens close to the mouse position.

## Testing
- UI test added for the context menu location regression.
- Existing lint and build verification were run successfully.
- Targeted `qbittorrent:latest` UI test passed.