### PR TITLE
feat: show bittorrent client version

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,7 @@
 import request from "request"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientFeatures } from "@shared/ipc-contract"
+import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
 import {
     cleanPath,
     defer,
@@ -197,7 +197,7 @@ export class DelugeRuntime implements BittorrentRuntime {
         return defer<any[]>((done) => this.rpc("web.get_hosts", [], done))
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
         const origin = `${server.proto}://${server.ip}:${server.port}`
 
         this.rpcUrl = `${origin}${buildClientPath(server, "json")}`
@@ -218,6 +218,11 @@ export class DelugeRuntime implements BittorrentRuntime {
         }
 
         const methods = await defer<string[]>((done) => this.rpc("web.connect", [hostId], done))
+        const hostStatus = await defer<[string, string, string]>((done) => this.rpc("web.get_host_status", [hostId], done))
+        const version = hostStatus?.[2]
+        if (typeof version !== "string" || !version.trim()) {
+            throw new Error("Deluge did not return its version")
+        }
 
         try {
             const enabledPlugins = await defer<string[]>((done) => this.rpc("core.get_enabled_plugins", [], done))
@@ -227,17 +232,20 @@ export class DelugeRuntime implements BittorrentRuntime {
         }
 
         return {
-            magnetLinks: Array.isArray(methods) && methods.includes("core.add_torrent_magnet"),
-            labels: this.supportsLabels,
-            torrentDetails: true,
-            uploadOptions: {
-                saveLocation: true,
-                category: this.supportsLabels,
-                startTorrent: true,
-                peerLimit: true,
-                firstAndLastPiecePrio: true,
-                downloadSpeedLimit: true,
-                uploadSpeedLimit: true,
+            version: version.trim(),
+            features: {
+                magnetLinks: Array.isArray(methods) && methods.includes("core.add_torrent_magnet"),
+                labels: this.supportsLabels,
+                torrentDetails: true,
+                uploadOptions: {
+                    saveLocation: true,
+                    category: this.supportsLabels,
+                    startTorrent: true,
+                    peerLimit: true,
+                    firstAndLastPiecePrio: true,
+                    downloadSpeedLimit: true,
+                    uploadSpeedLimit: true,
+                },
             },
         }
     }

--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -218,8 +218,8 @@ export class DelugeRuntime implements BittorrentRuntime {
         }
 
         const methods = await defer<string[]>((done) => this.rpc("web.connect", [hostId], done))
-        const hostStatus = await defer<[string, string, string]>((done) => this.rpc("web.get_host_status", [hostId], done))
-        const version = hostStatus?.[2]
+        const hostStatus = await defer<string[]>((done) => this.rpc("web.get_host_status", [hostId], done))
+        const version = hostStatus?.[hostStatus.length - 1]
         if (typeof version !== "string" || !version.trim()) {
             throw new Error("Deluge did not return its version")
         }

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -2,7 +2,7 @@ import type {
     BittorrentFileSelection,
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
-    TorrentClientFeatures,
+    TorrentClientConnection,
 } from "@shared/ipc-contract"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 
@@ -50,7 +50,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
     private files = new Map<string, MockTorrentFile[]>()
     private removedHashes: string[] = []
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
         const count = this.getTorrentCount(server)
         this.torrents.clear()
         this.files.clear()
@@ -91,21 +91,24 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         this.connected = true
 
         return {
-            magnetLinks: true,
-            labels: true,
-            fileSelection: true,
-            setLocation: true,
-            torrentDetails: true,
-            uploadOptions: {
-                saveLocation: true,
-                renameTorrent: true,
-                category: true,
-                startTorrent: true,
-                skipCheck: true,
-                sequentialDownload: true,
-                firstAndLastPiecePrio: true,
-                downloadSpeedLimit: true,
-                uploadSpeedLimit: true,
+            version: "1.0.0",
+            features: {
+                magnetLinks: true,
+                labels: true,
+                fileSelection: true,
+                setLocation: true,
+                torrentDetails: true,
+                uploadOptions: {
+                    saveLocation: true,
+                    renameTorrent: true,
+                    category: true,
+                    startTorrent: true,
+                    skipCheck: true,
+                    sequentialDownload: true,
+                    firstAndLastPiecePrio: true,
+                    downloadSpeedLimit: true,
+                    uploadSpeedLimit: true,
+                },
             },
         }
     }

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
@@ -22,6 +22,12 @@ export class QBittorrentApiV1 extends QBittorrentBaseApi {
         })
     }
 
+    getVersion(cb: (err?: any, version?: string) => void) {
+        this.get("version/qbittorrent", {}, (err, res, body) => {
+            this.handleError(cb)(err, res, body)
+        })
+    }
+
     syncMaindata(cb: (err?: any, body?: any) => void) {
         this.getJson("sync/maindata", { qs: { rid: this.rid } }, (err, res, body) => {
             if (!err) {

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
@@ -32,6 +32,12 @@ export class QBittorrentApiV2 extends QBittorrentBaseApi {
         })
     }
 
+    getVersion(cb: (err?: any, version?: string) => void) {
+        this.get("app/version", {}, (err, res, body) => {
+            this.handleError(cb)(err, res, body)
+        })
+    }
+
     syncMaindata(cb: (err?: any, body?: any) => void) {
         this.getJson("sync/maindata", { qs: { rid: this.rid } }, (err, res, body) => {
             if (!err) {

--- a/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
@@ -55,6 +55,7 @@ export abstract class QBittorrentBaseApi {
     }
 
     protected abstract buildPath(name: string): string
+    abstract getVersion(cb: (err?: any, version?: string) => void): void
 
     protected handleError(cb: (err: any, body?: any) => void, errors?: Record<number, Error>) {
         return (err: any, res: any, body: any) => {

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -4,7 +4,7 @@ import type {
     BittorrentFileSelection,
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
-    TorrentClientFeatures,
+    TorrentClientConnection,
 } from "@shared/ipc-contract"
 import { cleanPath, defer, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
@@ -61,10 +61,18 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         return this.api
     }
 
-    connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
-        return this.selectApi(server).then((api) => {
-            this.api = api
-            return defer((done) => api.login(done)).then(() => ({
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+        const api = await this.selectApi(server)
+        this.api = api
+        await defer((done) => api.login(done))
+        const version = await defer<string>((done) => api.getVersion(done))
+        if (typeof version !== "string" || !version.trim()) {
+            throw new Error("qBittorrent did not return its version")
+        }
+
+        return {
+            version: version.trim().replace(/^v(?=\d)/i, ""),
+            features: {
                 magnetLinks: true,
                 labels: true,
                 fileSelection: true,
@@ -81,8 +89,8 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                     downloadSpeedLimit: true,
                     uploadSpeedLimit: true,
                 },
-            }))
-        })
+            },
+        }
     }
 
     getSnapshot(fullUpdate?: boolean): Promise<any> {

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -1,6 +1,6 @@
 import xmlrpc from "@electorrent/xmlrpc"
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientFeatures } from "@shared/ipc-contract"
+import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
 import { cleanPath, defer, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { doubleArrayToHash, postfix, rtorrentFields, stringsToBooleans, stringsToNumbers, urlHostname } from "./helpers"
@@ -92,7 +92,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         await this.getMulticallHashes(hashes, commands, params)
     }
 
-    connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
         const options: Record<string, any> = {
             host: server.ip,
             port: server.port,
@@ -115,16 +115,24 @@ export class RtorrentRuntime implements BittorrentRuntime {
 
         this.client = server.proto === "https" ? xmlrpc.createSecureClient(options) : xmlrpc.createClient(options)
 
-        return this.call("system.client_version", []).then(() => ({
-            magnetLinks: true,
-            labels: true,
-            torrentDetails: true,
-            trackerFilter: true,
-            uploadOptions: {
-                saveLocation: true,
-                startTorrent: true,
+        const version = await this.call<string>("system.client_version", [])
+        if (typeof version !== "string" || !version.trim()) {
+            throw new Error("rTorrent did not return its version")
+        }
+
+        return {
+            version: version.trim(),
+            features: {
+                magnetLinks: true,
+                labels: true,
+                torrentDetails: true,
+                trackerFilter: true,
+                uploadOptions: {
+                    saveLocation: true,
+                    startTorrent: true,
+                },
             },
-        }))
+        }
     }
 
     async getSnapshot(): Promise<any> {

--- a/src/main/lib/bittorrent/clients/synology.ts
+++ b/src/main/lib/bittorrent/clients/synology.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance, AxiosResponse } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
 
-import type { BittorrentServerConfig, TorrentClientFeatures } from '@shared/ipc-contract'
+import type { BittorrentServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     createHttpsAgent,
     HTTP_LOGIN_TIMEOUT,
@@ -13,6 +13,7 @@ import type { BittorrentRuntime } from '@main/lib/bittorrent/types'
 
 const API_INFO = 'SYNO.API.Info'
 const API_TASK = 'SYNO.DownloadStation.Task'
+const API_DOWNLOAD_STATION_INFO = 'SYNO.DownloadStation.Info'
 const API_AUTH = 'SYNO.API.Auth'
 
 const ERR_COM: Record<number, string> = {
@@ -53,6 +54,8 @@ export class SynologyRuntime implements BittorrentRuntime {
     private authVersion = ''
     private dlPath = ''
     private dlVersion = ''
+    private infoPath = ''
+    private infoVersion = ''
     private taskPath = '/DownloadStation/task.cgi'
     private config(choice: string, args: any[] = []) {
         switch (choice) {
@@ -62,7 +65,7 @@ export class SynologyRuntime implements BittorrentRuntime {
                         api: API_INFO,
                         version: '1',
                         method: 'query',
-                        query: 'SYNO.API.Auth,SYNO.DownloadStation.Task',
+                        query: 'SYNO.API.Auth,SYNO.DownloadStation.Info,SYNO.DownloadStation.Task',
                     },
                     timeout: HTTP_REQUEST_TIMEOUT,
                 }
@@ -85,6 +88,15 @@ export class SynologyRuntime implements BittorrentRuntime {
                         version: this.dlVersion,
                         method: 'list',
                         additional: 'detail,transfer,tracker',
+                    },
+                    timeout: HTTP_REQUEST_TIMEOUT,
+                }
+            case 'info':
+                return {
+                    params: {
+                        api: API_DOWNLOAD_STATION_INFO,
+                        version: this.infoVersion,
+                        method: 'getinfo',
                     },
                     timeout: HTTP_REQUEST_TIMEOUT,
                 }
@@ -156,7 +168,7 @@ export class SynologyRuntime implements BittorrentRuntime {
         return !!data?.success
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
         this.server = server
         this.http = axios.create({
             httpsAgent: createHttpsAgent(server),
@@ -182,6 +194,8 @@ export class SynologyRuntime implements BittorrentRuntime {
         this.authVersion = queryResponse.data.data[API_AUTH].maxVersion
         this.dlPath = `/${queryResponse.data.data[API_TASK].path}`
         this.dlVersion = queryResponse.data.data[API_TASK].maxVersion
+        this.infoPath = `/${queryResponse.data.data[API_DOWNLOAD_STATION_INFO].path}`
+        this.infoVersion = queryResponse.data.data[API_DOWNLOAD_STATION_INFO].maxVersion
 
         const authResponse = await this.http.get(`${serverUrl(this.server)}${this.authPath}`, this.config('auth', [server.user, server.password]))
         this.handleError(authResponse)
@@ -189,11 +203,21 @@ export class SynologyRuntime implements BittorrentRuntime {
             throw new Error(`Login failed. Error: ${authResponse.data.error}`)
         }
 
+        const infoResponse = await this.http.get(`${serverUrl(this.server)}${this.infoPath}`, this.config('info'))
+        this.handleError(infoResponse)
+        const version = infoResponse.data?.data?.version_string ?? infoResponse.data?.data?.version
+        if ((typeof version !== 'string' && typeof version !== 'number') || !String(version).trim()) {
+            throw new Error('Synology Download Station did not return its version')
+        }
+
         return {
-            magnetLinks: true,
-            setLocation: true,
-            uploadOptions: {
-                saveLocation: true,
+            version: String(version).trim(),
+            features: {
+                magnetLinks: true,
+                setLocation: true,
+                uploadOptions: {
+                    saveLocation: true,
+                },
             },
         }
     }

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientFeatures } from '@shared/ipc-contract'
+import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     createHttpsAgent,
     HTTP_LOGIN_TIMEOUT,
@@ -165,11 +165,11 @@ export class TransmissionRuntime implements BittorrentRuntime {
         return http
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
         this.server = server
         this.session = undefined
 
-        await this.getHttpClient().post(this.url(), { method: 'session-get' }, {
+        let response = await this.getHttpClient().post(this.url(), { method: 'session-get' }, {
             timeout: HTTP_LOGIN_TIMEOUT,
             auth: {
                 username: server.user,
@@ -177,21 +177,34 @@ export class TransmissionRuntime implements BittorrentRuntime {
             },
             validateStatus: (status) => status === 200 || status === 409,
         })
+        if (response.status === 409) {
+            response = await this.getHttpClient().post(this.url(), { method: 'session-get' }, {
+                timeout: HTTP_LOGIN_TIMEOUT,
+            })
+        }
+
+        const version = response.data?.arguments?.version
+        if (typeof version !== 'string' || !version.trim()) {
+            throw new Error('Transmission did not return its version')
+        }
 
         return {
-            magnetLinks: true,
-            labels: true,
-            setLocation: true,
-            torrentDetails: true,
-            trackerFilter: true,
-            uploadOptions: {
-                saveLocation: true,
-                category: true,
-                startTorrent: true,
-                peerLimit: true,
-                sequentialDownload: true,
-                downloadSpeedLimit: true,
-                uploadSpeedLimit: true,
+            version: version.trim(),
+            features: {
+                magnetLinks: true,
+                labels: true,
+                setLocation: true,
+                torrentDetails: true,
+                trackerFilter: true,
+                uploadOptions: {
+                    saveLocation: true,
+                    category: true,
+                    startTorrent: true,
+                    peerLimit: true,
+                    sequentialDownload: true,
+                    downloadSpeedLimit: true,
+                    uploadSpeedLimit: true,
+                },
             },
         }
     }

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -3,7 +3,7 @@ import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
 import qs from 'qs'
 
-import type { BittorrentServerConfig, TorrentClientFeatures } from '@shared/ipc-contract'
+import type { BittorrentServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     createHttpsAgent,
     HTTP_LOGIN_TIMEOUT,
@@ -83,7 +83,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
         }
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures> {
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
         this.server = server
 
         this.http = axios.create({
@@ -139,11 +139,26 @@ export class UtorrentRuntime implements BittorrentRuntime {
 
         this.saveConnection(serverUrl(server), server.user, server.password)
 
+        const versionResponse = await this.http.get(`${this.data.url}/`, {
+            params: {
+                token: this.data.token,
+                t: Date.now(),
+                list: 1,
+            },
+        })
+        const build = versionResponse.data?.build
+        if ((typeof build !== 'string' && typeof build !== 'number') || !String(build).trim()) {
+            throw new Error('µTorrent did not return its build version')
+        }
+
         return {
-            magnetLinks: true,
-            labels: true,
-            uploadOptions: {
-                saveLocation: true,
+            version: String(build).trim(),
+            features: {
+                magnetLinks: true,
+                labels: true,
+                uploadOptions: {
+                    saveLocation: true,
+                },
             },
         }
     }

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -6,7 +6,7 @@ import type {
     BittorrentInvokeActionRequest,
     BittorrentServerConfig,
     BittorrentSetTorrentFileSelectionRequest,
-    TorrentClientFeatures,
+    TorrentClientConnection,
     BittorrentTorrentDetailsData,
     BittorrentUploadTorrentRequest,
 } from "@shared/ipc-contract"
@@ -17,7 +17,7 @@ import type { BittorrentRuntime } from "./types"
 
 class BittorrentManager {
     private sessions = new Map<number, BittorrentRuntime>()
-    private pendingConnections = new Map<number, Promise<TorrentClientFeatures>>()
+    private pendingConnections = new Map<number, Promise<TorrentClientConnection>>()
 
     private async getSession(sender: WebContents) {
         const senderId = sender.id
@@ -65,9 +65,9 @@ class BittorrentManager {
             }
 
             const runtime = createRuntime(server.client)
-            const features = await runtime.connect(server)
+            const connection = await runtime.connect(server)
             this.sessions.set(senderId, runtime)
-            return features
+            return connection
         })()
 
         this.pendingConnections.set(senderId, pendingConnect)

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -1,14 +1,14 @@
 import type {
     BittorrentFileSelection,
     BittorrentServerConfig,
-    TorrentClientFeatures,
+    TorrentClientConnection,
     BittorrentTorrentDetailsData,
 } from "@shared/ipc-contract"
 
 export type CallbackFunc<T = any> = (err: any, val: T) => void
 
 export interface BittorrentRuntime {
-    connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures>
+    connect(server: BittorrentServerConfig): Promise<TorrentClientConnection>
     getSnapshot(fullUpdate?: boolean): Promise<any>
     addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void>
     uploadTorrent(buffer: Uint8Array, filename: string, options?: Record<string, any>): Promise<void>

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -136,10 +136,10 @@ export function registerHandlers({ isDebug, getWindow, consumePendingLaunchPaylo
     })
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }) {
-        const features = await bittorrentManager.connect(event.sender, server)
+        const connection = await bittorrentManager.connect(event.sender, server)
         menu.setActiveServer(server)
         await onBittorrentConnected?.()
-        return features
+        return connection
     })
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.disconnect, async function(event: IpcMainInvokeEvent) {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -34,6 +34,11 @@ torrentApp.constant('$btclients', {
         service: new QBittorrentClient(),
         icon: CLIENT_METADATA.qbittorrent.icon
     },
+    'mock': {
+        name: CLIENT_METADATA.mock.name,
+        service: new MockBittorrentClient(),
+        icon: CLIENT_METADATA.mock.icon
+    },
     'transmission': {
         name: CLIENT_METADATA.transmission.name,
         service: new TransmissionClient(),

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -3,7 +3,7 @@ import type {
     ElectorrentBridge,
     BittorrentFileSelection,
     BittorrentServerConfig,
-    TorrentClientFeatures,
+    TorrentClientConnection,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
 
@@ -25,7 +25,7 @@ export function serializeServer(server: any): BittorrentServerConfig {
     }
 }
 
-export function connect(server: any): Promise<TorrentClientFeatures> {
+export function connect(server: any): Promise<TorrentClientConnection> {
     return bridge().connect(serializeServer(server))
 }
 

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -168,9 +168,14 @@ export interface TorrentDetailsPanelData {
 
 export abstract class TorrentClient<T extends Torrent = Torrent> {
     private resolvedFeatures = DEFAULT_FEATURES
+    private clientVersion = ""
 
     public get features(): ResolvedTorrentClientFeatures {
         return this.resolvedFeatures
+    }
+
+    public get version(): string {
+        return this.clientVersion
     }
 
     /**
@@ -194,7 +199,10 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
      */
     async connect(server: any): Promise<void> {
         this.resolvedFeatures = DEFAULT_FEATURES
-        this.resolvedFeatures = resolveFeatures(await connect(server))
+        this.clientVersion = ""
+        const connection = await connect(server)
+        this.resolvedFeatures = resolveFeatures(connection.features)
+        this.clientVersion = connection.version
     }
 
     /**

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -224,6 +224,9 @@
         </div>
         <torrent-details-panel settings="settings"></torrent-details-panel>
         <div class="action footer status-bar">
+            <div class="client-version" ng-if="$btclient.version">
+                {{$btclient.name}} {{$btclient.version}}
+            </div>
             <div class="download-speed">
                 <i class="ui blue arrow down icon"></i>
                 {{ totalDownloadSpeed | speed }} <span ng-if="totalDownloaded">({{ totalDownloaded | bytes:2 }})</span>

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -565,6 +565,13 @@ html, body {
             margin-left: 1rem;
             margin-right: 1rem;
         }
+
+        .client-version {
+            margin-left: 0;
+            margin-right: auto;
+            color: @unselectedTextColor;
+            font-size: 0.8rem;
+        }
     }
 }
 .ui.welcome.form.loading:before {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -187,6 +187,11 @@ export interface TorrentClientFeatures {
     readonly uploadOptions?: Readonly<TorrentUploadOptionsEnable>
 }
 
+export interface TorrentClientConnection {
+    readonly version: string
+    readonly features: TorrentClientFeatures
+}
+
 export interface ResolvedTorrentClientFeatures {
     readonly magnetLinks: boolean
     readonly labels: boolean
@@ -312,7 +317,7 @@ export interface ElectorrentBridge {
         getPathForFile(file: unknown): string
     }
     bittorrent: {
-        connect(server: BittorrentServerConfig): Promise<TorrentClientFeatures>
+        connect(server: BittorrentServerConfig): Promise<TorrentClientConnection>
         disconnect(): Promise<void>
         getSnapshot(request?: BittorrentSnapshotRequest): Promise<any>
         addTorrentUrl(request: BittorrentAddTorrentUrlRequest): Promise<void>

--- a/test/fixtures/mock/mock.spec.ts
+++ b/test/fixtures/mock/mock.spec.ts
@@ -13,11 +13,8 @@ setupMochaHooks()
 describe("given mocked bittorrent backend is running", function () {
   startApplicationHooks()
 
-  before(function () {
+  before(async function () {
     chai.should()
-  })
-
-  it("renders 100 mocked torrents over IPC", async function () {
     this.app = this.app || new App()
 
     await this.app.login({
@@ -28,7 +25,9 @@ describe("given mocked bittorrent backend is running", function () {
       port: 1,
     })
     await this.app.torrentsPageIsVisible({ timeout: 10 * 1000 })
+  })
 
+  it("renders 100 mocked torrents over IPC", async function () {
     await revealAllTorrentRows()
 
     const rows = await $$("#torrentTable tbody tr")
@@ -38,6 +37,12 @@ describe("given mocked bittorrent backend is running", function () {
     const lastName = await getTorrentNameText("0000000000000000000000000000000000000064")
     assert.include(firstName, "Mock Torrent 001")
     assert.include(lastName, "Mock Torrent 100")
+  })
+
+  it("shows client version in status bar", async function () {
+    const version = $(".status-bar .client-version")
+    await version.waitForDisplayed()
+    assert.equal(await version.getText(), "Mock Bittorrent 1.0.0")
   })
 })
 

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -11,7 +11,7 @@ import { dockerComposeHooks, startApplicationHooks, restartApplication } from ".
 import { browser, $ } from '@wdio/globals'
 import { createTorrentFile } from "./torrent";
 import { waitForModalClose, waitForModalOpen } from "./e2e/modal"
-import type { ClientId } from "../src/shared/client-metadata"
+import { CLIENT_METADATA, type ClientId } from "../src/shared/client-metadata"
 import type { TorrentClientFeatures } from "../src/shared/ipc-contract"
 
 const { assert } = chai
@@ -172,6 +172,15 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
             .filter((path) => path.split(".").reduce((value, key) => value?.[key], actualFeatures) !== true)
 
           assert.deepEqual(missingFeatures, [], `Missing enabled client features: ${missingFeatures.join(", ")}`)
+        })
+
+        it("shows client version in status bar", async function() {
+          const version = $(".status-bar .client-version")
+          await version.waitForDisplayed()
+          assert.match(
+            await version.getText(),
+            new RegExp(`^${CLIENT_METADATA[options.clientId].name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+\\S+`),
+          )
         })
 
         it("automatically connect when restarting app", async function() {


### PR DESCRIPTION
## Summary
- fetch backend version information when connecting every supported torrent client
- return version and feature metadata through connect IPC
- show muted client name and version at left side of status bar
- support both Deluge v1 and v2 host-status response shapes
- add shared and mock E2E coverage for version display

## Impact
Connected users can see exact backend client version without opening server administration UI.

## Root cause
Deluge v2 returns host status as `(host_id, status, version)`, while Deluge v1 returns `(host_id, host, port, status, version)`. Reading a fixed tuple index caused Deluge v1 connections to fail while resolving the version.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --suite "mock" --mochaOpts.grep "shows client version"`
- `npm run test -- --suite "mock"`
- `npm run test -- --suite "deluge:1" --mochaOpts.grep "shows client version in status bar"`
- `npm run test -- --suite "deluge:2" --mochaOpts.grep "shows client version in status bar"`

Electron E2E commands were run outside the sandbox. Both targeted Deluge tests passed with 1 test each; the full mock suite previously passed with 2 tests.