### PR TITLE
fix: preserve selected server when loading settings

### DIFF
--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -222,8 +222,8 @@ export class AppShellController {
             $scope.showLoading = true;
         };
 
-        const pageSettings = (settingsPage?: string) => {
-            $scope.$broadcast("setting:load");
+        const pageSettings = (settingsPage?: string, serverId?: string) => {
+            $scope.$broadcast("setting:load", serverId);
             $scope.showLoading = false;
             if (settingsPage) {
                 $scope.$broadcast("settings:page", settingsPage, true);
@@ -264,7 +264,7 @@ export class AppShellController {
                 });
             }).catch((err: unknown) => {
                 console.error(err);
-                pageSettings("connection");
+                pageSettings("connection", server.id);
             }).then(() => {
                 $scope.$apply();
             });

--- a/src/renderer/app/directives/settings-page/settings-page.controller.ts
+++ b/src/renderer/app/directives/settings-page/settings-page.controller.ts
@@ -67,9 +67,9 @@ export class SettingsPageController {
             $scope.$applyAsync();
         });
 
-        function loadAllSettings() {
+        function loadAllSettings(serverId?: string) {
             $scope.settings = settingsService.getAllSettingsCopy();
-            loadServerReference();
+            loadServerReference(serverId);
 
             serverCopy = angular.copy($scope.server);
 
@@ -80,10 +80,11 @@ export class SettingsPageController {
             });
         }
 
-        function loadServerReference() {
-            if ($rootScope.$server) {
+        function loadServerReference(serverId?: string) {
+            const selectedServerId = serverId || $rootScope.$server?.id;
+            if (selectedServerId) {
                 $scope.server = $scope.settings.servers.find((server: any) => {
-                    return server.id === $rootScope.$server?.id;
+                    return server.id === selectedServerId;
                 });
             }
         }
@@ -96,8 +97,8 @@ export class SettingsPageController {
             }
         }
 
-        $scope.$on("setting:load", () => {
-            Promise.resolve(loadPromise).then(() => loadAllSettings()).finally(() => {
+        $scope.$on("setting:load", (_event: unknown, serverId?: string) => {
+            Promise.resolve(loadPromise).then(() => loadAllSettings(serverId)).finally(() => {
                 $scope.$applyAsync();
             });
         });

--- a/test/testlib.ts
+++ b/test/testlib.ts
@@ -200,6 +200,13 @@ export function createTestSuite(optionsArg: TestSuiteOptionsOptional) {
           await restartApplication(this)
           await this.app.settingsPageIsVisible({ timeout: 10 * 1000})
           await this.app.settingsPageConnectionIsVisible()
+          await browser.waitUntil(async () => {
+            return await $("#page-settings-connection input[name='ip']").getValue() === options.host
+          })
+          assert.equal(await $("#page-settings-connection input[name='ip']").getValue(), options.host)
+          assert.equal(await $("#page-settings-connection input[name='port']").getValue(), String(options.port))
+          assert.equal(await $("#page-settings-connection input[name='username']").getValue(), options.username)
+          assert.equal(await $("#page-settings-connection input[name='password']").getValue(), options.password)
           await backend.unpause()
           await restartApplication(this)
           await this.app.torrentsPageIsVisible()


### PR DESCRIPTION
## Summary
- Pass the active server id through the settings load flow
- Rebind the settings page to the correct server after connection failures
- Add integration coverage for restoring the selected server settings on restart

## Testing
- Not run (not requested)