### PR TITLE
fix(theme): add dark subtle shadow token

### DIFF
--- a/src/renderer/styles/themes/dark/globals/site.variables
+++ b/src/renderer/styles/themes/dark/globals/site.variables
@@ -36,6 +36,7 @@
 @pageForeground: lighten(@gray-darker, 5%);
 @overlayBackground: @pageBackground;
 @highlightBackground: @gray;
+@subtleShadow: 0px 1px 2px 0 rgba(0, 0, 0, 0.2);
 @linkColor: #fff;
 @linkHoverColor: #fff;
 @padding-base-vertical: 8px;


### PR DESCRIPTION
## Summary
- Add `@subtleShadow` to the dark theme variables
- Align dark theme styling with a softer, reusable shadow token

## Testing
- Not run (not requested)