### PR TITLE
fix: use node:url for api calls

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -3,10 +3,10 @@ import parseTorrent from "parse-torrent"
 
 import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
 import {
-    cleanPath,
     defer,
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
+    serverUrl,
 } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 
@@ -57,14 +57,11 @@ const DELUGE_TORRENT_DETAIL_FIELDS = [
     "time_since_transfer",
 ]
 
-function buildClientPath(server: BittorrentServerConfig, endpoint: string) {
-    const prefix = cleanPath(server.path)
-    const suffix = endpoint.replace(/^\/+/, "")
-
-    return prefix ? `${prefix}/${suffix}` : `/${suffix}`
-}
-
 export class DelugeRuntime implements BittorrentRuntime {
+    private url(server: BittorrentServerConfig, endpoint?: string) {
+        return serverUrl(server, endpoint)
+    }
+
     private requestId = 0
 
     private rpcUrl = ""
@@ -198,10 +195,8 @@ export class DelugeRuntime implements BittorrentRuntime {
     }
 
     async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
-        const origin = `${server.proto}://${server.ip}:${server.port}`
-
-        this.rpcUrl = `${origin}${buildClientPath(server, "json")}`
-        this.uploadUrl = `${origin}${buildClientPath(server, "upload")}`
+        this.rpcUrl = this.url(server, "json")
+        this.uploadUrl = this.url(server, "upload")
         this.requestId = 0
         this.requestOptions = {
             timeout: HTTP_REQUEST_TIMEOUT,

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
@@ -1,9 +1,9 @@
+import { urlPath } from "@main/lib/bittorrent/helpers"
 import { AUTH_ERRORS, QBittorrentBaseApi, TORRENT_ERRORS } from "./base-api"
 
 export class QBittorrentApiV1 extends QBittorrentBaseApi {
     protected buildPath(name: string) {
-        const suffix = name.replace(/^\/+/, "")
-        return this.basePath ? `${this.basePath}/${suffix}` : `/${suffix}`
+        return urlPath(this.basePath, name)
     }
 
     login(cb: (err?: any, body?: any) => void) {

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
@@ -1,12 +1,11 @@
+import { urlPath } from "@main/lib/bittorrent/helpers"
 import { AUTH_ERRORS, QBittorrentBaseApi, TORRENT_ERRORS } from "./base-api"
 
 export class QBittorrentApiV2 extends QBittorrentBaseApi {
     private useStartStopEndpoints = false
 
     protected buildPath(name: string) {
-        const suffix = name.replace(/^\/+/, "")
-        const prefix = this.basePath ? `${this.basePath}/api/v2` : "/api/v2"
-        return `${prefix}/${suffix}`
+        return urlPath(this.basePath, "api/v2", name)
     }
 
     login(cb: (err?: any, body?: any) => void) {

--- a/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
@@ -3,7 +3,7 @@ import path from "path"
 
 import request from "request"
 
-import { HTTP_LOGIN_TIMEOUT, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
+import { appendUrlPath, HTTP_LOGIN_TIMEOUT, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
 
 export const AUTH_ERRORS: Record<number, Error> = {
     403: new Error("User's IP is banned for too many failed login attempts"),
@@ -79,7 +79,7 @@ export abstract class QBittorrentBaseApi {
     }
 
     protected url(name: string) {
-        return `${this.origin}${this.buildPath(name)}`
+        return appendUrlPath(this.origin, this.buildPath(name))
     }
 
     protected http(method: string, apiPath: string, requestOptions: Record<string, any>, cb: (err: any, res?: any, body?: any) => void) {

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -1,3 +1,4 @@
+import { URL } from "node:url"
 import request from "request"
 
 import type {
@@ -6,7 +7,7 @@ import type {
     BittorrentTorrentDetailsData,
     TorrentClientConnection,
 } from "@shared/ipc-contract"
-import { cleanPath, defer, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
+import { defer, HTTP_REQUEST_TIMEOUT, serverOriginUrl, serverUrl, urlPath } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { QBittorrentApiV1 } from "./api-v1"
 import { QBittorrentApiV2 } from "./api-v2"
@@ -15,20 +16,17 @@ import type { QBittorrentBaseApi } from "./base-api"
 const QBITTORRENT_PRIORITY_SKIP = 0
 const QBITTORRENT_PRIORITY_NORMAL = 1
 
-function buildClientPath(server: BittorrentServerConfig, endpoint: string) {
-    const prefix = cleanPath(server.path)
-    const suffix = endpoint.replace(/^\/+/, "")
-
-    return prefix ? `${prefix}/${suffix}` : `/${suffix}`
-}
-
 export class QBittorrentRuntime implements BittorrentRuntime {
+    private url(server: BittorrentServerConfig, endpoint?: string) {
+        return serverUrl(server, endpoint)
+    }
+
     private api: QBittorrentBaseApi | null = null
 
     private trackerToHashes = new Map<string, Set<string>>()
 
     private async selectApi(server: BittorrentServerConfig) {
-        const origin = `${server.proto}://${server.ip}:${server.port}`
+        const origin = serverOriginUrl(server)
         const requestOptions = {
             timeout: HTTP_REQUEST_TIMEOUT,
             ca: server.certificateData,
@@ -36,7 +34,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
             headers: {
                 Referer: origin,
             },
-            uri: `${origin}${buildClientPath(server, "version/api")}`,
+            uri: this.url(server, "version/api"),
         }
 
         const hasLegacyApi = await new Promise<boolean>((resolve) => {
@@ -45,7 +43,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
 
         const options = {
             origin,
-            path: cleanPath(server.path),
+            path: urlPath(server.path),
             user: server.user,
             pass: server.password,
             ca: server.certificateData,

--- a/src/main/lib/bittorrent/clients/rtorrent/helpers.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/helpers.ts
@@ -1,4 +1,4 @@
-export const URL_REGEX = /^[a-z]+:\/\/(?:[a-z0-9-]+\.)*((?:[a-z0-9-]+\.)[a-z]+)/
+import { URL } from "node:url"
 
 export const rtorrentFields = {
     trackers: {
@@ -52,8 +52,11 @@ export function postfix(param: string) {
 }
 
 export function urlHostname(trackerUrl: string) {
-    const match = trackerUrl.match(URL_REGEX)
-    return match && match[1]
+    try {
+        return new URL(trackerUrl).hostname
+    } catch {
+        return undefined
+    }
 }
 
 export function stringsToNumbers(object: Record<string, any>) {

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -1,7 +1,8 @@
+import { URL } from "node:url"
 import xmlrpc from "@electorrent/xmlrpc"
 
 import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
-import { cleanPath, defer, HTTP_REQUEST_TIMEOUT } from "@main/lib/bittorrent/helpers"
+import { defer, HTTP_REQUEST_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { doubleArrayToHash, postfix, rtorrentFields, stringsToBooleans, stringsToNumbers, urlHostname } from "./helpers"
 
@@ -14,6 +15,10 @@ type RtorrentMulticallCommand = string | [string, ...any[]]
 
 export class RtorrentRuntime implements BittorrentRuntime {
     private client: any
+
+    private url(server: BittorrentServerConfig) {
+        return server.path ? serverUrl(server) : serverUrl(server, "RPC2")
+    }
 
     private async call<T = any>(method: string, params: any[]): Promise<T> {
         return defer<T>((done) => this.client.methodCall(method, params, done))
@@ -93,10 +98,11 @@ export class RtorrentRuntime implements BittorrentRuntime {
     }
 
     async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+        const rpcUrl = new URL(this.url(server))
         const options: Record<string, any> = {
-            host: server.ip,
-            port: server.port,
-            path: cleanPath(server.path) || "/RPC2",
+            host: rpcUrl.hostname.replace(/^\[|\]$/g, ""),
+            port: Number(rpcUrl.port),
+            path: rpcUrl.pathname,
             headers: {
                 "User-Agent": "NodeJS XML-RPC Client",
                 "Content-Type": "text/xml",

--- a/src/main/lib/bittorrent/clients/synology.ts
+++ b/src/main/lib/bittorrent/clients/synology.ts
@@ -56,7 +56,12 @@ export class SynologyRuntime implements BittorrentRuntime {
     private dlVersion = ''
     private infoPath = ''
     private infoVersion = ''
-    private taskPath = '/DownloadStation/task.cgi'
+    private taskPath = 'DownloadStation/task.cgi'
+
+    private url(endpoint = '') {
+        return serverUrl(this.server, endpoint)
+    }
+
     private config(choice: string, args: any[] = []) {
         switch (choice) {
             case 'query':
@@ -184,26 +189,26 @@ export class SynologyRuntime implements BittorrentRuntime {
             return res
         })
 
-        const queryResponse = await this.http.get(`${serverUrl(this.server)}/query.cgi`, this.config('query'))
+        const queryResponse = await this.http.get(this.url('query.cgi'), this.config('query'))
         this.handleError(queryResponse)
         if (!this.isSuccess(queryResponse.data)) {
             throw new Error(`Getting initial API information from Auth and DownloadStation failed. Error: ${queryResponse.data.error}`)
         }
 
-        this.authPath = `/${queryResponse.data.data[API_AUTH].path}`
+        this.authPath = queryResponse.data.data[API_AUTH].path
         this.authVersion = queryResponse.data.data[API_AUTH].maxVersion
-        this.dlPath = `/${queryResponse.data.data[API_TASK].path}`
+        this.dlPath = queryResponse.data.data[API_TASK].path
         this.dlVersion = queryResponse.data.data[API_TASK].maxVersion
-        this.infoPath = `/${queryResponse.data.data[API_DOWNLOAD_STATION_INFO].path}`
+        this.infoPath = queryResponse.data.data[API_DOWNLOAD_STATION_INFO].path
         this.infoVersion = queryResponse.data.data[API_DOWNLOAD_STATION_INFO].maxVersion
 
-        const authResponse = await this.http.get(`${serverUrl(this.server)}${this.authPath}`, this.config('auth', [server.user, server.password]))
+        const authResponse = await this.http.get(this.url(this.authPath), this.config('auth', [server.user, server.password]))
         this.handleError(authResponse)
         if (!this.isSuccess(authResponse.data)) {
             throw new Error(`Login failed. Error: ${authResponse.data.error}`)
         }
 
-        const infoResponse = await this.http.get(`${serverUrl(this.server)}${this.infoPath}`, this.config('info'))
+        const infoResponse = await this.http.get(this.url(this.infoPath), this.config('info'))
         this.handleError(infoResponse)
         const version = infoResponse.data?.data?.version_string ?? infoResponse.data?.data?.version
         if ((typeof version !== 'string' && typeof version !== 'number') || !String(version).trim()) {
@@ -223,7 +228,7 @@ export class SynologyRuntime implements BittorrentRuntime {
     }
 
     async getSnapshot(): Promise<any> {
-        const response = await this.http.get(`${serverUrl(this.server)}${this.dlPath}`, this.config('torrents'))
+        const response = await this.http.get(this.url(this.dlPath), this.config('torrents'))
         this.handleError(response)
         if (!this.isSuccess(response.data)) {
             throw new Error(`Retrieving torrent data failed. Error: ${response.data.error}`)
@@ -238,7 +243,7 @@ export class SynologyRuntime implements BittorrentRuntime {
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {
-        const response = await this.http.get(`${serverUrl(this.server)}${this.taskPath}`, this.config('tUrl', [uri, this.getUploadOptions(options).destination]))
+        const response = await this.http.get(this.url(this.taskPath), this.config('tUrl', [uri, this.getUploadOptions(options).destination]))
         this.handleError(response)
         if (!this.isSuccess(response.data)) {
             throw new Error(`Create a DownloadStation task with the provided URL failed. Error: ${response.data.error}`)
@@ -258,14 +263,14 @@ export class SynologyRuntime implements BittorrentRuntime {
             contentType: 'application/x-bittorrent',
         })
 
-        const response = await this.http.post(`${serverUrl(this.server)}${this.taskPath}`, formData, {
+        const response = await this.http.post(this.url(this.taskPath), formData, {
             headers: formData.getHeaders(),
         })
         this.handleError(response)
     }
 
     private doAction(action: string, hashes: string[]) {
-        return this.http.get(`${serverUrl(this.server)}${this.taskPath}`, this.config('action', [action, hashes.join(',')]))
+        return this.http.get(this.url(this.taskPath), this.config('action', [action, hashes.join(',')]))
             .then((response) => this.handleError(response))
             .then(() => undefined)
     }
@@ -283,7 +288,7 @@ export class SynologyRuntime implements BittorrentRuntime {
     }
 
     setLocation(hashes: string[], location: string): Promise<void> {
-        return this.http.get(`${serverUrl(this.server)}${this.taskPath}`, this.config('setLocation', [hashes.join(','), location]))
+        return this.http.get(this.url(this.taskPath), this.config('setLocation', [hashes.join(','), location]))
             .then((response) => this.handleError(response))
             .then(() => undefined)
     }

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -90,8 +90,8 @@ export class TransmissionRuntime implements BittorrentRuntime {
     private server!: BittorrentServerConfig
     private session?: string
 
-    private url(pathValue = '') {
-        return `${serverUrl(this.server)}${pathValue}`
+    private url(endpoint = '') {
+        return serverUrl(this.server, endpoint)
     }
 
     private updateSession(res: any) {

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -1,3 +1,4 @@
+import { URL } from 'node:url'
 import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
@@ -16,7 +17,6 @@ export class UtorrentRuntime implements BittorrentRuntime {
     private server!: BittorrentServerConfig
     private http!: AxiosInstance
     private data = {
-        url: '',
         username: '',
         password: '',
         token: '',
@@ -24,14 +24,18 @@ export class UtorrentRuntime implements BittorrentRuntime {
         build: -1,
     }
 
-    private url(pathValue = '') {
-        return `${serverUrl(this.server)}${pathValue}`
+    private url(endpoint = '') {
+        const url = new URL(serverUrl(this.server, endpoint || undefined))
+        if (!endpoint) {
+            url.pathname = `${url.pathname.replace(/\/?$/, '')}/`
+        }
+
+        return url.toString()
     }
 
-    private saveConnection(urlValue: string, username: string, password: string) {
+    private saveConnection(username: string, password: string) {
         this.data.username = username
         this.data.password = password
-        this.data.url = urlValue
     }
 
     private extractTokenFromHTML(str: string) {
@@ -55,7 +59,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
             }
         }
 
-        const res = await this.http.get(`${this.data.url}/`, {
+        const res = await this.http.get(this.url(), {
             params: {
                 token: this.data.token,
                 t: Date.now(),
@@ -120,7 +124,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
             return res
         })
 
-        const res = await this.http.get(`${this.url()}/token.html`, {
+        const res = await this.http.get(this.url('token.html'), {
             timeout: HTTP_LOGIN_TIMEOUT,
             params: {
                 t: Date.now(),
@@ -137,9 +141,9 @@ export class UtorrentRuntime implements BittorrentRuntime {
             throw new Error('Failed to authenticate with server')
         }
 
-        this.saveConnection(serverUrl(server), server.user, server.password)
+        this.saveConnection(server.user, server.password)
 
-        const versionResponse = await this.http.get(`${this.data.url}/`, {
+        const versionResponse = await this.http.get(this.url(), {
             params: {
                 token: this.data.token,
                 t: Date.now(),
@@ -166,7 +170,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {
         const uploadLocation = await this.getUploadLocationParams(options)
 
-        await this.http.get(`${this.data.url}/`, {
+        await this.http.get(this.url(), {
             params: {
                 token: this.data.token,
                 t: Date.now(),
@@ -189,7 +193,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
         })
         const uploadLocation = await this.getUploadLocationParams(options)
 
-        await this.http.post(`${this.data.url}/`, formData, {
+        await this.http.post(this.url(), formData, {
             params: {
                 token: this.data.token,
                 action: 'add-file',
@@ -203,7 +207,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
     }
 
     async getSnapshot(): Promise<any> {
-        const res = await this.http.get(`${this.data.url}/`, {
+        const res = await this.http.get(this.url(), {
             params: {
                 token: this.data.token,
                 cid: this.data.cid,
@@ -216,7 +220,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
     }
 
     private doAction(action: string, hashes: string[]): Promise<void> {
-        return this.http.get(`${this.data.url}/`, {
+        return this.http.get(this.url(), {
             params: {
                 action,
                 hash: hashes,
@@ -276,7 +280,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
     }
 
     setLabel(hashes: string[], label: string): Promise<void> {
-        return this.http.get(`${this.data.url}/`, {
+        return this.http.get(this.url(), {
             params: {
                 token: this.data.token,
                 hash: hashes,

--- a/src/main/lib/bittorrent/helpers.ts
+++ b/src/main/lib/bittorrent/helpers.ts
@@ -1,4 +1,5 @@
 import https from "https"
+import { URL } from "node:url"
 import type { BittorrentServerConfig } from "@shared/ipc-contract"
 import type { CallbackFunc } from "./types"
 
@@ -17,14 +18,35 @@ export function defer<T>(fn: (f: CallbackFunc<T>) => void): Promise<T> {
     })
 }
 
-export function cleanPath(pathValue?: string) {
-    const raw = pathValue || ""
-    const trimmed = raw.replace(/^\/+|\/+$/g, "")
-    return trimmed ? `/${trimmed}` : ""
+export function urlPath(...pathValues: Array<string | undefined>) {
+    const path = pathValues
+        .map((pathValue) => (pathValue || "").replace(/^\/+|\/+$/g, ""))
+        .filter(Boolean)
+        .join("/")
+
+    return path ? `/${path}` : ""
 }
 
-export function serverUrl(server: BittorrentServerConfig) {
-    return `${server.proto}://${server.ip}:${server.port}${cleanPath(server.path)}`
+export function serverOriginUrl(server: BittorrentServerConfig) {
+    const url = new URL("http://localhost")
+    url.protocol = `${server.proto.replace(/:$/, "")}:`
+    url.host = `${server.ip.includes(":") && !server.ip.startsWith("[") ? `[${server.ip}]` : server.ip}:${server.port}`
+
+    return url.origin
+}
+
+export function serverUrl(server: BittorrentServerConfig, endpoint?: string) {
+    const url = new URL(serverOriginUrl(server))
+    url.pathname = urlPath(server.path, endpoint) || "/"
+
+    return url.pathname === "/" ? url.origin : url.toString()
+}
+
+export function appendUrlPath(baseUrl: string, endpoint?: string) {
+    const url = new URL(baseUrl)
+    url.pathname = urlPath(url.pathname, endpoint) || "/"
+
+    return url.pathname === "/" ? url.origin : url.toString()
 }
 
 export function createHttpsAgent(server: BittorrentServerConfig) {


### PR DESCRIPTION
Avoids using explicit port 80 for http and 443 for https, which may break virtual host matching in reverse proxies