### PR TITLE
feat(tls): add insecure TLS fallback

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -204,6 +204,7 @@ export class DelugeRuntime implements BittorrentRuntime {
         this.requestOptions = {
             timeout: HTTP_REQUEST_TIMEOUT,
             ca: server.certificateData,
+            strictSSL: server.tlsSecurity !== "insecure",
             jar: request.jar(),
         }
 

--- a/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
@@ -19,6 +19,7 @@ export type QBittorrentApiOptions = {
     user: string
     pass: string
     ca?: Uint8Array
+    strictSSL?: boolean
     timeout?: number
 }
 
@@ -47,6 +48,7 @@ export abstract class QBittorrentBaseApi {
         this.options = {
             timeout: this.timeout,
             ca: options.ca,
+            strictSSL: options.strictSSL,
             jar: request.jar(),
             headers: {
                 Referer: this.origin,

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -32,6 +32,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         const requestOptions = {
             timeout: HTTP_REQUEST_TIMEOUT,
             ca: server.certificateData,
+            strictSSL: server.tlsSecurity !== "insecure",
             method: "GET",
             headers: {
                 Referer: origin,
@@ -49,6 +50,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
             user: server.user,
             pass: server.password,
             ca: server.certificateData,
+            strictSSL: server.tlsSecurity !== "insecure",
             timeout: HTTP_REQUEST_TIMEOUT,
         }
 

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -111,6 +111,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
                 Connection: "Close",
             },
             ca: server.certificateData,
+            rejectUnauthorized: server.tlsSecurity !== "insecure",
             timeout: HTTP_REQUEST_TIMEOUT,
         }
 

--- a/src/main/lib/bittorrent/clients/synology.ts
+++ b/src/main/lib/bittorrent/clients/synology.ts
@@ -1,10 +1,10 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
+import https from 'https'
 
 import type { BittorrentServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
 import {
-    createHttpsAgent,
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
     serverUrl,
@@ -176,7 +176,10 @@ export class SynologyRuntime implements BittorrentRuntime {
     async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
         this.server = server
         this.http = axios.create({
-            httpsAgent: createHttpsAgent(server),
+            httpsAgent: new https.Agent({
+                ca: server.certificateData ? Buffer.from(server.certificateData) : undefined,
+                rejectUnauthorized: server.tlsSecurity !== "insecure",
+            }),
             adapter: httpAdapter,
             timeout: HTTP_REQUEST_TIMEOUT,
         })

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -1,9 +1,9 @@
 import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
+import https from 'https'
 
 import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from '@shared/ipc-contract'
 import {
-    createHttpsAgent,
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
     serverUrl,
@@ -131,7 +131,10 @@ export class TransmissionRuntime implements BittorrentRuntime {
                 username: this.server.user,
                 password: this.server.password,
             },
-            httpsAgent: createHttpsAgent(this.server),
+            httpsAgent: new https.Agent({
+                ca: this.server.certificateData ? Buffer.from(this.server.certificateData) : undefined,
+                rejectUnauthorized: this.server.tlsSecurity !== "insecure",
+            }),
             adapter: httpAdapter,
             timeout: HTTP_REQUEST_TIMEOUT,
         })

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -2,11 +2,11 @@ import { URL } from 'node:url'
 import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
+import https from 'https'
 import qs from 'qs'
 
 import type { BittorrentServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
 import {
-    createHttpsAgent,
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
     serverUrl,
@@ -95,7 +95,10 @@ export class UtorrentRuntime implements BittorrentRuntime {
                 username: server.user,
                 password: server.password,
             },
-            httpsAgent: createHttpsAgent(server),
+            httpsAgent: new https.Agent({
+                ca: server.certificateData ? Buffer.from(server.certificateData) : undefined,
+                rejectUnauthorized: server.tlsSecurity !== "insecure",
+            }),
             paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
             adapter: httpAdapter,
             timeout: HTTP_REQUEST_TIMEOUT,

--- a/src/main/lib/bittorrent/helpers.ts
+++ b/src/main/lib/bittorrent/helpers.ts
@@ -1,4 +1,3 @@
-import https from "https"
 import { URL } from "node:url"
 import type { BittorrentServerConfig } from "@shared/ipc-contract"
 import type { CallbackFunc } from "./types"
@@ -49,8 +48,3 @@ export function appendUrlPath(baseUrl: string, endpoint?: string) {
     return url.pathname === "/" ? url.origin : url.toString()
 }
 
-export function createHttpsAgent(server: BittorrentServerConfig) {
-    return new https.Agent({
-        ca: server.certificateData ? Buffer.from(server.certificateData) : undefined,
-    })
-}

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -175,6 +175,8 @@ import { UpdateModalDirective } from "@renderer/app/directives/update-modal/upda
 torrentApp.directive("updateModal", UpdateModalDirective.getInstance())
 import { CertificateModalDirective } from "@renderer/app/directives/certificate-modal/certificate-modal.directive"
 torrentApp.directive("certificateModal", CertificateModalDirective.getInstance())
+import { InsecureTlsModalDirective } from "@renderer/app/directives/insecure-tls-modal/insecure-tls-modal.directive"
+torrentApp.directive("insecureTlsModal", InsecureTlsModalDirective.getInstance())
 import { AddTorrentModalDirective } from "@renderer/app/directives/add-torrent-modal/add-torrent-modal.directive";
 torrentApp.directive('addTorrentModal', AddTorrentModalDirective.getInstance())
 import { TorrentUploadFormDirective } from "@renderer/app/directives/torrent-upload-form/torrent-upload-form.directive";

--- a/src/renderer/app/directives/certificate-modal/certificate-modal.template.html
+++ b/src/renderer/app/directives/certificate-modal/certificate-modal.template.html
@@ -169,20 +169,24 @@
         </div>
     </div>
     <div class="actions">
-        <div class="ui stackable grid">
-            <div class="ten wide column">
+        <div class="ui grid">
+            <div class="sixteen wide column">
                 <div class="ui left icon fluid input">
                     <input name="Fingerprint" type="text" readonly ng-model="data.fingerprint">
                     <i class="address card icon"></i>
                 </div>
             </div>
-            <div class="six wide column">
-                <button type="button" class="ui red deny button">
+            <div class="sixteen wide right aligned column">
+                <button type="button" class="ui black deny button">
                     Cancel
                 </button>
-                <button type="button" class="ui black right labeled icon approve button">
-                    Trust
-                    <i class="address card icon"></i>
+                <button type="button" class="ui orange right labeled icon button" ng-if="data.serverId" ng-click="allowInsecureTls()">
+                    Insecure TLS
+                    <i class="exclamation triangle icon"></i>
+                </button>
+                <button type="button" class="ui green right labeled icon approve button">
+                    Trust Certificate
+                    <i class="check icon"></i>
                 </button>
             </div>
         </div>

--- a/src/renderer/app/directives/insecure-tls-modal/insecure-tls-modal.directive.ts
+++ b/src/renderer/app/directives/insecure-tls-modal/insecure-tls-modal.directive.ts
@@ -1,18 +1,17 @@
 import { IDirective, IDirectiveFactory } from "angular";
-import html from "./certificate-modal.template.html";
+import html from "./insecure-tls-modal.template.html";
 
-export class CertificateModalDirective implements IDirective {
+export class InsecureTlsModalDirective implements IDirective {
     restrict = "E";
     scope = {
         data: "=",
         approve: "&",
-        allowInsecureTls: "&",
         after: "=",
         modalRef: "=",
     };
     template = html;
 
     static getInstance(): IDirectiveFactory {
-        return () => new CertificateModalDirective();
+        return () => new InsecureTlsModalDirective();
     }
 }

--- a/src/renderer/app/directives/insecure-tls-modal/insecure-tls-modal.template.html
+++ b/src/renderer/app/directives/insecure-tls-modal/insecure-tls-modal.template.html
@@ -1,0 +1,29 @@
+<modal
+    size="small"
+    approve="approve()"
+    after="after"
+    id="insecureTlsModal"
+    ng-ref="modalRef">
+    <i class="close icon"></i>
+    <div class="header">
+        Allow Insecure TLS?
+    </div>
+    <div class="content">
+        <div class="ui warning message">
+            <div class="header">TLS certificate verification will be disabled for this server.</div>
+            <p>Electorrent will no longer verify that the server certificate is trusted, valid, or issued for this hostname. This can expose your connection to interception.</p>
+        </div>
+        <p>Only continue if you control this server or understand the security risk.</p>
+        <div class="ui fluid input" ng-if="data.fingerprint">
+            <input name="Fingerprint" type="text" readonly ng-model="data.fingerprint">
+        </div>
+    </div>
+    <div class="actions">
+        <button type="button" class="ui black deny button">
+            Cancel
+        </button>
+        <button type="button" class="ui orange approve button">
+            I Understand, Use Insecure TLS
+        </button>
+    </div>
+</modal>

--- a/src/renderer/app/directives/notifications-center/notifications-center.controller.ts
+++ b/src/renderer/app/directives/notifications-center/notifications-center.controller.ts
@@ -14,9 +14,14 @@ interface NotificationsCenterScope extends IScope {
     close: (index: number) => void;
     installUpdate: () => void;
     installCertificate: () => void;
+    allowInsecureTls: () => void;
+    confirmInsecureTls: () => boolean | void;
+    insecureTlsResult: (accepted: boolean) => void;
     certificate: any;
+    insecureTlsCertificate: any;
     certificateResult: (accepted: boolean) => void;
     certificateModalRef?: ModalController;
+    insecureTlsModalRef?: ModalController;
     updateModalRef?: ModalController;
 }
 
@@ -34,6 +39,7 @@ export class NotificationsCenterController {
     ) {
         const electorrent = window.electorrent
         let id = 0;
+        let insecureTlsFlowActive = false;
 
         $scope.updateData = {
             releaseDate: "Just now...",
@@ -115,7 +121,7 @@ export class NotificationsCenterController {
                         fingerprint: cert.fingerprint,
                         raw: cert.raw,
                     }).then((result) => {
-                        certificateResponseService.resolve(cert.serverId, result.fingerprint);
+                        certificateResponseService.resolve(cert.serverId, { fingerprint: result.fingerprint });
                         $rootScope.$broadcast("certificate-installed", cert.serverId, result.fingerprint);
                         $notify.ok("Certificate installed", "The certificate has been trusted for this server to use");
                     }).catch((err: unknown) => {
@@ -128,6 +134,38 @@ export class NotificationsCenterController {
                     });
                 }
             };
+            $scope.allowInsecureTls = () => {
+                if (!cert.serverId) {
+                    return;
+                }
+                insecureTlsFlowActive = true;
+                $scope.insecureTlsCertificate = cert;
+                $scope.insecureTlsModalRef?.showModal();
+            };
+            $scope.confirmInsecureTls = () => {
+                if (!cert.serverId) {
+                    return false;
+                }
+
+                const saveInsecureTls = settingsService.getServer(cert.serverId)
+                    ? settingsService.enableInsecureTls(cert.serverId)
+                    : Promise.resolve();
+
+                saveInsecureTls.then(() => {
+                    $scope.certificateModalRef?.hideModal();
+                    certificateResponseService.resolve(cert.serverId, { tlsSecurity: "insecure" });
+                    $notify.warning("Insecure TLS enabled", "TLS certificate verification is disabled for this server");
+                }).catch((err: unknown) => {
+                    certificateResponseService.reject(cert.serverId, err);
+                    $notify.alert("Could not enable Insecure TLS", String(err));
+                });
+                return true;
+            };
+            $scope.insecureTlsResult = (accepted: boolean) => {
+                if (!accepted) {
+                    insecureTlsFlowActive = false;
+                }
+            };
             $scope.certificate = cert;
             showCertModal();
         });
@@ -137,9 +175,10 @@ export class NotificationsCenterController {
         };
 
         $scope.certificateResult = (accepted: boolean) => {
-            if (!accepted) {
+            if (!accepted && !insecureTlsFlowActive) {
                 certificateResponseService.reject($scope.certificate?.serverId);
             }
+            insecureTlsFlowActive = false;
         };
     }
 }

--- a/src/renderer/app/directives/notifications-center/notifications-center.template.html
+++ b/src/renderer/app/directives/notifications-center/notifications-center.template.html
@@ -14,7 +14,15 @@
 
 <certificate-modal
     approve="installCertificate()"
+    allow-insecure-tls="allowInsecureTls()"
     after="certificateResult"
     data="certificate"
     modal-ref="certificateModalRef">
 </certificate-modal>
+
+<insecure-tls-modal
+    approve="confirmInsecureTls()"
+    after="insecureTlsResult"
+    data="insecureTlsCertificate"
+    modal-ref="insecureTlsModalRef">
+</insecure-tls-modal>

--- a/src/renderer/app/directives/settings-page/settings-page.controller.ts
+++ b/src/renderer/app/directives/settings-page/settings-page.controller.ts
@@ -202,6 +202,7 @@ export class SettingsPageController {
                 console.error("Settings Error", err);
             }).finally(() => {
                 $scope.connecting = false;
+                $scope.$applyAsync();
             });
         };
 
@@ -217,6 +218,12 @@ export class SettingsPageController {
                     }
                 });
             }
+        };
+
+        $scope.disableInsecureTls = (server: any) => {
+            server.tlsSecurity = "default";
+            server.certificate = undefined;
+            server.certificateData = undefined;
         };
 
         $scope.removeServer = (server: any) => {

--- a/src/renderer/app/directives/settings-servers/settings-servers.template.html
+++ b/src/renderer/app/directives/settings-servers/settings-servers.template.html
@@ -6,6 +6,7 @@
             <th>Client</th>
             <th>IP Address</th>
             <th>Protocol</th>
+            <th>TLS</th>
             <th>Port</th>
             <th>Username</th>
             <th class="center aligned">Actions</th>
@@ -40,6 +41,12 @@
                     </div>
                 </div>
             </td>
+            <td class="collapsing">
+                <div class="ui orange label" ng-if="server.proto === 'https' && server.tlsSecurity === 'insecure'">
+                    <i class="exclamation triangle icon"></i> Insecure TLS
+                </div>
+                <span ng-if="server.proto !== 'https' || server.tlsSecurity !== 'insecure'">—</span>
+            </td>
             <td>{{server.port}}</td>
             <td>{{server.user}}</td>
             <td class="collapsing center aligned">
@@ -48,6 +55,9 @@
                 </button>
                 <button class="circular blue ui icon mini button" ng-click="openRenameModal(server)">
                     <i class="icon tag"></i>
+                </button>
+                <button ng-if="server.proto === 'https' && server.tlsSecurity === 'insecure'" class="circular orange ui icon mini button" ng-click="disableInsecureTls(server)" title="Disable Insecure TLS">
+                    <i class="icon shield alternate"></i>
                 </button>
                 <button class="circular red ui icon mini button" ng-click="removeServer(server)">
                     <i class="icon remove"></i>

--- a/src/renderer/app/services/certificate-response.ts
+++ b/src/renderer/app/services/certificate-response.ts
@@ -1,5 +1,9 @@
+export type CertificateResponse =
+    | { fingerprint: string }
+    | { tlsSecurity: "insecure" }
+
 interface PendingCertificateResponse {
-    resolve: (fingerprint: string) => void
+    resolve: (response: CertificateResponse) => void
     reject: (reason?: unknown) => void
 }
 
@@ -7,12 +11,12 @@ export class CertificateResponseService {
     private pending = new Map<string, PendingCertificateResponse>()
 
     wait(serverId: string) {
-        return new Promise<string>((resolve, reject) => {
+        return new Promise<CertificateResponse>((resolve, reject) => {
             this.pending.set(serverId, { resolve, reject })
         })
     }
 
-    resolve(serverId: string | undefined, fingerprint: string) {
+    resolve(serverId: string | undefined, response: CertificateResponse) {
         if (!serverId) {
             return
         }
@@ -23,7 +27,7 @@ export class CertificateResponseService {
         }
 
         this.pending.delete(serverId)
-        pending.resolve(fingerprint)
+        pending.resolve(response)
     }
 
     reject(serverId: string | undefined, reason?: unknown) {

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -10,28 +10,35 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
         /*
          * Well known error values used for error handling
          */
-        const ERR_SELF_SIGNED_CERT = "DEPTH_ZERO_SELF_SIGNED_CERT"
+        const TLS_CERTIFICATE_ERROR_CODES = new Set([
+            "DEPTH_ZERO_SELF_SIGNED_CERT",
+            "SELF_SIGNED_CERT_IN_CHAIN",
+            "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+            "CERT_HAS_EXPIRED",
+            "ERR_TLS_CERT_ALTNAME_INVALID",
+        ])
 
-        function isSelfSignedCertificateError(err: any) {
+        function isTlsCertificateError(err: any) {
             if (!err) {
                 return false
             }
 
-            if (err.code === ERR_SELF_SIGNED_CERT) {
+            if (err.code && TLS_CERTIFICATE_ERROR_CODES.has(err.code)) {
                 return true
             }
 
-            if (Array.isArray(err.errors) && err.errors.some(isSelfSignedCertificateError)) {
+            if (Array.isArray(err.errors) && err.errors.some(isTlsCertificateError)) {
                 return true
             }
 
-            if (err.cause && isSelfSignedCertificateError(err.cause)) {
+            if (err.cause && isTlsCertificateError(err.cause)) {
                 return true
             }
 
             const message = String(err.message || err).toLowerCase()
-            return message.includes("self signed certificate")
-                || message.includes(ERR_SELF_SIGNED_CERT.toLowerCase())
+            return Array.from(TLS_CERTIFICATE_ERROR_CODES).some((code) => message.includes(code.toLowerCase()))
+                || message.includes("self signed certificate")
+                || message.includes("certificate")
         }
 
         function isAggregateConnectionError(err: any) {
@@ -94,6 +101,7 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
             this.default = data.default
             this.lastused = data.lastused
             this.certificate = data.certificate
+            this.tlsSecurity = data.tlsSecurity === "insecure" ? "insecure" : "default"
             this.certificateData = data.certificateData ? new Uint8Array(data.certificateData) : undefined
             this.columns = this.parseColumns(data.columns)
             this.savedLocations = normalizeSavedLocations(data.savedLocations)
@@ -114,7 +122,8 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                 path: this.path,
                 default: this.default,
                 lastused: this.lastused || -1,
-                certificate: this.certificate,
+                certificate: this.tlsSecurity === "insecure" ? undefined : this.certificate,
+                tlsSecurity: this.isHTTPS() && this.tlsSecurity === "insecure" ? "insecure" : undefined,
                 columns: this.columns.filter((column) => column.enabled).map((column) => column.name),
                 savedLocations: normalizeSavedLocations(this.savedLocations),
                 defaultUploadOptionsEnabled: this.defaultUploadOptionsEnabled === true,
@@ -201,7 +210,7 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
 
             return connectOrTimeout.catch(function(err) {
                 self.isConnected = false
-                if (isSelfSignedCertificateError(err) || (self.isHTTPS() && isAggregateConnectionError(err))) {
+                if (self.isHTTPS() && (isTlsCertificateError(err) || isAggregateConnectionError(err))) {
                     return self.askForCertificate().then(function() {
                         return self.connect()
                     })
@@ -226,16 +235,24 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                 certificateResponseService.reject(self.id, err)
             })
 
-            return $q.when(response).then((fingerprint) => {
-                self.certificate = fingerprint
-                return electorrent.certificates.load(fingerprint)
-            }).then((certificateData) => {
-                self.certificateData = certificateData ? new Uint8Array(certificateData) : undefined
+            return $q.when(response).then((result) => {
+                if (result && result.tlsSecurity === "insecure") {
+                    self.tlsSecurity = "insecure"
+                    self.certificate = undefined
+                    self.certificateData = undefined
+                    return
+                }
+
+                self.tlsSecurity = "default"
+                self.certificate = result.fingerprint
+                return electorrent.certificates.load(result.fingerprint).then((certificateData) => {
+                    self.certificateData = certificateData ? new Uint8Array(certificateData) : undefined
+                })
             })
         }
 
         Server.prototype.getCertificate = function() {
-            return this.certificateData
+            return this.tlsSecurity === "insecure" ? undefined : this.certificateData
         }
 
         Server.prototype.equals = function(other) {
@@ -247,7 +264,8 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                 this.password === other.password &&
                 this.client === other.client &&
                 this.path === other.path &&
-                this.certificate === other.certificate
+                this.certificate === other.certificate &&
+                this.tlsSecurity === other.tlsSecurity
             )
         }
 

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -29,6 +29,12 @@ export let settingsService = ['$rootScope', '$bittorrent', 'notificationService'
     };
 
     function loadServerCertificate(server: any) {
+        if (server?.tlsSecurity === "insecure") {
+            server.certificate = undefined
+            server.certificateData = undefined
+            return Promise.resolve()
+        }
+
         if (!server?.certificate) {
             server.certificateData = undefined
             return Promise.resolve()
@@ -71,6 +77,7 @@ export let settingsService = ['$rootScope', '$bittorrent', 'notificationService'
             return
         }
 
+        server.tlsSecurity = "default"
         server.certificate = fingerprint
         loadServerCertificate(server).then(() => {
             return this.saveAllSettings()
@@ -156,6 +163,23 @@ export let settingsService = ['$rootScope', '$bittorrent', 'notificationService'
 
     this.trustCertificate = function(cert) {
         settings.certificates.push(cert.fingerprint)
+        return this.saveAllSettings()
+    }
+
+    this.enableInsecureTls = function(serverId: string) {
+        const server = this.getServer(serverId)
+        if (!server) {
+            return $q.reject(`Server with id ${serverId} not found`)
+        }
+
+        server.tlsSecurity = "insecure"
+        server.certificate = undefined
+        server.certificateData = undefined
+        return this.saveAllSettings()
+    }
+
+    this.disableInsecureTls = function(server) {
+        server.tlsSecurity = "default"
         return this.saveAllSettings()
     }
 

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -66,6 +66,8 @@ export type ParseTorrentRequest =
     | { uri: string }
     | { data: Uint8Array }
 
+export type TlsSecurity = "default" | "insecure"
+
 export interface BittorrentServerConfig extends StoredServerConfig {
     certificateData?: Uint8Array
 }
@@ -151,6 +153,7 @@ export interface StoredServerConfig {
     default?: boolean
     lastused?: number
     certificate?: string
+    tlsSecurity?: TlsSecurity
     columns: string[]
     savedLocations?: SavedLocationConfig[]
     defaultUploadOptionsEnabled?: boolean

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -149,6 +149,35 @@ export class App {
     await waitForModalClose(certificateModal, this.timeout)
   }
 
+  async openInsecureTlsConfirmation() {
+    const certificateModal = await this.certificateModalIsVisible()
+    const submit = certificateModal.$("button=Insecure TLS")
+    await submit.waitForExist()
+    await submit.waitForDisplayed()
+    await submit.waitForClickable()
+    await submit.waitForEnabled()
+    await submit.click()
+    return this.insecureTlsModalIsVisible()
+  }
+
+  async insecureTlsModalIsVisible() {
+    const insecureTlsModal = $("#insecureTlsModal")
+    await insecureTlsModal.waitForExist()
+    await waitForModalOpen(insecureTlsModal, this.timeout)
+    return insecureTlsModal
+  }
+
+  async acceptInsecureTls() {
+    const insecureTlsModal = await this.insecureTlsModalIsVisible()
+    const submit = insecureTlsModal.$("button.approve")
+    await submit.waitForExist()
+    await submit.waitForDisplayed()
+    await submit.waitForClickable()
+    await submit.waitForEnabled()
+    await submit.click()
+    await waitForModalClose(insecureTlsModal, this.timeout)
+  }
+
   async getNotificationError() {
       const msg = $("#notifications .negative")
       try {

--- a/test/specs/connection-insecure-tls.spec.ts
+++ b/test/specs/connection-insecure-tls.spec.ts
@@ -1,0 +1,21 @@
+import { configureSpec, getTestFixture } from "../framework/fixture"
+
+const fixture = getTestFixture()
+
+describe("insecure tls connection", function () {
+  configureSpec({ login: false })
+
+  it("connects when certificate identity verification fails", async function () {
+    this.retries(3)
+    await this.app.login({
+      ...fixture.client,
+      host: "127.0.0.1",
+      https: true,
+      port: fixture.proxyPort,
+    })
+    await this.app.certificateModalIsVisible()
+    await this.app.openInsecureTlsConfirmation()
+    await this.app.acceptInsecureTls()
+    await this.app.torrentsPageIsVisible()
+  })
+})

--- a/test/specs/torrent-columns.spec.ts
+++ b/test/specs/torrent-columns.spec.ts
@@ -119,6 +119,13 @@ describe("torrent columns", function () {
   })
 
   it("shows a sensible Ratio column value", async function () {
+    await browser.waitUntil(async () => {
+      return /^-?\d+\.\d{2}$/.test((await torrent.getColumn("ratio")).trim())
+    }, {
+      timeout: 20 * 1000,
+      timeoutMsg: "Ratio column did not show a decimal value",
+    })
+
     assert.match((await torrent.getColumn("ratio")).trim(), /^-?\d+\.\d{2}$/)
   })
 


### PR DESCRIPTION
## Summary
- add per-server Insecure TLS mode with explicit warning confirmation
- disable TLS verification across supported clients when enabled
- show Insecure TLS status in server settings and add E2E coverage

## Verification
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "connection-tls.spec.ts"
- npm run test -- --client "qbittorrent:latest" --spec "connection-insecure-tls.spec.ts"