### PR TITLE
feat: add alternative speed limits toggle

### DIFF
--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
@@ -149,6 +149,26 @@ export class QBittorrentApiV1 extends QBittorrentBaseApi {
         this.post("command/addCategory", { form: { category } }, (err, res, body) => this.handleError(cb)(err, res, body))
     }
 
+    getSpeedLimitsMode(cb: (err?: any, enabled?: boolean) => void) {
+        this.get("query/alternativeSpeedLimits", {}, (err, res, body) => {
+            this.handleError((actionErr, mode) => cb(actionErr, String(mode).trim() === "1"))(err, res, body)
+        })
+    }
+
+    setSpeedLimitsMode(enabled: boolean, cb: (err?: any, body?: any) => void) {
+        this.getSpeedLimitsMode((modeErr, current) => {
+            if (modeErr) {
+                cb(modeErr)
+                return
+            }
+            if (current === enabled) {
+                cb()
+                return
+            }
+            this.post("command/alternativeSpeedLimits", {}, (err, res, body) => this.handleError(cb)(err, res, body))
+        })
+    }
+
     toggleSequentialDownload(hashes: string[], cb: (err?: any, body?: any) => void) {
         this.performPostAction("toggleSequentialDownload", hashes, {}, cb)
     }

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
@@ -142,6 +142,18 @@ export class QBittorrentApiV2 extends QBittorrentBaseApi {
         this.post("torrents/createCategory", { form: { category, savePath } }, cb)
     }
 
+    getSpeedLimitsMode(cb: (err?: any, enabled?: boolean) => void) {
+        this.get("transfer/speedLimitsMode", {}, (err, res, body) => {
+            this.handleError((actionErr, mode) => cb(actionErr, String(mode).trim() === "1"))(err, res, body)
+        })
+    }
+
+    setSpeedLimitsMode(enabled: boolean, cb: (err?: any, body?: any) => void) {
+        this.post("transfer/setSpeedLimitsMode", { form: { mode: enabled ? "1" : "0" } }, (err, res, body) => {
+            this.handleError(cb)(err, res, body)
+        })
+    }
+
     toggleSequentialDownload(hashes: string[], cb: (err?: any, body?: any) => void) {
         this.performPostAction("toggleSequentialDownload", hashes, {}, cb)
     }

--- a/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
@@ -174,5 +174,9 @@ export abstract class QBittorrentBaseApi {
 
     abstract createCategory(category: string, savePath: string, cb: (err?: any, body?: any) => void): void
 
+    abstract getSpeedLimitsMode(cb: (err?: any, enabled?: boolean) => void): void
+
+    abstract setSpeedLimitsMode(enabled: boolean, cb: (err?: any, body?: any) => void): void
+
     abstract toggleSequentialDownload(hashes: string[], cb: (err?: any, body?: any) => void): void
 }

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -82,6 +82,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 setLocation: true,
                 torrentDetails: true,
                 trackerFilter: true,
+                alternativeSpeedLimits: true,
                 uploadOptions: {
                     saveLocation: true,
                     renameTorrent: true,
@@ -117,6 +118,10 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         this.removeDeletedTorrentHashes(data?.torrents_removed, changedTrackerHashes)
         this.mergeTorrentCache(data)
         this.prepareTrackerData(data, changedTrackerHashes)
+
+        if (data?.server_state && data.server_state.use_alt_speed_limits === undefined) {
+            data.server_state.use_alt_speed_limits = await defer<boolean>((done) => api.getSpeedLimitsMode(done))
+        }
 
         return data
     }
@@ -293,6 +298,11 @@ export class QBittorrentRuntime implements BittorrentRuntime {
     pauseAll(): Promise<void> {
         const api = this.getApi()
         return defer((done) => api.pauseAll(done))
+    }
+
+    setAlternativeSpeedLimitsMode(_hashes: string[], enabled: boolean): Promise<void> {
+        const api = this.getApi()
+        return defer((done) => api.setSpeedLimitsMode(enabled, done))
     }
 
     recheck(hashes: string[]): Promise<void> {

--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -51,6 +51,10 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
         torrents.freeDiskSpace = data.server_state.free_space_on_disk ?? null;
       }
 
+      if (data?.server_state?.use_alt_speed_limits !== undefined) {
+        torrents.alternativeSpeedLimitsEnabled = data.server_state.use_alt_speed_limits === true || data.server_state.use_alt_speed_limits === 1;
+      }
+
       if (Array.isArray(data.categories) || Array.isArray(data.labels)) {
         torrents.labels = data.categories || data.labels;
       } else if (typeof data.categories === "object") {
@@ -102,6 +106,10 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
 
     pauseAll(): Promise<void> {
       return invokeAction("pauseAll");
+    };
+
+    setAlternativeSpeedLimitsMode(enabled: boolean): Promise<void> {
+      return invokeAction("setAlternativeSpeedLimitsMode", [], enabled);
     };
 
     recheck(torrents: Torrent[]): Promise<void> {

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -20,6 +20,7 @@ export interface TorrentUpdates {
     dirty?: boolean,
     trackers?: any[],
     freeDiskSpace?: number | null,
+    alternativeSpeedLimitsEnabled?: boolean,
 }
 
 /**
@@ -51,6 +52,7 @@ const DEFAULT_FEATURES: ResolvedTorrentClientFeatures = Object.freeze({
     setLocation: false,
     torrentDetails: false,
     trackerFilter: false,
+    alternativeSpeedLimits: false,
     uploadOptions: DEFAULT_UPLOAD_OPTIONS,
 })
 
@@ -304,6 +306,13 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
             throw new Error("Set location not supported for this client")
         }
         return Promise.reject(new Error("Set location not implemented for this client"))
+    }
+
+    async setAlternativeSpeedLimitsMode(_enabled: boolean): Promise<void> {
+        if (!this.features.alternativeSpeedLimits) {
+            throw new Error("Alternative speed limits not supported for this client")
+        }
+        return Promise.reject(new Error("Alternative speed limits not implemented for this client"))
     }
 
     async getTorrentDetails(torrent: T): Promise<TorrentDetailsPanelData> {

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -34,6 +34,7 @@ export class TorrentsPageController {
         let lastSelected: any = null;
         let timeout: angular.IPromise<void> | undefined;
         let reconnect: angular.IPromise<void> | undefined;
+        let alternativeSpeedLimitsPopupTimeout: angular.IPromise<void> | undefined;
         let deferredUploads: Array<{ item: PendingTorrentUploadItem; askUploadOptions: boolean }> = [];
 
         let settings = settingsService.getAllSettings();
@@ -49,6 +50,7 @@ export class TorrentsPageController {
         $scope.totalUploaded = 0;
         $scope.freeDiskSpace = null;
         $scope.alternativeSpeedLimitsEnabled = false;
+        $scope.alternativeSpeedLimitsPopupMessage = "";
         $scope.contextMenu = null;
         $scope.showDragAndDrop = false;
         $scope.labelsDrowdown = null;
@@ -288,6 +290,20 @@ export class TorrentsPageController {
                 console.error("Torrent sync error", err);
                 $notify.alert("Refresh failed", "The torrent list could not be refreshed");
             });
+        }
+
+        function showAlternativeSpeedLimitsPopup() {
+            if (alternativeSpeedLimitsPopupTimeout) {
+                $timeout.cancel(alternativeSpeedLimitsPopupTimeout);
+            }
+
+            $scope.alternativeSpeedLimitsPopupMessage = $scope.alternativeSpeedLimitsEnabled
+                ? "Alternative rate limits enabled"
+                : "Alternative rate limits disabled";
+            alternativeSpeedLimitsPopupTimeout = $timeout(() => {
+                $scope.alternativeSpeedLimitsPopupMessage = "";
+                alternativeSpeedLimitsPopupTimeout = undefined;
+            }, 2000);
         }
 
         function openDeleteConfirmation(action: (torrents: any[]) => Promise<void>, label: string) {
@@ -594,6 +610,7 @@ export class TorrentsPageController {
         $scope.setAlternativeSpeedLimitsMode = (enabled: boolean) => {
             return $rootScope.$btclient.setAlternativeSpeedLimitsMode(enabled)
                 .then(() => syncAfterTorrentMutation())
+                .then(() => showAlternativeSpeedLimitsPopup())
                 .catch((err: unknown) => {
                     console.error("Alternative speed limits error", err);
                     $notify.alert("Invalid action", "The alternative rate limits mode could not be changed");

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -48,6 +48,7 @@ export class TorrentsPageController {
         $scope.totalDownloaded = 0;
         $scope.totalUploaded = 0;
         $scope.freeDiskSpace = null;
+        $scope.alternativeSpeedLimitsEnabled = false;
         $scope.contextMenu = null;
         $scope.showDragAndDrop = false;
         $scope.labelsDrowdown = null;
@@ -590,6 +591,15 @@ export class TorrentsPageController {
             return syncAfterTorrentMutation();
         };
 
+        $scope.setAlternativeSpeedLimitsMode = (enabled: boolean) => {
+            return $rootScope.$btclient.setAlternativeSpeedLimitsMode(enabled)
+                .then(() => syncAfterTorrentMutation())
+                .catch((err: unknown) => {
+                    console.error("Alternative speed limits error", err);
+                    $notify.alert("Invalid action", "The alternative rate limits mode could not be changed");
+                });
+        };
+
         $scope.doContextAction = (action: any, label: string, item: any) => {
             if (item && item.id === "torrent-details") {
                 const currentTorrent = getCurrentSelectedTorrent();
@@ -799,6 +809,9 @@ export class TorrentsPageController {
                 updateTrackers(torrents);
                 if (Object.prototype.hasOwnProperty.call(torrents, "freeDiskSpace")) {
                     $scope.freeDiskSpace = torrents.freeDiskSpace ?? null;
+                }
+                if (Object.prototype.hasOwnProperty.call(torrents, "alternativeSpeedLimitsEnabled")) {
+                    $scope.alternativeSpeedLimitsEnabled = torrents.alternativeSpeedLimitsEnabled === true;
                 }
             }).then(() => {
                 syncDetailsPanel();

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -34,7 +34,6 @@ export class TorrentsPageController {
         let lastSelected: any = null;
         let timeout: angular.IPromise<void> | undefined;
         let reconnect: angular.IPromise<void> | undefined;
-        let alternativeSpeedLimitsPopupTimeout: angular.IPromise<void> | undefined;
         let deferredUploads: Array<{ item: PendingTorrentUploadItem; askUploadOptions: boolean }> = [];
 
         let settings = settingsService.getAllSettings();
@@ -50,7 +49,6 @@ export class TorrentsPageController {
         $scope.totalUploaded = 0;
         $scope.freeDiskSpace = null;
         $scope.alternativeSpeedLimitsEnabled = false;
-        $scope.alternativeSpeedLimitsPopupMessage = "";
         $scope.contextMenu = null;
         $scope.showDragAndDrop = false;
         $scope.labelsDrowdown = null;
@@ -290,20 +288,6 @@ export class TorrentsPageController {
                 console.error("Torrent sync error", err);
                 $notify.alert("Refresh failed", "The torrent list could not be refreshed");
             });
-        }
-
-        function showAlternativeSpeedLimitsPopup() {
-            if (alternativeSpeedLimitsPopupTimeout) {
-                $timeout.cancel(alternativeSpeedLimitsPopupTimeout);
-            }
-
-            $scope.alternativeSpeedLimitsPopupMessage = $scope.alternativeSpeedLimitsEnabled
-                ? "Alternative rate limits enabled"
-                : "Alternative rate limits disabled";
-            alternativeSpeedLimitsPopupTimeout = $timeout(() => {
-                $scope.alternativeSpeedLimitsPopupMessage = "";
-                alternativeSpeedLimitsPopupTimeout = undefined;
-            }, 2000);
         }
 
         function openDeleteConfirmation(action: (torrents: any[]) => Promise<void>, label: string) {
@@ -610,7 +594,6 @@ export class TorrentsPageController {
         $scope.setAlternativeSpeedLimitsMode = (enabled: boolean) => {
             return $rootScope.$btclient.setAlternativeSpeedLimitsMode(enabled)
                 .then(() => syncAfterTorrentMutation())
-                .then(() => showAlternativeSpeedLimitsPopup())
                 .catch((err: unknown) => {
                     console.error("Alternative speed limits error", err);
                     $notify.alert("Invalid action", "The alternative rate limits mode could not be changed");

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -247,11 +247,8 @@
                 >
                     <i class="ui" ng-class="alternativeSpeedLimitsEnabled ? 'green tachometer alternate icon' : 'grey clock outline icon'"></i>
                 </a>
-                <div
-                    ng-if="alternativeSpeedLimitsPopupMessage"
-                    class="ui top center popup visible transition alternative-speed-limits-popup"
-                >
-                    {{ alternativeSpeedLimitsPopupMessage }}
+                <div class="ui top center popup transition alternative-speed-limits-popup">
+                    Alternative rate limits {{ alternativeSpeedLimitsEnabled ? 'enabled' : 'disabled' }}
                 </div>
             </div>
             <div class="free-space" ng-if="freeDiskSpace != null">

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -235,6 +235,18 @@
                 <i class="ui orange arrow up icon"></i>
                 {{ totalUploadSpeed | speed }} <span ng-if="totalUploaded">({{ totalUploaded | bytes:2 }})</span>
             </div>
+            <button
+                ng-if="$btclient.features.alternativeSpeedLimits"
+                type="button"
+                class="ui mini icon button alternative-speed-limits"
+                ng-class="{active: alternativeSpeedLimitsEnabled}"
+                data-role="alternative-speed-limits"
+                aria-label="Alternative rate limits"
+                title="Alternative rate limits"
+                ng-click="setAlternativeSpeedLimitsMode(!alternativeSpeedLimitsEnabled)"
+            >
+                <i class="tachometer alternate icon"></i>
+            </button>
             <div class="free-space" ng-if="freeDiskSpace != null">
                 <i class="ui grey database icon"></i>
                 Free: {{ freeDiskSpace | bytes }}

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -248,7 +248,7 @@
                     <i class="ui" ng-class="alternativeSpeedLimitsEnabled ? 'green tachometer alternate icon' : 'grey clock outline icon'"></i>
                 </a>
                 <div class="ui top center popup transition alternative-speed-limits-popup">
-                    Alternative rate limits {{ alternativeSpeedLimitsEnabled ? 'enabled' : 'disabled' }}
+                    {{ alternativeSpeedLimitsEnabled ? 'Slow speed mode' : 'Normal speed mode' }}
                 </div>
             </div>
             <div class="free-space" ng-if="freeDiskSpace != null">

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -235,18 +235,25 @@
                 <i class="ui orange arrow up icon"></i>
                 {{ totalUploadSpeed | speed }} <span ng-if="totalUploaded">({{ totalUploaded | bytes:2 }})</span>
             </div>
-            <a
-                ng-if="$btclient.features.alternativeSpeedLimits"
-                href=""
-                class="alternative-speed-limits"
-                ng-class="{active: alternativeSpeedLimitsEnabled}"
-                data-role="alternative-speed-limits"
-                aria-label="Alternative rate limits"
-                title="Alternative rate limits"
-                ng-click="$event.preventDefault(); setAlternativeSpeedLimitsMode(!alternativeSpeedLimitsEnabled)"
-            >
-                <i class="ui" ng-class="alternativeSpeedLimitsEnabled ? 'green tachometer alternate icon' : 'grey clock outline icon'"></i>
-            </a>
+            <div ng-if="$btclient.features.alternativeSpeedLimits" class="alternative-speed-limits-control">
+                <a
+                    href=""
+                    class="alternative-speed-limits"
+                    ng-class="{active: alternativeSpeedLimitsEnabled}"
+                    data-role="alternative-speed-limits"
+                    aria-label="Alternative rate limits"
+                    title="Alternative rate limits"
+                    ng-click="$event.preventDefault(); setAlternativeSpeedLimitsMode(!alternativeSpeedLimitsEnabled)"
+                >
+                    <i class="ui" ng-class="alternativeSpeedLimitsEnabled ? 'green tachometer alternate icon' : 'grey clock outline icon'"></i>
+                </a>
+                <div
+                    ng-if="alternativeSpeedLimitsPopupMessage"
+                    class="ui top center popup visible transition alternative-speed-limits-popup"
+                >
+                    {{ alternativeSpeedLimitsPopupMessage }}
+                </div>
+            </div>
             <div class="free-space" ng-if="freeDiskSpace != null">
                 <i class="ui grey database icon"></i>
                 Free: {{ freeDiskSpace | bytes }}

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -245,7 +245,7 @@
                     title="Alternative rate limits"
                     ng-click="$event.preventDefault(); setAlternativeSpeedLimitsMode(!alternativeSpeedLimitsEnabled)"
                 >
-                    <i class="ui" ng-class="alternativeSpeedLimitsEnabled ? 'green tachometer alternate icon' : 'grey clock outline icon'"></i>
+                    <i class="ui" ng-class="alternativeSpeedLimitsEnabled ? 'red tachometer alternate icon' : 'green tachometer alternate icon'"></i>
                 </a>
                 <div class="ui top center popup transition alternative-speed-limits-popup">
                     {{ alternativeSpeedLimitsEnabled ? 'Slow speed mode' : 'Normal speed mode' }}

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -235,18 +235,18 @@
                 <i class="ui orange arrow up icon"></i>
                 {{ totalUploadSpeed | speed }} <span ng-if="totalUploaded">({{ totalUploaded | bytes:2 }})</span>
             </div>
-            <button
+            <a
                 ng-if="$btclient.features.alternativeSpeedLimits"
-                type="button"
-                class="ui mini icon button alternative-speed-limits"
+                href=""
+                class="alternative-speed-limits"
                 ng-class="{active: alternativeSpeedLimitsEnabled}"
                 data-role="alternative-speed-limits"
                 aria-label="Alternative rate limits"
                 title="Alternative rate limits"
-                ng-click="setAlternativeSpeedLimitsMode(!alternativeSpeedLimitsEnabled)"
+                ng-click="$event.preventDefault(); setAlternativeSpeedLimitsMode(!alternativeSpeedLimitsEnabled)"
             >
-                <i class="tachometer alternate icon"></i>
-            </button>
+                <i class="ui" ng-class="alternativeSpeedLimitsEnabled ? 'green tachometer alternate icon' : 'grey clock outline icon'"></i>
+            </a>
             <div class="free-space" ng-if="freeDiskSpace != null">
                 <i class="ui grey database icon"></i>
                 Free: {{ freeDiskSpace | bytes }}

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -586,6 +586,7 @@ html, body {
 
             .alternative-speed-limits-popup {
                 position: absolute;
+                top: auto;
                 left: 50%;
                 right: auto;
                 bottom: calc(100% + 0.75rem);

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -572,6 +572,21 @@ html, body {
             color: @unselectedTextColor;
             font-size: 0.8rem;
         }
+
+        .alternative-speed-limits-control {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+
+            .alternative-speed-limits-popup {
+                position: absolute;
+                right: 50%;
+                bottom: 1.75rem;
+                display: block;
+                white-space: nowrap;
+                transform: translateX(50%);
+            }
+        }
     }
 }
 .ui.welcome.form.loading:before {

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -578,13 +578,21 @@ html, body {
             display: inline-flex;
             align-items: center;
 
+            &:hover .alternative-speed-limits-popup {
+                display: block;
+                opacity: 1;
+                visibility: visible;
+            }
+
             .alternative-speed-limits-popup {
                 position: absolute;
-                right: 50%;
-                bottom: 1.75rem;
-                display: block;
+                left: 50%;
+                right: auto;
+                bottom: calc(100% + 0.75rem);
+                display: none;
                 white-space: nowrap;
-                transform: translateX(50%);
+                transform: translateX(-50%);
+                z-index: 1000;
             }
         }
     }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -184,6 +184,7 @@ export interface TorrentClientFeatures {
     readonly setLocation?: boolean
     readonly torrentDetails?: boolean
     readonly trackerFilter?: boolean
+    readonly alternativeSpeedLimits?: boolean
     readonly uploadOptions?: Readonly<TorrentUploadOptionsEnable>
 }
 
@@ -199,6 +200,7 @@ export interface ResolvedTorrentClientFeatures {
     readonly setLocation: boolean
     readonly torrentDetails: boolean
     readonly trackerFilter: boolean
+    readonly alternativeSpeedLimits: boolean
     readonly uploadOptions: Readonly<Required<Record<keyof TorrentUploadOptions, boolean>>>
 }
 

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -9,6 +9,7 @@ const features = {
   setLocation: true,
   torrentDetails: true,
   trackerFilter: true,
+  alternativeSpeedLimits: true,
   uploadOptions: {
     saveLocation: true,
     renameTorrent: true,

--- a/test/specs/application.spec.ts
+++ b/test/specs/application.spec.ts
@@ -38,5 +38,25 @@ describe("application", function () {
         return footerText.includes("Free:")
       })
     })
+
+    it("toggles alternative rate limits from the status bar", async function () {
+      const button = $("[data-role='alternative-speed-limits']")
+      await button.waitForDisplayed()
+
+      const isActive = async () => ((await button.getAttribute("class")) || "").split(/\s+/).includes("active")
+      const initial = await isActive()
+
+      try {
+        await button.waitForClickable()
+        await button.click()
+        await browser.waitUntil(async () => await isActive() !== initial)
+      } finally {
+        if (await isActive() !== initial) {
+          await button.waitForClickable()
+          await button.click()
+          await browser.waitUntil(async () => await isActive() === initial)
+        }
+      }
+    })
   }
 })


### PR DESCRIPTION
## Summary
- add a client-agnostic alternative speed limits capability and status-bar toggle
- wire qBittorrent Web API v1/v2 speed limits mode calls through the runtime
- add qBittorrent application spec coverage for the status-bar toggle

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "application.spec.ts"