### PR TITLE
feat: add free disk space support

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -73,6 +73,8 @@ export class DelugeRuntime implements BittorrentRuntime {
 
     private supportsLabels = false
 
+    private downloadLocation: string | null = null
+
     private getUploadOptions(options?: Record<string, any>) {
         if (!options) {
             return {}
@@ -227,6 +229,11 @@ export class DelugeRuntime implements BittorrentRuntime {
             this.supportsLabels = false
         }
 
+        const coreConfig = await this.getCoreConfigValues(["download_location"])
+        this.downloadLocation = typeof coreConfig?.download_location === "string" && coreConfig.download_location.trim()
+            ? coreConfig.download_location
+            : null
+
         return {
             version: version.trim(),
             features: {
@@ -234,6 +241,7 @@ export class DelugeRuntime implements BittorrentRuntime {
                 labels: this.supportsLabels,
                 torrentDetails: true,
                 speedLimits: true,
+                freeDiskSpace: true,
                 uploadOptions: {
                     saveLocation: true,
                     category: this.supportsLabels,
@@ -251,15 +259,29 @@ export class DelugeRuntime implements BittorrentRuntime {
         const fields = this.supportsLabels
             ? DELUGE_TORRENT_FIELDS
             : DELUGE_TORRENT_FIELDS.filter((field) => field !== "label")
-        const snapshot = await defer<Record<string, any>>((done) => this.rpc("web.update_ui", [fields, {}], done))
-        const labels = this.supportsLabels
-            ? await defer<string[]>((done) => this.rpc("label.get_labels", [], done))
-            : []
+        const [snapshot, labels, freeDiskSpace] = await Promise.all([
+            defer<Record<string, any>>((done) => this.rpc("web.update_ui", [fields, {}], done)),
+            this.supportsLabels
+                ? defer<string[]>((done) => this.rpc("label.get_labels", [], done))
+                : Promise.resolve([]),
+            this.getFreeDiskSpace(),
+        ])
 
         return {
             ...snapshot,
             labels: Array.isArray(labels) ? labels : [],
+            freeDiskSpace,
         }
+    }
+
+    private async getFreeDiskSpace(): Promise<number | null> {
+        if (!this.downloadLocation) {
+            return null
+        }
+
+        const value = await defer<number>((done) => this.rpc("core.get_free_space", [this.downloadLocation], done))
+        const numeric = typeof value === "number" ? value : Number(value)
+        return Number.isFinite(numeric) && numeric >= 0 ? numeric : null
     }
 
     async getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -98,6 +98,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
                 fileSelection: true,
                 setLocation: true,
                 torrentDetails: true,
+                freeDiskSpace: true,
                 uploadOptions: {
                     saveLocation: true,
                     renameTorrent: true,

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -84,6 +84,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 trackerFilter: true,
                 alternativeSpeedLimits: true,
                 speedLimits: true,
+                freeDiskSpace: true,
                 uploadOptions: {
                     saveLocation: true,
                     renameTorrent: true,

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -197,6 +197,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
                 torrentDetails: true,
                 trackerFilter: true,
                 speedLimits: true,
+                freeDiskSpace: true,
                 uploadOptions: {
                     saveLocation: true,
                     category: true,
@@ -211,14 +212,23 @@ export class TransmissionRuntime implements BittorrentRuntime {
     }
 
     async getSnapshot(): Promise<any> {
-        const resp = await this.getHttpClient().post(this.url(), {
-            arguments: {
-                fields: TRANSMISSION_FIELDS,
-            },
-            method: 'torrent-get',
-        })
+        const [torrentsResponse, sessionResponse] = await Promise.all([
+            this.getHttpClient().post(this.url(), {
+                arguments: {
+                    fields: TRANSMISSION_FIELDS,
+                },
+                method: 'torrent-get',
+            }),
+            this.getHttpClient().post(this.url(), { method: 'session-get' }),
+        ])
 
-        return resp.data
+        return {
+            ...torrentsResponse.data,
+            arguments: {
+                ...torrentsResponse.data?.arguments,
+                freeDiskSpace: sessionResponse.data?.arguments?.['download-dir-free-space'],
+            },
+        }
     }
 
     async getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {

--- a/src/renderer/app/bittorrent/deluge/delugeservice.ts
+++ b/src/renderer/app/bittorrent/deluge/delugeservice.ts
@@ -3,6 +3,7 @@ import { Torrent } from "@renderer/app/bittorrent/abstracttorrent";
 import { DelugeTorrent } from "./torrentd";
 import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
+import { applyFreeDiskSpace } from "@renderer/app/bittorrent/free-disk-space";
 
 export class DelugeClient extends TorrentClient<DelugeTorrent> {
     public name = 'Deluge'
@@ -10,13 +11,13 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
     async torrents(): Promise<TorrentUpdates> {
         const data: Record<string, any> = await getSnapshot()
 
-        return {
+        return applyFreeDiskSpace({
             labels: Array.isArray(data.labels) ? data.labels : [],
             all: Object.keys(data.torrents || {}).map((hash) => new DelugeTorrent(hash, data.torrents[hash])),
             changed: [],
             deleted: [],
             dirty: true,
-        }
+        }, data.freeDiskSpace)
     }
 
     defaultPath(): string {

--- a/src/renderer/app/bittorrent/free-disk-space.ts
+++ b/src/renderer/app/bittorrent/free-disk-space.ts
@@ -1,0 +1,24 @@
+import type { TorrentUpdates } from "./torrentclient"
+
+export function normalizeFreeDiskSpace(value: unknown): number | null | undefined {
+    if (value === undefined) {
+        return undefined
+    }
+
+    if (value === null) {
+        return null
+    }
+
+    const numeric = typeof value === "number" ? value : Number(value)
+    return Number.isFinite(numeric) && numeric >= 0 ? numeric : null
+}
+
+export function applyFreeDiskSpace(updates: TorrentUpdates, value: unknown): TorrentUpdates {
+    const freeDiskSpace = normalizeFreeDiskSpace(value)
+
+    if (freeDiskSpace !== undefined) {
+        updates.freeDiskSpace = freeDiskSpace
+    }
+
+    return updates
+}

--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -12,6 +12,7 @@ import { TorrentFile } from "@renderer/app/bittorrent/abstracttorrent";
 import { QBittorrentTorrent } from "./torrentq";
 import { addTorrentUrl, getSnapshot, getTorrentDetails, getTorrentFiles, invokeAction, setTorrentFileSelection, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
+import { applyFreeDiskSpace } from "@renderer/app/bittorrent/free-disk-space";
 
 export interface QBittorrentUploadOptions {
   savepath?: string
@@ -48,9 +49,7 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
         deleted: [],
       };
 
-      if (data?.server_state?.free_space_on_disk !== undefined) {
-        torrents.freeDiskSpace = data.server_state.free_space_on_disk ?? null;
-      }
+      applyFreeDiskSpace(torrents, data?.server_state?.free_space_on_disk);
 
       if (data?.server_state?.use_alt_speed_limits !== undefined) {
         torrents.alternativeSpeedLimitsEnabled = data.server_state.use_alt_speed_limits === true || data.server_state.use_alt_speed_limits === 1;

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -55,6 +55,7 @@ const DEFAULT_FEATURES: ResolvedTorrentClientFeatures = Object.freeze({
     trackerFilter: false,
     alternativeSpeedLimits: false,
     speedLimits: false,
+    freeDiskSpace: false,
     uploadOptions: DEFAULT_UPLOAD_OPTIONS,
 })
 

--- a/src/renderer/app/bittorrent/transmission/transmissionservice.ts
+++ b/src/renderer/app/bittorrent/transmission/transmissionservice.ts
@@ -4,6 +4,7 @@ import { TransmissionTorrent } from "./torrentt";
 import _ from "underscore"
 import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
+import { applyFreeDiskSpace } from "@renderer/app/bittorrent/free-disk-space";
 
 const URL_REGEX = /^[a-z]+:\/\/(?:[a-z0-9-]+\.)*((?:[a-z0-9-]+\.)[a-z]+)/;
 
@@ -32,7 +33,7 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
         torrents.all.flatMap((torrent) => torrent.labels)
       ));
       torrents.trackers = this.getTrackers(torrents.all);
-      return torrents;
+      return applyFreeDiskSpace(torrents, data?.arguments?.freeDiskSpace);
     }
 
     build(data: Record<string, any>) {

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -814,7 +814,7 @@ export class TorrentsPageController {
                 changeTorrents(torrents);
                 updateLabels(torrents);
                 updateTrackers(torrents);
-                if (Object.prototype.hasOwnProperty.call(torrents, "freeDiskSpace")) {
+                if ($rootScope.$btclient?.features?.freeDiskSpace && Object.prototype.hasOwnProperty.call(torrents, "freeDiskSpace")) {
                     $scope.freeDiskSpace = torrents.freeDiskSpace ?? null;
                 }
                 if (Object.prototype.hasOwnProperty.call(torrents, "alternativeSpeedLimitsEnabled")) {

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -251,7 +251,7 @@
                     {{ alternativeSpeedLimitsEnabled ? 'Slow speed mode' : 'Normal speed mode' }}
                 </div>
             </div>
-            <div class="free-space" ng-if="freeDiskSpace != null">
+            <div class="free-space" ng-if="$btclient.features.freeDiskSpace && freeDiskSpace != null">
                 <i class="ui grey database icon"></i>
                 Free: {{ freeDiskSpace | bytes }}
             </div>

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -191,6 +191,7 @@ export interface TorrentClientFeatures {
     readonly trackerFilter?: boolean
     readonly alternativeSpeedLimits?: boolean
     readonly speedLimits?: boolean
+    readonly freeDiskSpace?: boolean
     readonly uploadOptions?: Readonly<TorrentUploadOptionsEnable>
 }
 
@@ -208,6 +209,7 @@ export interface ResolvedTorrentClientFeatures {
     readonly trackerFilter: boolean
     readonly alternativeSpeedLimits: boolean
     readonly speedLimits: boolean
+    readonly freeDiskSpace: boolean
     readonly uploadOptions: Readonly<Required<Record<keyof TorrentUploadOptions, boolean>>>
 }
 

--- a/test/clients/deluge/index.ts
+++ b/test/clients/deluge/index.ts
@@ -6,6 +6,7 @@ const baseFeatures = {
   labels: true,
   torrentDetails: true,
   speedLimits: true,
+  freeDiskSpace: true,
   uploadOptions: {
     saveLocation: true,
     category: true,

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -11,6 +11,7 @@ const features = {
   trackerFilter: true,
   alternativeSpeedLimits: true,
   speedLimits: true,
+  freeDiskSpace: true,
   uploadOptions: {
     saveLocation: true,
     renameTorrent: true,

--- a/test/clients/transmission/index.ts
+++ b/test/clients/transmission/index.ts
@@ -9,6 +9,7 @@ const features = {
   torrentDetails: true,
   trackerFilter: true,
   speedLimits: true,
+  freeDiskSpace: true,
   uploadOptions: {
     saveLocation: true,
     category: true,

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -87,6 +87,8 @@ services:
       - ${CLIENT_HOST_PORT:-9091}:9091
     tmpfs:
       - /downloads
+      - /downloads/complete
+      - /downloads/incomplete
 
   utorrent:
     image: ekho/utorrent:${VERSION:-latest}

--- a/test/specs/application.spec.ts
+++ b/test/specs/application.spec.ts
@@ -31,32 +31,38 @@ describe("application", function () {
     assert.match(await version.getText(), new RegExp(`^${escapeRegExp(CLIENT_METADATA[client.clientId].name)}\\s+\\S+`))
   })
 
-  if (client.features.freeDiskSpace) {
-    it("shows free disk space in the footer for clients that support it", async function () {
-      await browser.waitUntil(async () => {
-        const footerText = await this.app.getTorrentsFooterText()
-        return footerText.includes("Free:")
-      })
+  it("shows free disk space in the footer for clients that support it", async function () {
+    if (client.features.freeDiskSpace !== true) {
+      return this.skip()
+    }
+
+    await browser.waitUntil(async () => {
+      const footerText = await this.app.getTorrentsFooterText()
+      return footerText.includes("Free:")
     })
+  })
 
-    it("toggles alternative rate limits from the status bar", async function () {
-      const button = $("[data-role='alternative-speed-limits']")
-      await button.waitForDisplayed()
+  it("toggles alternative rate limits from the status bar", async function () {
+    if (client.features.alternativeSpeedLimits !== true) {
+      return this.skip()
+    }
 
-      const isActive = async () => ((await button.getAttribute("class")) || "").split(/\s+/).includes("active")
-      const initial = await isActive()
+    const button = $("[data-role='alternative-speed-limits']")
+    await button.waitForDisplayed()
 
-      try {
+    const isActive = async () => ((await button.getAttribute("class")) || "").split(/\s+/).includes("active")
+    const initial = await isActive()
+
+    try {
+      await button.waitForClickable()
+      await button.click()
+      await browser.waitUntil(async () => await isActive() !== initial)
+    } finally {
+      if (await isActive() !== initial) {
         await button.waitForClickable()
         await button.click()
-        await browser.waitUntil(async () => await isActive() !== initial)
-      } finally {
-        if (await isActive() !== initial) {
-          await button.waitForClickable()
-          await button.click()
-          await browser.waitUntil(async () => await isActive() === initial)
-        }
+        await browser.waitUntil(async () => await isActive() === initial)
       }
-    })
-  }
+    }
+  })
 })

--- a/test/specs/application.spec.ts
+++ b/test/specs/application.spec.ts
@@ -31,8 +31,8 @@ describe("application", function () {
     assert.match(await version.getText(), new RegExp(`^${escapeRegExp(CLIENT_METADATA[client.clientId].name)}\\s+\\S+`))
   })
 
-  if (client.clientId === "qbittorrent") {
-    it("keeps qBittorrent free space in the footer after incremental syncs", async function () {
+  if (client.features.freeDiskSpace) {
+    it("shows free disk space in the footer for clients that support it", async function () {
       await browser.waitUntil(async () => {
         const footerText = await this.app.getTorrentsFooterText()
         return footerText.includes("Free:")


### PR DESCRIPTION
## Summary
- add a freeDiskSpace client feature flag and gate the footer/test by capability
- add native free disk space reporting for Transmission and Deluge alongside qBittorrent
- share free-space normalization in renderer client services

## Research
Native support included:
- qBittorrent: sync/maindata server_state.free_space_on_disk
- Transmission: session-get download-dir-free-space
- Deluge: core.get_free_space(download_location)

Excluded from implementation:
- rTorrent: only torrent/directory-scoped d.free_diskspace, not a global/default download-directory value suitable for this footer
- uTorrent/Synology: no native API support found

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "application.spec.ts"
- npm run test -- --client "transmission" --spec "application.spec.ts"
- npm run test -- --client "deluge:1" --spec "application.spec.ts"
- npm run test -- --client "deluge:2" --spec "application.spec.ts"