### PR TITLE
fix(qbittorrent): omit default port from origin URL

### DIFF
--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -28,7 +28,9 @@ export class QBittorrentRuntime implements BittorrentRuntime {
     private trackerToHashes = new Map<string, Set<string>>()
 
     private async selectApi(server: BittorrentServerConfig) {
-        const origin = `${server.proto}://${server.ip}:${server.port}`
+        const defaultPort = server.proto === "https" ? 443 : 80
+        const portSuffix = server.port !== defaultPort ? `:${server.port}` : ""
+        const origin = `${server.proto}://${server.ip}${portSuffix}`
         const requestOptions = {
             timeout: HTTP_REQUEST_TIMEOUT,
             ca: server.certificateData,


### PR DESCRIPTION
## Problem

Connecting to qBittorrent behind a reverse proxy (e.g. Traefik) on the default HTTPS port 443 always fails with a 401, even with correct credentials.

**Root cause:** The origin URL was built as `https://host:443`, so every HTTP request included `Host: host:443`. Traefik (and similar proxies) route on `Host: host` without the port, so no route matched and all requests returned 401.

This regression was introduced when the qBittorrent client was inlined from the `@electorrent/node-qbittorrent` npm package. The old package used `url.resolve()` to build request URLs, which silently drops default ports per the URL specification. The inlined code switched to string template concatenation, which always includes the port.

## Fix

Omit the port from the origin string when it equals the scheme default (443 for HTTPS, 80 for HTTP), restoring the original behaviour.

```
// before
const origin = `${server.proto}://${server.ip}:${server.port}`

// after
const defaultPort = server.proto === "https" ? 443 : 80
const portSuffix = server.port !== defaultPort ? `:${server.port}` : ""
const origin = `${server.proto}://${server.ip}${portSuffix}`
```

## Test plan

- [ ] Connect via HTTPS on port 443 behind a reverse proxy — should succeed
- [ ] Connect on a non-default port (e.g. 8080) — port should still be included
- [ ] Connect via HTTP on port 80 — should succeed without port in URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)