### PR TITLE
fix: sync torrents after user mutations

### DIFF
--- a/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.controller.ts
+++ b/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.controller.ts
@@ -1,8 +1,9 @@
-import { IRootScopeService, IScope } from "angular";
+import { IRootScopeService } from "angular";
 import { TorrentFile } from "@renderer/app/bittorrent/abstracttorrent";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
+import type { TorrentFilesModalScope as TorrentFilesModalDirectiveScope } from "./torrent-files-modal.directive";
 
-export interface TorrentFilesModalScope extends IScope {
+export interface TorrentFilesModalScope extends TorrentFilesModalDirectiveScope {
   torrent: any;
   files: TorrentFile[];
   loading: boolean;
@@ -105,6 +106,7 @@ export class TorrentFilesModalController {
     try {
       this.scope.loading = true;
       await this.rootScope.$btclient.setTorrentFileSelection(torrent, files);
+      await this.scope.onSaved?.();
       this.close();
     } catch (err) {
       this.scope.error = err && err.message ? err.message : "Failed to save selection";

--- a/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.directive.ts
+++ b/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.directive.ts
@@ -2,10 +2,15 @@ import { IDirective, IDirectiveFactory } from "angular";
 import { TorrentFilesModalController } from "./torrent-files-modal.controller";
 import html from "./torrent-files-modal.template.html";
 
+export interface TorrentFilesModalScope extends angular.IScope {
+  onSaved?: () => Promise<void> | void;
+}
+
 export class TorrentFilesModalDirective implements IDirective {
   template = html;
   restrict = "E";
   scope = {
+    onSaved: "<",
   };
   controller = TorrentFilesModalController;
   controllerAs = "ctl";

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -229,6 +229,7 @@ export class TorrentsPageController {
         $scope.uploadTorrent = async (torrent: Uint8Array, filename: string, options?: TorrentUploadOptions, sourcePath?: string) => {
             try {
                 await $rootScope.$btclient?.uploadTorrent(torrent, filename, options, sourcePath);
+                await syncAfterTorrentMutation();
             } catch (e) {
                 $notify.alert("Could not upload torrent", "The torrent could not be uploaded to the server");
                 console.error(e);
@@ -238,6 +239,7 @@ export class TorrentsPageController {
         $scope.uploadTorrentURL = async (uri: string, options?: TorrentUploadOptions) => {
             try {
                 await $rootScope.$btclient?.addTorrentUrl(uri, options);
+                await syncAfterTorrentMutation();
             } catch (err) {
                 $notify.alert("Upload failed", "The torrent link could not be uploaded");
                 console.error(err);
@@ -261,7 +263,7 @@ export class TorrentsPageController {
         });
 
         $scope.$on("torrentLocation:updated", () => {
-            $scope.update();
+            syncAfterTorrentMutation();
         });
 
         function clearDeleteConfirmation() {
@@ -278,6 +280,13 @@ export class TorrentsPageController {
 
         function syncDetailsPanel() {
             $rootScope.$emit("torrentDetails:sync", getCurrentSelectedTorrent());
+        }
+
+        function syncAfterTorrentMutation() {
+            return $scope.update().catch((err: unknown) => {
+                console.error("Torrent sync error", err);
+                $notify.alert("Refresh failed", "The torrent list could not be refreshed");
+            });
         }
 
         function openDeleteConfirmation(action: (torrents: any[]) => Promise<void>, label: string) {
@@ -315,7 +324,7 @@ export class TorrentsPageController {
 
             return action.call($rootScope.$btclient, torrents)
                 .then(() => {
-                    return $scope.update();
+                    return syncAfterTorrentMutation();
                 })
                 .catch((err: unknown) => {
                     console.error("Context action error", err);
@@ -334,7 +343,14 @@ export class TorrentsPageController {
 
         function remove() {
             const selectedTorrents = $scope.arrayTorrents.filter(({ selected: isSelected }: { selected: boolean }) => isSelected);
-            $rootScope.$btclient?.deleteTorrents(selectedTorrents);
+            return $rootScope.$btclient?.deleteTorrents(selectedTorrents)
+                .then(() => {
+                    return syncAfterTorrentMutation();
+                })
+                .catch((err: unknown) => {
+                    console.error("Remove torrents error", err);
+                    $notify.alert("Invalid action", "The action could not be performed because the server responded with a faulty reply");
+                });
         }
 
         function selectAll() {
@@ -562,12 +578,16 @@ export class TorrentsPageController {
         $scope.doAction = (action: any, name: string, data: any, ...args: any[]) => {
             return action.call($rootScope.$btclient, selected, data, ...args)
                 .then(() => {
-                    return $scope.update();
+                    return syncAfterTorrentMutation();
                 })
                 .catch((err: unknown) => {
                     console.error("Action error", err);
                     $notify.alert("Invalid action", "The action could not be performed because the server responded with a faulty reply");
                 });
+        };
+
+        $scope.syncAfterTorrentMutation = () => {
+            return syncAfterTorrentMutation();
         };
 
         $scope.doContextAction = (action: any, label: string, item: any) => {

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -277,6 +277,6 @@
         upload-torrent-url-action="uploadTorrentURL">
     </add-torrent-modal>
 
-    <torrent-files-modal></torrent-files-modal>
+    <torrent-files-modal on-saved="syncAfterTorrentMutation"></torrent-files-modal>
     <set-location-modal></set-location-modal>
 </div>


### PR DESCRIPTION
## Summary
- Refresh the torrent list immediately after successful user-initiated torrent mutations.
- Wire upload, URL upload, menu/shortcut remove, set-location, and file-selection save paths through a shared post-mutation sync.
- Add a direct `onSaved` callback from the torrent files modal instead of introducing a new sync event.

## Root Cause
Some mutation paths completed their torrent client side effect but waited for the next polling cycle before updating the renderer, so users could see stale torrent rows after uploads, edits, or removals.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --suite "qbittorrent:latest" --mochaOpts.grep "torrent actions|torrent file selection|torrent uploads"`

Note: the targeted test command initially hit the sandbox when binding Electron debug ports on `127.0.0.1`; rerunning with local port access passed.