### PR TITLE
test: assert non-empty values in torrent-columns spec

### DIFF
--- a/src/main/lib/bittorrent/clients/rtorrent/helpers.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/helpers.ts
@@ -45,6 +45,7 @@ export const rtorrentFields = {
         left_bytes: "d.left_bytes",
         label: "d.custom1",
         addtime: "d.custom=addtime",
+        loadDate: "d.load_date",
     },
 }
 

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -218,6 +218,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
             peers: "d.peers_accounted",
             seeds: "d.peers_complete",
             additionDate: ["d.custom", "addtime"],
+            loadDate: "d.load_date",
         }
         const numericDetailFields = [
             "totalSize",
@@ -232,6 +233,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
             "peers",
             "seeds",
             "additionDate",
+            "loadDate",
         ] as const
         const fileCommands = {
             path: "f.path",
@@ -267,7 +269,8 @@ export class RtorrentRuntime implements BittorrentRuntime {
         const message = typeof detailFields.message === "string" ? detailFields.message : null
         const peers = typeof detailFields.peers === "number" ? detailFields.peers : null
         const seeds = typeof detailFields.seeds === "number" ? detailFields.seeds : null
-        const additionDate = typeof detailFields.additionDate === "number" ? detailFields.additionDate : null
+        const loadDate = typeof detailFields.loadDate === "number" ? detailFields.loadDate : null
+        const additionDate = typeof detailFields.additionDate === "number" && detailFields.additionDate > 0 ? detailFields.additionDate : loadDate
         const ratio = totalDownloaded > 0 ? totalUploaded / totalDownloaded : null
 
         return {

--- a/src/renderer/app/bittorrent/rtorrent/torrentr.ts
+++ b/src/renderer/app/bittorrent/rtorrent/torrentr.ts
@@ -2,6 +2,14 @@ import {Torrent} from "@renderer/app/bittorrent/abstracttorrent";
 
 export class RtorrentTorrent extends Torrent {
 
+    private static normalizeEpochMilliseconds(...timestamps: any[]) {
+        const timestamp = timestamps
+            .map((value) => Number(value))
+            .find((value) => Number.isFinite(value) && value > 0)
+
+        return timestamp ? timestamp * 1000 : undefined
+    }
+
     active: boolean;
     checked: boolean;
     checking: boolean;
@@ -31,7 +39,7 @@ export class RtorrentTorrent extends Torrent {
             seedsInSwarm: data.seeders_total, /* Seeds In Swarm (integer): number of connected seeds in swarm */
             torrentQueueOrder: undefined, /* Queue (integer): the number in the download queue */
             statusMessage: undefined, /* Status (string): the current status of the torrent (e.g. downloading)  */
-            dateAdded: data.addtime * 1000, /* Date Added (integer): number of milliseconds unix time */
+            dateAdded: RtorrentTorrent.normalizeEpochMilliseconds(data.addtime, data.loadDate), /* Date Added (integer): number of milliseconds unix time */
             dateCompleted: data.completedAt > 0 ? data.completedAt * 1000 : undefined, /* Date Completed (integer): number of milliseconds unix time */
             savePath: data.directory, /* Save Path (string): the path at which the downloaded content is saved */
         });

--- a/src/renderer/app/directives/progress/progress.controller.ts
+++ b/src/renderer/app/directives/progress/progress.controller.ts
@@ -7,7 +7,7 @@ export class ProgressController {
 
     label() {
         let label = this.torrent.statusText();
-        if (this.torrent.isStatusDownloading()) {
+        if (this.torrent.isStatusDownloading() || this.torrent.isStatusCompleted() || this.torrent.isStatusSeeding()) {
             label += ` ${this.torrent.getPercentStr()}`;
         }
 

--- a/test/specs/torrent-columns.spec.ts
+++ b/test/specs/torrent-columns.spec.ts
@@ -27,9 +27,9 @@ const builtInColumns = [
   "Ratio",
 ]
 
-const dateIsSensible = (value: string) => !/1969|1970/.test(value)
-const completedDateIsSensible = (value: string) => value.length > 0 && dateIsSensible(value)
+const dateIsSensible = (value: string) => value.length > 0 && !/1969|1970/.test(value)
 const decodeTorrentName = (name: string) => name.replace(/[._]/g, " ").replace(/(\[[^\]]*\])(.*)$/, "$2 $1").trim()
+const totalPeers = (value: string) => Number(value.match(/^\d+ of (\d+)$/)?.[1] ?? 0)
 
 function assertSpeed(value: string) {
   assert.match(value, /^\d+(?:\.\d+)? [KMGT]?B\/s$/)
@@ -89,10 +89,24 @@ describe("torrent columns", function () {
   })
 
   it("shows a sensible Peers column value", async function () {
+    await browser.waitUntil(async () => {
+      return totalPeers((await torrent.getColumn("peersConnected")).trim()) > 0
+    }, {
+      timeout: 20 * 1000,
+      timeoutMsg: "Peers column did not show a positive total peer count",
+    })
+
     assert.match((await torrent.getColumn("peersConnected")).trim(), /^\d+ of \d+$/)
   })
 
   it("shows a sensible Seeds column value", async function () {
+    await browser.waitUntil(async () => {
+      return totalPeers((await torrent.getColumn("seedsConnected")).trim()) > 0
+    }, {
+      timeout: 20 * 1000,
+      timeoutMsg: "Seeds column did not show a positive total seed count",
+    })
+
     assert.match((await torrent.getColumn("seedsConnected")).trim(), /^\d+ of \d+$/)
   })
 
@@ -128,13 +142,22 @@ describe("torrent columns", function () {
       return dateIsSensible((await torrent.getColumn("dateAdded")).trim())
     }, {
       timeout: 20 * 1000,
-      timeoutMsg: "Date Added column did not show a sensible date",
+      timeoutMsg: "Date Added column did not show a non-empty sensible date",
+    })
+  })
+
+  it("shows 100.0% progress when a torrent finishes", async function () {
+    await browser.waitUntil(async () => {
+      return (await torrent.getColumn("percent")).includes("100.0%")
+    }, {
+      timeout: 20 * 1000,
+      timeoutMsg: "Progress column did not show 100.0% for the finished torrent",
     })
   })
 
   it("shows Date Completed when a torrent finishes", async function () {
     await browser.waitUntil(async () => {
-      return completedDateIsSensible((await torrent.getColumn("dateCompleted")).trim())
+      return dateIsSensible((await torrent.getColumn("dateCompleted")).trim())
     }, {
       timeout: 20 * 1000,
       timeoutMsg: "Date Completed column did not show a completion date for the finished torrent",


### PR DESCRIPTION
## Summary
- Assert torrent column values are non-empty/sensible.
- Use rTorrent `d.load_date` as the fallback source for Date Added when `d.custom=addtime` is unavailable.
- Apply the same fallback to rTorrent torrent details addition date.

## Validation
- npm run lint
- npm run build
- npm run test -- --client rtorrent --spec torrent-columns.spec.ts --mochaOpts.grep "shows a sensible Date Added column value"