### PR TITLE
test: run wdio with 4 workers in CI

### DIFF
--- a/test/framework/fixture.ts
+++ b/test/framework/fixture.ts
@@ -13,6 +13,7 @@ export interface TestFixture {
   backend: DockerComposeService
   tracker: DockerComposeService
   proxyPort: number
+  sharedDir: string
   app: App
 }
 
@@ -84,6 +85,10 @@ export function requireFeature(isSupported: (client: TestClient) => boolean) {
 
 export function createUniqueLabel(prefix: string) {
   return `${prefix}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+export function getTorrentFilePath(torrentName = "slow") {
+  return path.join(getTestFixture().sharedDir, `${torrentName}.torrent`)
 }
 
 export function formatBytes(bytes: number, fractionSize = 1) {

--- a/test/framework/service.ts
+++ b/test/framework/service.ts
@@ -1,4 +1,5 @@
-import compose from "docker-compose"
+import compose, { type IDockerComposeOptions } from "docker-compose"
+import fs from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { TEST_CLIENTS, type TestClient } from "../clients"
@@ -12,99 +13,148 @@ interface ElectorrentCapabilities extends WebdriverIO.Capabilities {
   "electorrent:client"?: TestClient
 }
 
+interface ComposeEnvironment {
+  cwd: string
+  options: IDockerComposeOptions
+}
+
 export default class ElectorrentTestService {
-  private composeEnvironments: Array<{ cwd: string, env: NodeJS.ProcessEnv }> = []
-
-  async onPrepare(
-    _config: WebdriverIO.Config,
-    capabilities: ElectorrentCapabilities[],
-  ) {
-    const clients = new Map(
-      capabilities
-        .map((capability) => capability["electorrent:client"])
-        .filter((client): client is TestClient => Boolean(client))
-        .map((client) => [client.key, client]),
-    )
-
-    for (const client of clients.values()) {
-      const { clientIndex, commonEnv, proxyPort, trackerPort } = this.getClientEnvironment(client)
-
-      await this.startCompose(path.join(testDir, "shared", "opentracker"), {
-        ...commonEnv,
-        TRACKER_PORT: String(trackerPort),
-      })
-      await this.startCompose(path.join(testDir, client.fixture), {
-        ...commonEnv,
-        VERSION: client.version,
-        HOST_PORT: String(client.port),
-        RPC_PORT: String(52000 + clientIndex),
-        PEER_PORT: String(53000 + clientIndex),
-        PEER_UDP_PORT: String(54000 + clientIndex),
-      })
-      await waitForHttp({
-        url: `http://${client.host}:${client.port}`,
-        statusCode: client.acceptHttpStatus,
-      })
-      await this.startCompose(path.join(testDir, "shared", "nginx"), {
-        ...commonEnv,
-        HOST_PORT: String(proxyPort),
-        PROXY_HOST: path.basename(client.fixture),
-        PROXY_PORT: String(client.proxyPort ?? client.containerPort),
-      })
-    }
-  }
+  private composeEnvironments: ComposeEnvironment[] = []
 
   async beforeSession(
     _config: WebdriverIO.Config,
     capabilities: ElectorrentCapabilities,
+    _specs: string[],
+    cid = process.env.WDIO_WORKER_ID ?? "0-0",
   ) {
     const client = capabilities["electorrent:client"]
     if (!client) {
       return
     }
 
-    const { commonEnv, proxyPort, trackerPort } = this.getClientEnvironment(client)
+    const workerIndex = this.getWorkerIndex(cid)
+    const { backendPort, commonEnv, composeOptions, proxyPort, sharedDir, trackerPort } = this.getClientEnvironment(
+      client,
+      workerIndex,
+    )
+
+    await this.startClientEnvironment(client, workerIndex)
 
     initializeTestFixture({
-      client,
-      backend: new DockerComposeService(path.join(testDir, client.fixture), {}, { env: commonEnv }),
+      client: { ...client, port: backendPort },
+      backend: new DockerComposeService(path.join(testDir, client.fixture), {}, { env: commonEnv, composeOptions }),
       tracker: new DockerComposeService(
         path.join(testDir, "shared", "opentracker"),
         { serviceName: "peer" },
-        { env: { ...commonEnv, TRACKER_PORT: String(trackerPort) } },
+        { env: { ...commonEnv, SHARED_DIR: sharedDir, TRACKER_PORT: String(trackerPort) }, composeOptions },
       ),
       proxyPort,
+      sharedDir,
     })
   }
 
-  async onComplete() {
-    if (!process.env.MOCHA_DOCKER_CLEANUP) {
-      return
-    }
-    for (const options of [...this.composeEnvironments].reverse()) {
-      await compose.downAll({ ...options, log: false })
-    }
+  async afterSession() {
+    await this.stopComposeEnvironments()
   }
 
-  private getClientEnvironment(client: TestClient) {
+  async onComplete() {
+    await this.stopComposeEnvironments()
+  }
+
+  private async startClientEnvironment(client: TestClient, workerIndex: number) {
+    const { backendPort, commonEnv, composeOptions, proxyPort, sharedDir, trackerPort } = this.getClientEnvironment(
+      client,
+      workerIndex,
+    )
+
+    const trackerEnv = {
+      ...commonEnv,
+      SHARED_DIR: sharedDir,
+      TRACKER_PORT: String(trackerPort),
+    }
+    const clientEnv = {
+      ...commonEnv,
+      VERSION: client.version,
+      HOST_PORT: String(backendPort),
+      RPC_PORT: String(52000 + this.getPortOffset(client, workerIndex)),
+      PEER_PORT: String(53000 + this.getPortOffset(client, workerIndex)),
+      PEER_UDP_PORT: String(54000 + this.getPortOffset(client, workerIndex)),
+    }
+    const nginxEnv = {
+      ...commonEnv,
+      HOST_PORT: String(proxyPort),
+      PROXY_HOST: path.basename(client.fixture),
+      PROXY_PORT: String(client.proxyPort ?? client.containerPort),
+    }
+    const trackerDir = path.join(testDir, "shared", "opentracker")
+    const clientDir = path.join(testDir, client.fixture)
+    const nginxDir = path.join(testDir, "shared", "nginx")
+
+    await this.stopCompose(nginxDir, nginxEnv, composeOptions)
+    await this.stopCompose(clientDir, clientEnv, composeOptions)
+    await this.stopCompose(trackerDir, trackerEnv, composeOptions)
+
+    fs.rmSync(sharedDir, { recursive: true, force: true })
+    fs.mkdirSync(sharedDir, { recursive: true })
+
+    await this.startCompose(trackerDir, trackerEnv, composeOptions)
+    await this.startCompose(clientDir, clientEnv, composeOptions)
+    await waitForHttp({
+      url: `http://${client.host}:${backendPort}`,
+      statusCode: client.acceptHttpStatus,
+    })
+    await this.startCompose(nginxDir, nginxEnv, composeOptions)
+  }
+
+  private getClientEnvironment(client: TestClient, workerIndex: number) {
     const suffix = client.key.replace(/[^a-z0-9]+/gi, "-").toLowerCase()
-    const clientIndex = Object.keys(TEST_CLIENTS).indexOf(client.key)
-    const networkName = `electorrent-p2p-${suffix}`
-    const proxyPort = 50000 + clientIndex
-    const trackerPort = 51000 + clientIndex
+    const projectName = `electorrent-${suffix}-worker-${workerIndex}`
+    const networkName = `${projectName}-p2p`
+    const portOffset = this.getPortOffset(client, workerIndex)
+    const proxyPort = 50000 + portOffset
+    const trackerPort = 51000 + portOffset
+    const backendPort = 55000 + portOffset
     const commonEnv = {
       ...process.env,
-      COMPOSE_PROJECT_NAME: `electorrent-${suffix}`,
       NETWORK_NAME: networkName,
     }
+    const composeOptions = ["--project-name", projectName]
+    const sharedDir = path.join(testDir, "shared", "opentracker", "data", projectName)
 
-    return { clientIndex, commonEnv, proxyPort, trackerPort }
+    return { backendPort, commonEnv, composeOptions, proxyPort, sharedDir, trackerPort }
   }
 
-  private async startCompose(cwd: string, env: NodeJS.ProcessEnv) {
-    const options = { cwd, env, log: false }
-    await compose.downAll({ ...options, commandOptions: ["--volumes"] })
+  private getPortOffset(client: TestClient, workerIndex: number) {
+    const clientIndex = Object.keys(TEST_CLIENTS).indexOf(client.key)
+
+    return (clientIndex * 100) + workerIndex
+  }
+
+  private getWorkerIndex(cid: string) {
+    const cidParts = cid.split("-")
+    const workerIndex = Number(cidParts[cidParts.length - 1])
+
+    if (Number.isInteger(workerIndex) && workerIndex >= 0) {
+      return workerIndex
+    }
+
+    return 0
+  }
+
+  private async startCompose(cwd: string, env: NodeJS.ProcessEnv, composeOptions: string[]) {
+    const options = { cwd, env, composeOptions, log: false }
     await compose.upAll(options)
-    this.composeEnvironments.push({ cwd, env })
+    this.composeEnvironments.push({ cwd, options })
+  }
+
+  private async stopCompose(cwd: string, env: NodeJS.ProcessEnv, composeOptions: string[]) {
+    await compose.downAll({ cwd, env, composeOptions, commandOptions: ["--volumes"], log: false })
+  }
+
+  private async stopComposeEnvironments() {
+    for (const { options } of [...this.composeEnvironments].reverse()) {
+      await compose.downAll({ ...options, commandOptions: ["--volumes"], log: false })
+    }
+    this.composeEnvironments = []
   }
 }

--- a/test/shared/opentracker/docker-compose.yml
+++ b/test/shared/opentracker/docker-compose.yml
@@ -4,7 +4,7 @@ x-peer: &peer
   networks:
     - p2p
   volumes:
-    - ./data/shared:/shared
+    - ${SHARED_DIR:-./data/shared}:/shared
   tmpfs:
     - /srv
   entrypoint: ["/start"]

--- a/test/specs/settings.spec.ts
+++ b/test/specs/settings.spec.ts
@@ -1,13 +1,10 @@
 import chai from "chai"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import { $, browser } from "@wdio/globals"
 import * as e2e from "../e2e"
-import { configureSpec } from "../framework/fixture"
+import { configureSpec, getTorrentFilePath } from "../framework/fixture"
 import { restartApplication } from "../shared"
 
 const assert: Chai.AssertStatic = chai.assert
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 describe("settings", function () {
   configureSpec()
 
@@ -106,7 +103,7 @@ describe("settings", function () {
   })
 
   it("can enable always ask for upload options", async function () {
-    const torrentFile = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const torrentFile = getTorrentFilePath()
     let torrent: e2e.Torrent | undefined
 
     await this.app.settingsGotoTab("general")

--- a/test/specs/torrent-actions.spec.ts
+++ b/test/specs/torrent-actions.spec.ts
@@ -1,16 +1,14 @@
 import chai from "chai"
 import fs from "node:fs"
 import path from "node:path"
-import { fileURLToPath } from "node:url"
 import parseTorrent from "parse-torrent"
 import { $ } from "@wdio/globals"
 import * as e2e from "../e2e"
 import { waitForModalClose } from "../e2e/modal"
 import { createTorrentFile } from "../torrent"
-import { configureSpec, createUniqueLabel, getTestFixture } from "../framework/fixture"
+import { configureSpec, createUniqueLabel, getTestFixture, getTorrentFilePath } from "../framework/fixture"
 
 const { assert } = chai
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const fixture = getTestFixture()
 const client = fixture.client
 const backend = fixture.backend
@@ -22,7 +20,7 @@ describe("torrent actions", function () {
   let torrent: e2e.Torrent
 
   before(async function () {
-    const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const filename = getTorrentFilePath()
     torrent = await this.app.uploadTorrent({ filename })
     await torrent.waitForExist()
   })

--- a/test/specs/torrent-details.spec.ts
+++ b/test/specs/torrent-details.spec.ts
@@ -1,12 +1,8 @@
 import fs from "node:fs"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import parseTorrent from "parse-torrent"
 import { browser } from "@wdio/globals"
 import * as e2e from "../e2e"
-import { configureSpec, formatBytes, requireFeature } from "../framework/fixture"
-
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+import { configureSpec, formatBytes, getTorrentFilePath, requireFeature } from "../framework/fixture"
 describe("torrent details", function () {
   configureSpec()
   requireFeature(({ features }) => features.torrentDetails === true)
@@ -15,7 +11,7 @@ describe("torrent details", function () {
   let torrentMetadata: parseTorrent.Instance
 
   before(async function () {
-    const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const filename = getTorrentFilePath()
     torrentMetadata = parseTorrent(fs.readFileSync(filename)) as parseTorrent.Instance
     torrent = await this.app.uploadTorrent({ filename })
     await torrent.waitForExist()

--- a/test/specs/torrent-file-selection.spec.ts
+++ b/test/specs/torrent-file-selection.spec.ts
@@ -1,12 +1,8 @@
 import chai from "chai"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import { $ } from "@wdio/globals"
 import * as e2e from "../e2e"
 import { waitForModalClose, waitForModalOpen } from "../e2e/modal"
-import { configureSpec, requireFeature } from "../framework/fixture"
-
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+import { configureSpec, getTorrentFilePath, requireFeature } from "../framework/fixture"
 
 describe("torrent file selection", function () {
   configureSpec()
@@ -15,7 +11,7 @@ describe("torrent file selection", function () {
   let torrent: e2e.Torrent
 
   before(async function () {
-    const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const filename = getTorrentFilePath()
     torrent = await this.app.uploadTorrent({ filename })
     await torrent.waitForExist()
   })

--- a/test/specs/torrent-labels.spec.ts
+++ b/test/specs/torrent-labels.spec.ts
@@ -1,9 +1,5 @@
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import * as e2e from "../e2e"
-import { configureSpec, createUniqueLabel, requireFeature } from "../framework/fixture"
-
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+import { configureSpec, createUniqueLabel, getTorrentFilePath, requireFeature } from "../framework/fixture"
 
 describe("torrent labels", function () {
   configureSpec()
@@ -15,7 +11,7 @@ describe("torrent labels", function () {
   let torrent: e2e.Torrent
 
   before(async function () {
-    const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const filename = getTorrentFilePath()
     torrent = await this.app.uploadTorrent({ filename })
     await torrent.waitForExist()
     initialLabelCount = (await this.app.getAllSidebarLabels()).length

--- a/test/specs/torrent-uploads.spec.ts
+++ b/test/specs/torrent-uploads.spec.ts
@@ -1,10 +1,6 @@
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import * as e2e from "../e2e"
-import { configureSpec, getTestFixture, requireFeature } from "../framework/fixture"
+import { configureSpec, getTestFixture, getTorrentFilePath, requireFeature } from "../framework/fixture"
 import { restartApplication } from "../shared"
-
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const fixture = getTestFixture()
 const client = fixture.client
 
@@ -14,7 +10,7 @@ describe("torrent uploads", function () {
   describe("torrent file uploads", function () {
     let torrent: e2e.Torrent
     before(async function () {
-      const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+      const filename = getTorrentFilePath()
       torrent = await this.app.uploadTorrent({ filename })
     })
 
@@ -44,7 +40,7 @@ describe("torrent uploads", function () {
 
     before(async function () {
       await restartApplication(this)
-      const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+      const filename = getTorrentFilePath()
       torrent = await this.app.uploadMagnetLink({ filename })
     })
 

--- a/test/torrent.ts
+++ b/test/torrent.ts
@@ -1,8 +1,6 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { DockerComposeService } from "./shared/compose";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+import { getTestFixture } from "./framework/fixture";
 
 /**
  * Create a torrent file in the tracker service.
@@ -35,6 +33,5 @@ export async function createTorrentFile(tracker: DockerComposeService, options: 
         cmd.push("--tracker-url", options.trackerUrl);
     }
     await tracker.exec(cmd);
-    const torrentPath = path.join(__dirname, `shared/opentracker/data/shared/${torrentName}.torrent`)
-    return torrentPath;
+    return path.join(getTestFixture().sharedDir, `${torrentName}.torrent`);
 }

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -105,8 +105,8 @@ export const config: WebdriverIO.Config = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxInstances: 1,
-    maxInstancesPerCapability: 1,
+    maxInstances: 4,
+    maxInstancesPerCapability: 4,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:


### PR DESCRIPTION
## Summary
- Configure WDIO to run up to 4 concurrent workers
- Start Docker Compose fixtures per WDIO worker with unique Compose project names
- Allocate worker-specific host ports and clean worker Compose projects

## Validation
- Not run locally per request; awaiting GitHub Actions