### PR TITLE
feat: add torrent ratio targets

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -28,6 +28,8 @@ const DELUGE_TORRENT_FIELDS = [
     "ratio",
     "save_path",
     "seeds_peers_ratio",
+    "stop_at_ratio",
+    "stop_ratio",
     "state",
     "time_added",
     "total_done",
@@ -242,6 +244,7 @@ export class DelugeRuntime implements BittorrentRuntime {
                 labels: this.supportsLabels,
                 torrentDetails: true,
                 speedLimits: true,
+                ratioLimits: true,
                 freeDiskSpace: true,
                 uploadOptions: {
                     saveLocation: true,
@@ -304,6 +307,7 @@ export class DelugeRuntime implements BittorrentRuntime {
                 seedingTime: details.seeding_time ?? null,
                 connectionsLimit: details.max_connections ?? null,
                 shareRatio: details.ratio ?? null,
+                ratioLimit: details.stop_at_ratio ? (details.stop_ratio ?? null) : null,
                 additionDate: details.time_added ?? null,
                 completionDate: details.completed_time ?? null,
                 downloadSpeed: details.download_payload_rate ?? null,
@@ -432,5 +436,13 @@ export class DelugeRuntime implements BittorrentRuntime {
         }
 
         return defer((done) => this.rpc("core.set_torrent_options", [hashes, torrentOptions], done)).then(() => undefined)
+    }
+
+    async setRatioLimit(hashes: string[], options: Record<string, any>): Promise<void> {
+        const ratioLimit = Number(options.ratioLimit)
+        await Promise.all(hashes.map(async (hash) => {
+            await defer((done) => this.rpc("core.set_torrent_stop_at_ratio", [hash, true], done))
+            await defer((done) => this.rpc("core.set_torrent_stop_ratio", [hash, ratioLimit], done))
+        }))
     }
 }

--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -439,10 +439,11 @@ export class DelugeRuntime implements BittorrentRuntime {
     }
 
     async setRatioLimit(hashes: string[], options: Record<string, any>): Promise<void> {
-        const ratioLimit = Number(options.ratioLimit)
-        await Promise.all(hashes.map(async (hash) => {
-            await defer((done) => this.rpc("core.set_torrent_stop_at_ratio", [hash, true], done))
-            await defer((done) => this.rpc("core.set_torrent_stop_ratio", [hash, ratioLimit], done))
-        }))
+        const torrentOptions = {
+            stop_at_ratio: true,
+            stop_ratio: Number(options.ratioLimit),
+        }
+
+        return defer((done) => this.rpc("core.set_torrent_options", [hashes, torrentOptions], done)).then(() => undefined)
     }
 }

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -23,6 +23,7 @@ interface MockTorrent {
     priority: number
     progress: number
     ratio: number
+    ratio_limit?: number
     save_path: string
     seq_dl: boolean
     size: number
@@ -68,6 +69,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
                 fileSelection: true,
                 setLocation: true,
                 torrentDetails: true,
+                ratioLimits: true,
                 freeDiskSpace: true,
                 uploadOptions: {
                     saveLocation: true,
@@ -138,6 +140,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
             priority: input.priority ?? index,
             progress,
             ratio: input.ratio ?? Number((index / 10).toFixed(2)),
+            ratio_limit: input.ratio_limit,
             save_path: input.save_path ?? "/mock/downloads",
             seq_dl: input.seq_dl ?? (index % 2 === 0),
             size,
@@ -259,6 +262,16 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         })
     }
 
+    async setRatioLimit(hashes: string[], options: Record<string, any>): Promise<void> {
+        this.assertConnected()
+        hashes.forEach((hash) => {
+            const torrent = this.torrents.get(hash)
+            if (torrent) {
+                torrent.ratio_limit = Number(options.ratioLimit)
+            }
+        })
+    }
+
     async getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {
         this.assertConnected()
         const torrent = this.torrents.get(hash)
@@ -283,6 +296,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
                 connections: torrent.num_leechs + torrent.num_seeds,
                 connectionsLimit: 100,
                 shareRatio: torrent.ratio,
+                ratioLimit: torrent.ratio_limit ?? null,
                 additionDate: torrent.added_on,
                 completionDate: torrent.completion_on ?? null,
                 createdBy: "Electorrent Mock",

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -93,6 +93,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 trackerFilter: true,
                 alternativeSpeedLimits: true,
                 speedLimits: true,
+                ratioLimits: true,
                 freeDiskSpace: true,
                 uploadOptions: {
                     saveLocation: true,
@@ -390,6 +391,28 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         await Promise.all(requests)
     }
 
+    async setRatioLimit(hashes: string[], options: Record<string, any>): Promise<void> {
+        const api = this.getApi()
+        const ratioLimit = Number(options.ratioLimit)
+        await new Promise<void>((resolve, reject) => {
+            api.post("torrents/setShareLimits", {
+                form: {
+                    hashes: hashes.join("|"),
+                    ratioLimit: String(ratioLimit),
+                    seedingTimeLimit: "-2",
+                    inactiveSeedingTimeLimit: "-2",
+                    shareLimitAction: "0",
+                },
+            }, (err: any) => {
+                if (err) {
+                    reject(err)
+                    return
+                }
+                resolve()
+            })
+        })
+    }
+
     async getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {
         const api = this.getApi()
         const [properties, files] = await Promise.all([
@@ -429,6 +452,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 connections: properties.nb_connections ?? null,
                 connectionsLimit: properties.nb_connections_limit ?? null,
                 shareRatio: properties.share_ratio ?? null,
+                ratioLimit: properties.ratio_limit ?? properties.ratioLimit ?? null,
                 additionDate: properties.addition_date ?? null,
                 completionDate: properties.completion_date ?? null,
                 createdBy: properties.created_by ?? null,

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -64,6 +64,8 @@ const TRANSMISSION_FIELDS = [
     'recheckProgress',
     'secondsDownloading',
     'secondsSeeding',
+    'seedRatioLimit',
+    'seedRatioMode',
     'sequentialDownload',
     'sequential_download',
     'seedIdleLimit',
@@ -200,6 +202,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
                 torrentDetails: true,
                 trackerFilter: true,
                 speedLimits: true,
+                ratioLimits: true,
                 freeDiskSpace: true,
                 uploadOptions: {
                     saveLocation: true,
@@ -269,6 +272,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
                 connections: torrent.peersConnected ?? null,
                 connectionsLimit: torrent.maxConnectedPeers ?? null,
                 shareRatio: torrent.uploadRatio ?? null,
+                ratioLimit: torrent.seedRatioMode > 0 ? (torrent.seedRatioLimit ?? null) : null,
                 additionDate: torrent.addedDate ?? null,
                 completionDate: torrent.doneDate ?? null,
                 createdBy: torrent.creator ?? null,
@@ -483,5 +487,12 @@ export class TransmissionRuntime implements BittorrentRuntime {
         })
 
         return this.doAction('torrent-set', hashes, args).then((response) => this.ensureSuccess(response)).then(() => undefined)
+    }
+
+    setRatioLimit(hashes: string[], options: Record<string, any>): Promise<void> {
+        return this.doAction('torrent-set', hashes, {
+            seedRatioMode: 1,
+            seedRatioLimit: Number(options.ratioLimit),
+        }).then((response) => this.ensureSuccess(response)).then(() => undefined)
     }
 }

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -24,9 +24,6 @@ export class UtorrentRuntime implements BittorrentRuntime {
         build: -1,
     }
 
-    private ratioLimits = new Map<string, number>()
-    private torrentCache = new Map<string, any[]>()
-
     private url(endpoint = '') {
         const url = new URL(serverUrl(this.server, endpoint || undefined))
         if (!endpoint) {
@@ -167,7 +164,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
                 magnetLinks: true,
                 labels: true,
                 speedLimits: true,
-                ratioLimits: true,
+                ratioLimits: false,
                 uploadOptions: {
                     saveLocation: true,
                 },
@@ -222,50 +219,6 @@ export class UtorrentRuntime implements BittorrentRuntime {
                 t: Date.now(),
                 list: 1,
             },
-        })
-
-        const injectRatioLimit = (torrent: any[]) => {
-            const hash = typeof torrent?.[0] === 'string' ? torrent[0] : undefined
-            const ratioLimit = hash ? this.ratioLimits.get(hash) ?? this.ratioLimits.get(hash.toLowerCase()) : undefined
-            if (!hash) {
-                return
-            }
-            if (ratioLimit !== undefined) {
-                const additionalDataIndex = 27
-                torrent[additionalDataIndex] = {
-                    ...(torrent[additionalDataIndex] || {}),
-                    seed_override: 1,
-                    seed_ratio: ratioLimit,
-                }
-            }
-            this.torrentCache.set(hash, torrent)
-            this.torrentCache.set(hash.toLowerCase(), torrent)
-        }
-        const seenHashes = new Set<string>()
-        const track = (torrent: any[]) => {
-            const hash = typeof torrent?.[0] === 'string' ? torrent[0] : undefined
-            if (hash) {
-                seenHashes.add(hash)
-                seenHashes.add(hash.toLowerCase())
-            }
-            injectRatioLimit(torrent)
-        }
-        if (Array.isArray(res.data?.torrents)) {
-            res.data.torrents.forEach(track)
-        }
-        if (Array.isArray(res.data?.torrentp)) {
-            res.data.torrentp.forEach(track)
-        }
-        this.ratioLimits.forEach((_ratioLimit, hash) => {
-            if (seenHashes.has(hash)) {
-                return
-            }
-            const cached = this.torrentCache.get(hash)
-            if (!cached) {
-                return
-            }
-            injectRatioLimit(cached)
-            res.data.torrentp = [...(Array.isArray(res.data?.torrentp) ? res.data.torrentp : []), cached]
         })
 
         return res.data
@@ -374,10 +327,6 @@ export class UtorrentRuntime implements BittorrentRuntime {
             this.setProperty(hashes, 'seed_override', 1),
             this.setProperty(hashes, 'seed_ratio', ratioLimit),
         ])
-        hashes.forEach((hash) => {
-            this.ratioLimits.set(hash, ratioLimit / 1000)
-            this.ratioLimits.set(hash.toLowerCase(), ratioLimit / 1000)
-        })
         this.data.cid = 0
     }
 }

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -24,6 +24,9 @@ export class UtorrentRuntime implements BittorrentRuntime {
         build: -1,
     }
 
+    private ratioLimits = new Map<string, number>()
+    private torrentCache = new Map<string, any[]>()
+
     private url(endpoint = '') {
         const url = new URL(serverUrl(this.server, endpoint || undefined))
         if (!endpoint) {
@@ -164,6 +167,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
                 magnetLinks: true,
                 labels: true,
                 speedLimits: true,
+                ratioLimits: true,
                 uploadOptions: {
                     saveLocation: true,
                 },
@@ -218,6 +222,50 @@ export class UtorrentRuntime implements BittorrentRuntime {
                 t: Date.now(),
                 list: 1,
             },
+        })
+
+        const injectRatioLimit = (torrent: any[]) => {
+            const hash = typeof torrent?.[0] === 'string' ? torrent[0] : undefined
+            const ratioLimit = hash ? this.ratioLimits.get(hash) ?? this.ratioLimits.get(hash.toLowerCase()) : undefined
+            if (!hash) {
+                return
+            }
+            if (ratioLimit !== undefined) {
+                const additionalDataIndex = 27
+                torrent[additionalDataIndex] = {
+                    ...(torrent[additionalDataIndex] || {}),
+                    seed_override: 1,
+                    seed_ratio: ratioLimit,
+                }
+            }
+            this.torrentCache.set(hash, torrent)
+            this.torrentCache.set(hash.toLowerCase(), torrent)
+        }
+        const seenHashes = new Set<string>()
+        const track = (torrent: any[]) => {
+            const hash = typeof torrent?.[0] === 'string' ? torrent[0] : undefined
+            if (hash) {
+                seenHashes.add(hash)
+                seenHashes.add(hash.toLowerCase())
+            }
+            injectRatioLimit(torrent)
+        }
+        if (Array.isArray(res.data?.torrents)) {
+            res.data.torrents.forEach(track)
+        }
+        if (Array.isArray(res.data?.torrentp)) {
+            res.data.torrentp.forEach(track)
+        }
+        this.ratioLimits.forEach((_ratioLimit, hash) => {
+            if (seenHashes.has(hash)) {
+                return
+            }
+            const cached = this.torrentCache.get(hash)
+            if (!cached) {
+                return
+            }
+            injectRatioLimit(cached)
+            res.data.torrentp = [...(Array.isArray(res.data?.torrentp) ? res.data.torrentp : []), cached]
         })
 
         return res.data
@@ -318,5 +366,18 @@ export class UtorrentRuntime implements BittorrentRuntime {
             requests.push(this.setProperty(hashes, 'ulrate', Number(options.uploadSpeedLimit)))
         }
         await Promise.all(requests)
+    }
+
+    async setRatioLimit(hashes: string[], options: Record<string, any>): Promise<void> {
+        const ratioLimit = Math.round(Number(options.ratioLimit) * 1000)
+        await Promise.all([
+            this.setProperty(hashes, 'seed_override', 1),
+            this.setProperty(hashes, 'seed_ratio', ratioLimit),
+        ])
+        hashes.forEach((hash) => {
+            this.ratioLimits.set(hash, ratioLimit / 1000)
+            this.ratioLimits.set(hash.toLowerCase(), ratioLimit / 1000)
+        })
+        this.data.cid = 0
     }
 }

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -210,5 +210,7 @@ import { SetLocationModalDirective } from "@renderer/app/directives/set-location
 torrentApp.directive('setLocationModal', SetLocationModalDirective.getInstance())
 import { TorrentSpeedModalDirective } from "@renderer/app/directives/torrent-speed-modal/torrent-speed-modal.directive";
 torrentApp.directive('torrentSpeedModal', TorrentSpeedModalDirective.getInstance())
+import { TorrentSetRatioModalDirective } from "@renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.directive";
+torrentApp.directive('torrentSetRatioModal', TorrentSetRatioModalDirective.getInstance())
 import { SavedLocationModalDirective } from "@renderer/app/directives/saved-location-modal/saved-location-modal.directive";
 torrentApp.directive('savedLocationModal', SavedLocationModalDirective.getInstance())

--- a/src/renderer/app/bittorrent/abstracttorrent.ts
+++ b/src/renderer/app/bittorrent/abstracttorrent.ts
@@ -333,7 +333,7 @@ export abstract class Torrent implements TorrentProps {
     })
 
     static COL_RATIO_LIMIT = new Column({
-      name: 'Ratio Target',
+      name: 'Ratio Limit',
       enabled: false,
       template: '{{torrent.ratioLimit | torrentRatio}}',
       attribute: 'ratioLimit'

--- a/src/renderer/app/bittorrent/abstracttorrent.ts
+++ b/src/renderer/app/bittorrent/abstracttorrent.ts
@@ -22,6 +22,7 @@ export interface TorrentProps {
     downloaded?: number
     uploaded?: number
     ratio?: number
+    ratioLimit?: number
     uploadSpeed?: number
     downloadSpeed?: number
     uploadLimit?: number
@@ -57,6 +58,7 @@ export abstract class Torrent implements TorrentProps {
     downloaded: number
     uploaded: number
     ratio: number
+    ratioLimit: number
     uploadSpeed: number
     downloadSpeed: number
     uploadLimit: number
@@ -330,6 +332,13 @@ export abstract class Torrent implements TorrentProps {
       attribute: 'ratio'
     })
 
+    static COL_RATIO_LIMIT = new Column({
+      name: 'Ratio Target',
+      enabled: true,
+      template: '{{torrent.ratioLimit | torrentRatio}}',
+      attribute: 'ratioLimit'
+    })
+
     static COLUMNS = [
         Torrent.COL_NAME,
         Torrent.COL_SIZE,
@@ -343,7 +352,8 @@ export abstract class Torrent implements TorrentProps {
         Torrent.COL_SEEDS,
         Torrent.COL_QUEUE,
         Torrent.COL_ETA,
-        Torrent.COL_RATIO
+        Torrent.COL_RATIO,
+        Torrent.COL_RATIO_LIMIT
     ]
 
     private static alphabetical(a: string, b: string) {

--- a/src/renderer/app/bittorrent/abstracttorrent.ts
+++ b/src/renderer/app/bittorrent/abstracttorrent.ts
@@ -334,7 +334,7 @@ export abstract class Torrent implements TorrentProps {
 
     static COL_RATIO_LIMIT = new Column({
       name: 'Ratio Target',
-      enabled: true,
+      enabled: false,
       template: '{{torrent.ratioLimit | torrentRatio}}',
       attribute: 'ratioLimit'
     })

--- a/src/renderer/app/bittorrent/deluge/delugeservice.ts
+++ b/src/renderer/app/bittorrent/deluge/delugeservice.ts
@@ -107,7 +107,7 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
                 this.createTorrentDetailsField("downloaded", "Downloaded", this.toNumber(info.totalDownloaded) ?? torrent.downloaded, "bytes"),
                 this.createTorrentDetailsField("uploaded", "Uploaded", this.toNumber(info.totalUploaded) ?? torrent.uploaded, "bytes"),
                 this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
-                this.createTorrentDetailsField("ratio-limit", "Ratio Target", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
+                this.createTorrentDetailsField("ratio-limit", "Ratio Limit", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
                 this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
                 this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
                 this.createTorrentDetailsField("download-limit", "Download Limit", toSpeedLimitBytes(info.downloadLimit), "speedLimit", { allowEmpty: true }),

--- a/src/renderer/app/bittorrent/deluge/delugeservice.ts
+++ b/src/renderer/app/bittorrent/deluge/delugeservice.ts
@@ -1,4 +1,4 @@
-import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentSpeedLimitOptions, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
+import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentRatioLimitOptions, TorrentSpeedLimitOptions, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { Torrent } from "@renderer/app/bittorrent/abstracttorrent";
 import { DelugeTorrent } from "./torrentd";
 import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
@@ -80,6 +80,10 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
         return invokeAction("setSpeedLimits", torrents.map((torrent) => torrent.hash), options)
     }
 
+    setRatioLimit(torrents: DelugeTorrent[], options: TorrentRatioLimitOptions): Promise<void> {
+        return invokeAction("setRatioLimit", torrents.map((torrent) => torrent.hash), options)
+    }
+
     protected getTorrentDetailsData(torrent: DelugeTorrent): Promise<BittorrentTorrentDetailsData> {
         return getTorrentDetails(torrent.hash)
     }
@@ -103,6 +107,7 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
                 this.createTorrentDetailsField("downloaded", "Downloaded", this.toNumber(info.totalDownloaded) ?? torrent.downloaded, "bytes"),
                 this.createTorrentDetailsField("uploaded", "Uploaded", this.toNumber(info.totalUploaded) ?? torrent.uploaded, "bytes"),
                 this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
+                this.createTorrentDetailsField("ratio-limit", "Ratio Target", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
                 this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
                 this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
                 this.createTorrentDetailsField("download-limit", "Download Limit", toSpeedLimitBytes(info.downloadLimit), "speedLimit", { allowEmpty: true }),
@@ -207,6 +212,12 @@ export class DelugeClient extends TorrentClient<DelugeTorrent> {
             label: "Set Speed Limits",
             click: () => Promise.resolve(),
             icon: "dashboard",
+        },
+        {
+            id: "torrent-set-ratio",
+            label: "Set Ratio",
+            click: () => Promise.resolve(),
+            icon: "percent",
         },
         {
             label: 'Remove',

--- a/src/renderer/app/bittorrent/deluge/torrentd.ts
+++ b/src/renderer/app/bittorrent/deluge/torrentd.ts
@@ -17,6 +17,7 @@ export class DelugeTorrent extends Torrent {
             downloaded: data.total_done, /* Downloaded (integer): number of bytes */
             uploaded: data.total_uploaded, /* Uploaded (integer): number of bytes */
             ratio: data.ratio, /* Ratio (integer): integer i per-mille (1:1 = 1000) */
+            ratioLimit: data.stop_at_ratio ? data.stop_ratio : undefined,
             uploadSpeed: data.upload_payload_rate,  /* Upload Speed (integer): bytes per second */
             downloadSpeed: data.download_payload_rate, /* Download Speed (integer): bytes per second */
             uploadLimit: data.max_upload_speed >= 0 ? data.max_upload_speed * 1024 : 0,

--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -6,6 +6,7 @@ import {
   ContextActionList,
   TorrentUploadOptions,
   TorrentSpeedLimitOptions,
+  TorrentRatioLimitOptions,
   TorrentDetailsInfoSection,
 } from "@renderer/app/bittorrent/torrentclient";
 import { TorrentFile } from "@renderer/app/bittorrent/abstracttorrent";
@@ -159,6 +160,10 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
       return invokeAction("setSpeedLimits", torrents.map((torrent) => torrent.hash), options);
     }
 
+    setRatioLimit(torrents: QBittorrentTorrent[], options: TorrentRatioLimitOptions): Promise<void> {
+      return invokeAction("setRatioLimit", torrents.map((torrent) => torrent.hash), options);
+    }
+
     deleteTorrents(torrents: QBittorrentTorrent[]): Promise<void> {
       return this.delete(torrents)
     }
@@ -205,6 +210,7 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
           this.createTorrentDetailsField("downloaded", "Downloaded", this.toNumber(info.totalDownloaded) ?? torrent.downloaded, "bytes"),
           this.createTorrentDetailsField("uploaded", "Uploaded", this.toNumber(info.totalUploaded) ?? torrent.uploaded, "bytes"),
           this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
+          this.createTorrentDetailsField("ratio-limit", "Ratio Target", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
           this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
           this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
           this.createTorrentDetailsField("download-limit", "Download Limit", this.toNumber(info.downloadLimit) ?? this.toNumber(torrent.downLimit), "speedLimit", { allowEmpty: true }),
@@ -342,6 +348,12 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
         label: "Set Speed Limits",
         click: () => Promise.resolve(),
         icon: "dashboard",
+      },
+      {
+        id: "torrent-set-ratio",
+        label: "Set Ratio",
+        click: () => Promise.resolve(),
+        icon: "percent",
       },
       {
         label: "Remove",

--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -210,7 +210,7 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
           this.createTorrentDetailsField("downloaded", "Downloaded", this.toNumber(info.totalDownloaded) ?? torrent.downloaded, "bytes"),
           this.createTorrentDetailsField("uploaded", "Uploaded", this.toNumber(info.totalUploaded) ?? torrent.uploaded, "bytes"),
           this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
-          this.createTorrentDetailsField("ratio-limit", "Ratio Target", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
+          this.createTorrentDetailsField("ratio-limit", "Ratio Limit", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
           this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
           this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
           this.createTorrentDetailsField("download-limit", "Download Limit", this.toNumber(info.downloadLimit) ?? this.toNumber(torrent.downLimit), "speedLimit", { allowEmpty: true }),

--- a/src/renderer/app/bittorrent/qbittorrent/torrentq.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/torrentq.ts
@@ -60,6 +60,7 @@ export class QBittorrentTorrent extends Torrent {
             downloaded: data.total_downloaded,
             uploaded: data.total_uploaded,
             ratio: data.share_ration || data.ratio,
+            ratioLimit: data.ratio_limit,
             uploadSpeed: data.up_speed || data.upspeed,
             downloadSpeed: data.dl_speed || data.dlspeed,
             uploadLimit: data.up_limit,

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -11,6 +11,10 @@ import { connect } from "./ipc"
 
 export type { TorrentSpeedLimitOptions, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@shared/ipc-contract"
 
+export interface TorrentRatioLimitOptions {
+    ratioLimit: number
+}
+
 export type TorrentActionRole = "resume" | "stop" | "delete"
 
 export interface TorrentUpdates {
@@ -55,6 +59,7 @@ const DEFAULT_FEATURES: ResolvedTorrentClientFeatures = Object.freeze({
     trackerFilter: false,
     alternativeSpeedLimits: false,
     speedLimits: false,
+    ratioLimits: false,
     freeDiskSpace: false,
     uploadOptions: DEFAULT_UPLOAD_OPTIONS,
 })
@@ -324,6 +329,13 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
             throw new Error("Speed limits not supported for this client")
         }
         return Promise.reject(new Error("Speed limits not implemented for this client"))
+    }
+
+    async setRatioLimit(_torrents: T[], _options: TorrentRatioLimitOptions): Promise<void> {
+        if (!this.features.ratioLimits) {
+            throw new Error("Ratio limits not supported for this client")
+        }
+        return Promise.reject(new Error("Ratio limits not implemented for this client"))
     }
 
     async getTorrentDetails(torrent: T): Promise<TorrentDetailsPanelData> {

--- a/src/renderer/app/bittorrent/transmission/torrentt.ts
+++ b/src/renderer/app/bittorrent/transmission/torrentt.ts
@@ -23,6 +23,7 @@ export class TransmissionTorrent extends Torrent {
             downloaded: data.downloadedEver, /* Downloaded (integer): number of bytes */
             uploaded: data.uploadedEver, /* Uploaded (integer): number of bytes */
             ratio: data.uploadRatio, /* Ratio (integer): integer i per-mille (1:1 = 1000) */
+            ratioLimit: data.seedRatioMode > 0 ? data.seedRatioLimit : undefined,
             uploadSpeed: data.rateUpload,  /* Upload Speed (integer): bytes per second */
             downloadSpeed: data.rateDownload, /* Download Speed (integer): bytes per second */
             uploadLimit: data.uploadLimited ? data.uploadLimit * 1024 : 0,

--- a/src/renderer/app/bittorrent/transmission/transmissionservice.ts
+++ b/src/renderer/app/bittorrent/transmission/transmissionservice.ts
@@ -147,7 +147,7 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
           this.createTorrentDetailsField("downloaded", "Downloaded", this.toNumber(info.totalDownloaded) ?? torrent.downloaded, "bytes"),
           this.createTorrentDetailsField("uploaded", "Uploaded", this.toNumber(info.totalUploaded) ?? torrent.uploaded, "bytes"),
           this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
-          this.createTorrentDetailsField("ratio-limit", "Ratio Target", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
+          this.createTorrentDetailsField("ratio-limit", "Ratio Limit", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
           this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
           this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
           this.createTorrentDetailsField("download-limit", "Download Limit", toSpeedLimitBytes(info.downloadLimit), "speedLimit", { allowEmpty: true }),

--- a/src/renderer/app/bittorrent/transmission/transmissionservice.ts
+++ b/src/renderer/app/bittorrent/transmission/transmissionservice.ts
@@ -1,4 +1,4 @@
-import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentSpeedLimitOptions, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
+import { ContextActionList, TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentRatioLimitOptions, TorrentSpeedLimitOptions, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { Torrent } from "@renderer/app/bittorrent/abstracttorrent";
 import { TransmissionTorrent } from "./torrentt";
 import _ from "underscore"
@@ -116,6 +116,10 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
       return invokeAction("setSpeedLimits", torrents.map((torrent) => torrent.hash), options);
     }
 
+    setRatioLimit(torrents: TransmissionTorrent[], options: TorrentRatioLimitOptions): Promise<void> {
+      return invokeAction("setRatioLimit", torrents.map((torrent) => torrent.hash), options);
+    }
+
     extraColumns = [Torrent.COL_DOWNLIMIT, Torrent.COL_UPLIMIT];
 
     protected getTorrentDetailsData(torrent: TransmissionTorrent): Promise<BittorrentTorrentDetailsData> {
@@ -143,6 +147,7 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
           this.createTorrentDetailsField("downloaded", "Downloaded", this.toNumber(info.totalDownloaded) ?? torrent.downloaded, "bytes"),
           this.createTorrentDetailsField("uploaded", "Uploaded", this.toNumber(info.totalUploaded) ?? torrent.uploaded, "bytes"),
           this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
+          this.createTorrentDetailsField("ratio-limit", "Ratio Target", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
           this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
           this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
           this.createTorrentDetailsField("download-limit", "Download Limit", toSpeedLimitBytes(info.downloadLimit), "speedLimit", { allowEmpty: true }),
@@ -261,6 +266,12 @@ export class TransmissionClient extends TorrentClient<TransmissionTorrent> {
         label: "Set Speed Limits",
         click: () => Promise.resolve(),
         icon: "dashboard",
+      },
+      {
+        id: "torrent-set-ratio",
+        label: "Set Ratio",
+        click: () => Promise.resolve(),
+        icon: "percent",
       },
       {
         label: "Remove",

--- a/src/renderer/app/bittorrent/utorrent/torrentu.ts
+++ b/src/renderer/app/bittorrent/utorrent/torrentu.ts
@@ -1,5 +1,90 @@
 import {Torrent} from "@renderer/app/bittorrent/abstracttorrent";
 
+interface UtorrentApiAdditionalData {
+    seed_override?: number
+    seed_ratio?: number
+    [key: string]: any
+}
+
+interface UtorrentApiTorrent {
+    hash: string
+    status: number
+    name: string
+    size: number
+    percent: number
+    downloaded: number
+    uploaded: number
+    ratio: number
+    uploadSpeed: number
+    downloadSpeed: number
+    eta: number
+    label: string
+    peersConnected: number
+    peersInSwarm: number
+    seedsConnected: number
+    seedsInSwarm: number
+    availability: number
+    torrentQueueOrder: number
+    remaining: number
+    downloadUrl: string
+    rssFeedUrl: string
+    statusMessage: string
+    streamId: string
+    dateAdded: number
+    dateCompleted: number
+    appUpdateUrl: string
+    savePath: string
+    additionalData?: UtorrentApiAdditionalData
+}
+
+const apiPropertiesOrder: Array<keyof UtorrentApiTorrent> = [
+    "hash",
+    "status",
+    "name",
+    "size",
+    "percent",
+    "downloaded",
+    "uploaded",
+    "ratio",
+    "uploadSpeed",
+    "downloadSpeed",
+    "eta",
+    "label",
+    "peersConnected",
+    "peersInSwarm",
+    "seedsConnected",
+    "seedsInSwarm",
+    "availability",
+    "torrentQueueOrder",
+    "remaining",
+    "downloadUrl",
+    "rssFeedUrl",
+    "statusMessage",
+    "streamId",
+    "dateAdded",
+    "dateCompleted",
+    "appUpdateUrl",
+    "savePath",
+    "additionalData",
+]
+
+function parseUtorrentApiTorrent(data: any[]): UtorrentApiTorrent {
+    const torrent: any = {}
+    apiPropertiesOrder.forEach((property, index) => {
+        torrent[property] = data[index]
+    })
+    return torrent as UtorrentApiTorrent
+}
+
+function parseRatioLimit(additionalData?: UtorrentApiAdditionalData): number | undefined {
+    if (!additionalData?.seed_override) {
+        return undefined
+    }
+
+    const seedRatio = Number(additionalData.seed_ratio)
+    return Number.isFinite(seedRatio) ? seedRatio / 1000 : undefined
+}
+
 export class UtorrentTorrent extends Torrent {
 
     /* Custom/additional attributes */
@@ -9,9 +94,9 @@ export class UtorrentTorrent extends Torrent {
     streamId: string
     rssFeedUrl: string
     appUpdateUrl: string
-    additionalData: Record<string, any>
+    additionalData: UtorrentApiAdditionalData
 
-    constructor(data: Record<string, any>) {
+    constructor(data: UtorrentApiTorrent) {
 
         super({
             hash: data.hash,
@@ -21,7 +106,7 @@ export class UtorrentTorrent extends Torrent {
             downloaded: data.downloaded,
             uploaded: data.uploaded,
             ratio: (data.ratio / 1000),
-            ratioLimit: data.additionalData?.seed_override ? (data.additionalData.seed_ratio / 1000) : undefined,
+            ratioLimit: parseRatioLimit(data.additionalData),
             uploadSpeed: data.uploadSpeed,
             downloadSpeed: data.downloadSpeed,
             eta: data.eta,
@@ -44,47 +129,12 @@ export class UtorrentTorrent extends Torrent {
         this.streamId = data.streamId;
         this.rssFeedUrl = data.rssFeedUrl;
         this.appUpdateUrl = data.appUpdateUrl;
-        this.additionalData = data.additionalData;
+        this.additionalData = data.additionalData || {};
 
     }
 
-    static apiPropertiesOrder = [
-        "hash",
-        "status",
-        "name",
-        "size",
-        "percent",
-        "downloaded",
-        "uploaded",
-        "ratio",
-        "uploadSpeed",
-        "downloadSpeed",
-        "eta",
-        "label",
-        "peersConnected",
-        "peersInSwarm",
-        "seedsConnected",
-        "seedsInSwarm",
-        "availability",
-        "torrentQueueOrder",
-        "remaining",
-        "downloadUrl",
-        "rssFeedUrl",
-        "statusMessage",
-        "streamId",
-        "dateAdded",
-        "dateCompleted",
-        "appUpdateUrl",
-        "savePath",
-        "additionalData",
-    ]
-
-    static fromArray(data: any[]): UtorrentTorrent {
-        let args = {}
-        for (let i = 0; i < data.length; i++) {
-            args[this.apiPropertiesOrder[i]] = data[i]
-        }
-        return new UtorrentTorrent(args)
+    static fromApiArray(data: any[]): UtorrentTorrent {
+        return new UtorrentTorrent(parseUtorrentApiTorrent(data))
     }
 
     statusesMap = {

--- a/src/renderer/app/bittorrent/utorrent/torrentu.ts
+++ b/src/renderer/app/bittorrent/utorrent/torrentu.ts
@@ -21,6 +21,7 @@ export class UtorrentTorrent extends Torrent {
             downloaded: data.downloaded,
             uploaded: data.uploaded,
             ratio: (data.ratio / 1000),
+            ratioLimit: data.additionalData?.seed_override ? (data.additionalData.seed_ratio / 1000) : undefined,
             uploadSpeed: data.uploadSpeed,
             downloadSpeed: data.downloadSpeed,
             eta: data.eta,

--- a/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
+++ b/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
@@ -5,16 +5,7 @@ import { addTorrentUrl, getSnapshot, invokeAction, uploadTorrent } from "@render
 export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
   public name = "µTorrent"
   public id = "utorrent"
-  private ratioLimits = new Map<string, number>()
-
-  build = (array: Array<any>): UtorrentTorrent => {
-    const torrent = UtorrentTorrent.fromArray(array)
-    const ratioLimit = this.ratioLimits.get(torrent.hash) ?? this.ratioLimits.get(torrent.hash.toLowerCase())
-    if (ratioLimit !== undefined) {
-      torrent.ratioLimit = ratioLimit
-    }
-    return torrent
-  }
+  build = (array: Array<any>): UtorrentTorrent => UtorrentTorrent.fromApiArray(array)
 
   defaultPath(): string {
     return "/gui";
@@ -103,14 +94,10 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
     return invokeAction("setSpeedLimits", torrents.map((torrent) => torrent.hash), options);
   }
 
-  setRatioLimit(torrents: UtorrentTorrent[], options: TorrentRatioLimitOptions): Promise<void> {
-    return invokeAction("setRatioLimit", torrents.map((torrent) => torrent.hash), options).then(() => {
-      torrents.forEach((torrent) => {
-        torrent.ratioLimit = options.ratioLimit;
-        this.ratioLimits.set(torrent.hash, options.ratioLimit);
-        this.ratioLimits.set(torrent.hash.toLowerCase(), options.ratioLimit);
-      });
-    });
+  async setRatioLimit(torrents: UtorrentTorrent[], options: TorrentRatioLimitOptions): Promise<void> {
+    const hashes = torrents.map((torrent) => torrent.hash);
+    await invokeAction("setRatioLimit", hashes, options);
+    await invokeAction("getprops", hashes);
   };
 
   private baseActionHeader: TorrentActionList<UtorrentTorrent> = [
@@ -176,12 +163,6 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
       label: "Set Speed Limits",
       click: () => Promise.resolve(),
       icon: "dashboard",
-    },
-    {
-      id: "torrent-set-ratio",
-      label: "Set Ratio",
-      click: () => Promise.resolve(),
-      icon: "percent",
     },
     {
       label: "Remove",

--- a/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
+++ b/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
@@ -1,12 +1,19 @@
-import { ContextActionList, TorrentActionList, TorrentClient, TorrentSpeedLimitOptions, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
+import { ContextActionList, TorrentActionList, TorrentClient, TorrentRatioLimitOptions, TorrentSpeedLimitOptions, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { UtorrentTorrent } from "./torrentu";
 import { addTorrentUrl, getSnapshot, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 
 export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
   public name = "µTorrent"
   public id = "utorrent"
-  build(array: Array<any>): UtorrentTorrent {
-    return UtorrentTorrent.fromArray(array)
+  private ratioLimits = new Map<string, number>()
+
+  build = (array: Array<any>): UtorrentTorrent => {
+    const torrent = UtorrentTorrent.fromArray(array)
+    const ratioLimit = this.ratioLimits.get(torrent.hash) ?? this.ratioLimits.get(torrent.hash.toLowerCase())
+    if (ratioLimit !== undefined) {
+      torrent.ratioLimit = ratioLimit
+    }
+    return torrent
   }
 
   defaultPath(): string {
@@ -94,6 +101,16 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
 
   setSpeedLimits(torrents: UtorrentTorrent[], options: TorrentSpeedLimitOptions): Promise<void> {
     return invokeAction("setSpeedLimits", torrents.map((torrent) => torrent.hash), options);
+  }
+
+  setRatioLimit(torrents: UtorrentTorrent[], options: TorrentRatioLimitOptions): Promise<void> {
+    return invokeAction("setRatioLimit", torrents.map((torrent) => torrent.hash), options).then(() => {
+      torrents.forEach((torrent) => {
+        torrent.ratioLimit = options.ratioLimit;
+        this.ratioLimits.set(torrent.hash, options.ratioLimit);
+        this.ratioLimits.set(torrent.hash.toLowerCase(), options.ratioLimit);
+      });
+    });
   };
 
   private baseActionHeader: TorrentActionList<UtorrentTorrent> = [
@@ -159,6 +176,12 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
       label: "Set Speed Limits",
       click: () => Promise.resolve(),
       icon: "dashboard",
+    },
+    {
+      id: "torrent-set-ratio",
+      label: "Set Ratio",
+      click: () => Promise.resolve(),
+      icon: "percent",
     },
     {
       label: "Remove",

--- a/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.controller.ts
+++ b/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.controller.ts
@@ -79,13 +79,13 @@ export class TorrentSetRatioModalController {
     }
 
     if (this.scope.ratioLimit === null || this.scope.ratioLimit === undefined || String(this.scope.ratioLimit) === "") {
-      this.scope.error = "Enter a ratio target";
+      this.scope.error = "Enter a ratio limit";
       return;
     }
 
     const ratioLimit = Number(this.scope.ratioLimit);
     if (!Number.isFinite(ratioLimit) || ratioLimit < 0) {
-      this.scope.error = "Ratio target must be zero or greater";
+      this.scope.error = "Ratio limit must be zero or greater";
       return;
     }
 
@@ -94,13 +94,13 @@ export class TorrentSetRatioModalController {
       this.scope.error = null;
       const client = this.rootScope.$btclient;
       if (!client || typeof client.setRatioLimit !== "function") {
-        throw new Error("Ratio targets are not available for the current client");
+        throw new Error("Ratio limits are not available for the current client");
       }
       await client.setRatioLimit(this.scope.torrents, { ratioLimit });
       await this.scope.onSaved?.();
       this.close();
     } catch (err: any) {
-      this.scope.error = err?.message || "Failed to set ratio target";
+      this.scope.error = err?.message || "Failed to set ratio limit";
     } finally {
       this.scope.loading = false;
     }

--- a/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.controller.ts
+++ b/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.controller.ts
@@ -1,0 +1,108 @@
+import { IScope } from "angular";
+import { ModalController } from "@renderer/app/directives/modal/modal.controller";
+import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
+
+export interface TorrentSetRatioModalScope extends IScope {
+  torrents: any[];
+  ratioLimit?: number | null;
+  loading: boolean;
+  error: string | null;
+  modalRef?: TorrentSetRatioModalController;
+  onSaved?: () => Promise<void> | void;
+}
+
+export class TorrentSetRatioModalController {
+  static $inject = ["$scope", "$rootScope"];
+
+  scope: TorrentSetRatioModalScope;
+  rootScope: ElectorrentRootScope;
+  modalref: ModalController;
+
+  constructor(
+    scope: TorrentSetRatioModalScope,
+    rootScope: ElectorrentRootScope,
+  ) {
+    this.scope = scope;
+    this.rootScope = rootScope;
+    this.reset();
+    this.scope.modalRef = this;
+  }
+
+  private reset() {
+    this.scope.torrents = [];
+    this.scope.ratioLimit = null;
+    this.scope.loading = false;
+    this.scope.error = null;
+  }
+
+  private getSharedRatioLimit(torrents: any[]) {
+    const limits = torrents
+      .map((torrent) => torrent?.ratioLimit)
+      .filter((value) => value !== null && value !== undefined && Number(value) >= 0);
+
+    if (limits.length !== torrents.length || limits.length === 0) {
+      return null;
+    }
+
+    const [firstLimit] = limits;
+    if (!limits.every((limit) => Number(limit) === Number(firstLimit))) {
+      return null;
+    }
+
+    return Number(Number(firstLimit).toFixed(2));
+  }
+
+  open(torrents: any[]) {
+    this.scope.torrents = torrents.slice();
+    this.scope.ratioLimit = this.getSharedRatioLimit(torrents);
+    this.scope.error = null;
+    this.scope.loading = false;
+
+    if (this.modalref) {
+      this.modalref.showModal();
+    }
+  }
+
+  onHidden() {
+    this.reset();
+  }
+
+  close() {
+    if (this.modalref) {
+      this.modalref.hideModal();
+    }
+  }
+
+  async apply() {
+    if (!this.scope.torrents.length) {
+      return;
+    }
+
+    if (this.scope.ratioLimit === null || this.scope.ratioLimit === undefined || String(this.scope.ratioLimit) === "") {
+      this.scope.error = "Enter a ratio target";
+      return;
+    }
+
+    const ratioLimit = Number(this.scope.ratioLimit);
+    if (!Number.isFinite(ratioLimit) || ratioLimit < 0) {
+      this.scope.error = "Ratio target must be zero or greater";
+      return;
+    }
+
+    try {
+      this.scope.loading = true;
+      this.scope.error = null;
+      const client = this.rootScope.$btclient;
+      if (!client || typeof client.setRatioLimit !== "function") {
+        throw new Error("Ratio targets are not available for the current client");
+      }
+      await client.setRatioLimit(this.scope.torrents, { ratioLimit });
+      await this.scope.onSaved?.();
+      this.close();
+    } catch (err: any) {
+      this.scope.error = err?.message || "Failed to set ratio target";
+    } finally {
+      this.scope.loading = false;
+    }
+  }
+}

--- a/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.directive.ts
+++ b/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.directive.ts
@@ -1,0 +1,18 @@
+import { IDirective, IDirectiveFactory } from "angular";
+import { TorrentSetRatioModalController } from "./torrent-set-ratio-modal.controller";
+import html from "./torrent-set-ratio-modal.template.html";
+
+export class TorrentSetRatioModalDirective implements IDirective {
+  template = html;
+  restrict = "E";
+  scope = {
+    modalRef: "=?",
+    onSaved: "<",
+  };
+  controller = TorrentSetRatioModalController;
+  controllerAs = "ctl";
+
+  static getInstance(): IDirectiveFactory {
+    return () => new TorrentSetRatioModalDirective();
+  }
+}

--- a/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.template.html
+++ b/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.template.html
@@ -6,20 +6,20 @@
     <i class="close icon"></i>
     <div class="header">
         <i class="percent icon"></i>
-        Set Ratio Target
+        Set Ratio Limit
     </div>
     <div class="content">
         <form class="ui form" ng-submit="ctl.apply()">
-            <p>Enter a ratio target. The current ratio is shown when all selected torrents share the same target.</p>
+            <p>Enter a ratio limit. The current limit is shown when all selected torrents share the same limit.</p>
             <div class="field">
-                <label for="torrent-set-ratio-value">Ratio target</label>
+                <label for="torrent-set-ratio-value">Ratio limit</label>
                 <input
                     id="torrent-set-ratio-value"
                     data-role="torrent-set-ratio-value"
                     type="number"
                     min="0"
                     step="0.01"
-                    placeholder="Ratio target"
+                    placeholder="Ratio limit"
                     ng-model="ctl.scope.ratioLimit">
             </div>
             <div class="ui negative message" ng-if="ctl.scope.error">

--- a/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.template.html
+++ b/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.template.html
@@ -1,0 +1,45 @@
+<modal
+    id="torrent-set-ratio-modal"
+    size="tiny"
+    on-hidden="ctl.onHidden()"
+    ng-ref="ctl.modalref">
+    <i class="close icon"></i>
+    <div class="header">
+        <i class="percent icon"></i>
+        Set Ratio Target
+    </div>
+    <div class="content">
+        <form class="ui form" ng-submit="ctl.apply()">
+            <p>Enter a ratio target. The current ratio is shown when all selected torrents share the same target.</p>
+            <div class="field">
+                <label for="torrent-set-ratio-value">Ratio target</label>
+                <input
+                    id="torrent-set-ratio-value"
+                    data-role="torrent-set-ratio-value"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    placeholder="Ratio target"
+                    ng-model="ctl.scope.ratioLimit">
+            </div>
+            <div class="ui negative message" ng-if="ctl.scope.error">
+                <p>{{ ctl.scope.error }}</p>
+            </div>
+        </form>
+    </div>
+    <div class="actions">
+        <button type="button" class="ui black deny button" ng-class="{ disabled: ctl.scope.loading }" ng-click="ctl.close()">
+            Cancel
+        </button>
+        <button
+            type="button"
+            class="ui green right labeled icon button"
+            data-role="torrent-set-ratio-apply"
+            ng-class="{ disabled: ctl.scope.loading }"
+            ng-disabled="ctl.scope.loading"
+            ng-click="ctl.apply()">
+            Apply
+            <i class="checkmark icon"></i>
+        </button>
+    </div>
+</modal>

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -13,6 +13,7 @@ interface TorrentControllerScope extends angular.IScope {
         torrents: any[];
     };
     speedLimitModalRef?: { open(torrents: any[]): void };
+    setRatioModalRef?: { open(torrents: any[]): void };
     [key: string]: any;
 }
 
@@ -672,6 +673,12 @@ export class TorrentsPageController {
             if (item && item.id === "torrent-set-speed-limits") {
                 if (selected.length >= 1) {
                     $scope.speedLimitModalRef?.open(selected.slice());
+                }
+                return $q.resolve();
+            }
+            if (item && item.id === "torrent-set-ratio") {
+                if (selected.length >= 1) {
+                    $scope.setRatioModalRef?.open(selected.slice());
                 }
                 return $q.resolve();
             }

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -174,6 +174,7 @@
     </modal>
 
     <torrent-speed-modal modal-ref="speedLimitModalRef" on-saved="syncAfterTorrentMutation"></torrent-speed-modal>
+    <torrent-set-ratio-modal modal-ref="setRatioModalRef" on-saved="syncAfterTorrentMutation"></torrent-set-ratio-modal>
 
     <add-torrent-modal
         torrents="pendingTorrentFiles"

--- a/src/renderer/app/filters/torrent-ratio.filter.ts
+++ b/src/renderer/app/filters/torrent-ratio.filter.ts
@@ -6,7 +6,7 @@ export class TorrentRatioFilter {
     }
 
     public transform: IFilterNumber = (ratio): string => {
-        if (this.isNumeric(ratio)) {
+        if (this.isNumeric(ratio) && Number(ratio) >= 0) {
             return parseFloat(String(ratio)).toFixed(2);
         }
 

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -194,6 +194,7 @@ export interface TorrentClientFeatures {
     readonly trackerFilter?: boolean
     readonly alternativeSpeedLimits?: boolean
     readonly speedLimits?: boolean
+    readonly ratioLimits?: boolean
     readonly freeDiskSpace?: boolean
     readonly uploadOptions?: Readonly<TorrentUploadOptionsEnable>
 }
@@ -212,6 +213,7 @@ export interface ResolvedTorrentClientFeatures {
     readonly trackerFilter: boolean
     readonly alternativeSpeedLimits: boolean
     readonly speedLimits: boolean
+    readonly ratioLimits: boolean
     readonly freeDiskSpace: boolean
     readonly uploadOptions: Readonly<Required<Record<keyof TorrentUploadOptions, boolean>>>
 }

--- a/test/clients/deluge/index.ts
+++ b/test/clients/deluge/index.ts
@@ -6,6 +6,7 @@ const baseFeatures = {
   labels: true,
   torrentDetails: true,
   speedLimits: true,
+  ratioLimits: true,
   freeDiskSpace: true,
   uploadOptions: {
     saveLocation: true,

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -11,6 +11,7 @@ const features = {
   trackerFilter: true,
   alternativeSpeedLimits: true,
   speedLimits: true,
+  ratioLimits: true,
   freeDiskSpace: true,
   uploadOptions: {
     saveLocation: true,

--- a/test/clients/transmission/index.ts
+++ b/test/clients/transmission/index.ts
@@ -9,6 +9,7 @@ const features = {
   torrentDetails: true,
   trackerFilter: true,
   speedLimits: true,
+  ratioLimits: true,
   freeDiskSpace: true,
   uploadOptions: {
     saveLocation: true,

--- a/test/clients/utorrent/index.ts
+++ b/test/clients/utorrent/index.ts
@@ -6,7 +6,7 @@ const features = {
   magnetLinks: true,
   labels: true,
   speedLimits: true,
-  ratioLimits: true,
+  ratioLimits: false,
   uploadOptions: {
     saveLocation: true,
   },

--- a/test/clients/utorrent/index.ts
+++ b/test/clients/utorrent/index.ts
@@ -6,6 +6,7 @@ const features = {
   magnetLinks: true,
   labels: true,
   speedLimits: true,
+  ratioLimits: true,
   uploadOptions: {
     saveLocation: true,
   },

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -3,7 +3,7 @@ import { ClickOptions } from "webdriverio";
 import { browser, $, $$ } from '@wdio/globals'
 import { waitForModalClose, waitForModalOpen } from "./modal"
 
-export type ColumnName = "decodedName" | "size" | "downloadSpeed" | "uploadSpeed" | "downloadLimit" | "uploadLimit" | "percent" | "label" | "dateAdded" | "dateCompleted" | "peersConnected" | "seedsConnected" | "torrentQueueOrder" | "eta" | "ratio"
+export type ColumnName = "decodedName" | "size" | "downloadSpeed" | "uploadSpeed" | "downloadLimit" | "uploadLimit" | "percent" | "label" | "dateAdded" | "dateCompleted" | "peersConnected" | "seedsConnected" | "torrentQueueOrder" | "eta" | "ratio" | "ratioLimit"
 
 export class Torrent {
   app: App
@@ -155,6 +155,20 @@ export class Torrent {
     return modal;
   }
 
+  async openSetRatioModal() {
+    await this.openContextMenu()
+
+    const contextMenu = $("#contextmenu")
+    const action = contextMenu.$("a=Set Ratio")
+    await action.waitForDisplayed()
+    await action.click()
+    await contextMenu.waitForDisplayed({ reverse: true })
+
+    const modal = $("#torrent-set-ratio-modal");
+    await waitForModalOpen(modal, this.timeout);
+    return modal;
+  }
+
   async openDetailsPanel() {
     await this.clickContextMenu("torrent-details")
 
@@ -235,6 +249,29 @@ export class Torrent {
     await cancel.click();
     await waitForModalClose(modal, this.timeout);
     return { download, upload };
+  }
+
+  async setRatioLimit(ratioLimit: number) {
+    const modal = await this.openSetRatioModal();
+    const input = modal.$("input[data-role='torrent-set-ratio-value']");
+    await input.waitForDisplayed();
+    await input.clearValue();
+    await input.setValue(String(ratioLimit));
+
+    const approve = modal.$("button[data-role='torrent-set-ratio-apply']");
+    await approve.waitForEnabled();
+    await approve.click();
+    await waitForModalClose(modal, this.timeout);
+  }
+
+  async getRatioModalValue() {
+    const modal = await this.openSetRatioModal();
+    const ratio = await modal.$("input[data-role='torrent-set-ratio-value']").getValue();
+    const cancel = modal.$("button.deny");
+    await cancel.waitForClickable();
+    await cancel.click();
+    await waitForModalClose(modal, this.timeout);
+    return ratio;
   }
 
   async stop({ state = "Stopped", timeout = this.timeout } = {}) {

--- a/test/specs/standard/settings.spec.ts
+++ b/test/specs/standard/settings.spec.ts
@@ -121,7 +121,7 @@ describe("settings", function () {
       torrent = await this.app.uploadTorrent({ filename: torrentFile })
       await this.app.uploadTorrentModalVisible()
       await this.app.uploadTorrentModalSubmit()
-      await torrent.waitForExist()
+      await torrent.waitForExist({ timeout: 30 * 1000 })
     } finally {
       if (torrent && await torrent.isExisting()) {
         await torrent.delete()

--- a/test/specs/standard/torrent-ratio-limits.spec.ts
+++ b/test/specs/standard/torrent-ratio-limits.spec.ts
@@ -1,0 +1,44 @@
+import { browser } from '@wdio/globals'
+import { createTorrentFile } from '../../torrent'
+import { configureSpec, createUniqueLabel, getTestFixture, requireFeature } from '../../framework/fixture'
+
+const fixture = getTestFixture()
+const client = fixture.client
+const tracker = fixture.tracker
+
+describe('torrent ratio limits', function () {
+  configureSpec()
+  requireFeature(({ features }) => features.ratioLimits === true)
+
+  let torrent
+
+  beforeEach(async function () {
+    const filename = await createTorrentFile(tracker, { torrentName: createUniqueLabel('torrent-ratio-limits') })
+    torrent = await this.app.uploadTorrent({ filename })
+    await torrent.waitForStates([client.downloadLabel, 'Seeding'])
+  })
+
+  afterEach(async function () {
+    if (torrent) {
+      await torrent.delete().catch(() => undefined)
+      torrent = null
+    }
+  })
+
+  it('sets ratio target from context menu', async function () {
+    const ratioLimit = 1.5
+    await torrent.setRatioLimit(ratioLimit)
+
+    await browser.waitUntil(async () => await torrent.getRatioModalValue() === String(ratioLimit), {
+      timeout: 10 * 1000,
+      timeoutMsg: `Expected ratio modal to show ratio target ${ratioLimit}`,
+    })
+
+    if (client.clientId !== 'utorrent') {
+      await browser.waitUntil(async () => await torrent.getColumn('ratioLimit') === ratioLimit.toFixed(2), {
+        timeout: 10 * 1000,
+        timeoutMsg: `Expected ratio target column to become ${ratioLimit.toFixed(2)}`,
+      })
+    }
+  })
+})

--- a/test/specs/standard/torrent-ratio-limits.spec.ts
+++ b/test/specs/standard/torrent-ratio-limits.spec.ts
@@ -1,6 +1,9 @@
+import chai from 'chai'
 import { browser } from '@wdio/globals'
 import { createTorrentFile } from '../../torrent'
 import { configureSpec, createUniqueLabel, getTestFixture, requireFeature } from '../../framework/fixture'
+
+const { assert } = chai
 
 const fixture = getTestFixture()
 const client = fixture.client
@@ -11,6 +14,14 @@ describe('torrent ratio limits', function () {
   requireFeature(({ features }) => features.ratioLimits === true)
 
   let torrent
+
+  before(async function () {
+    await this.app.openSettings()
+    await this.app.settingsGotoTab('layout')
+    await this.app.setLayoutColumnEnabled('Ratio Limit', true)
+    await this.app.settingsSave()
+    await this.app.torrentsPageIsVisible()
+  })
 
   beforeEach(async function () {
     const filename = await createTorrentFile(tracker, { torrentName: createUniqueLabel('torrent-ratio-limits') })
@@ -25,13 +36,15 @@ describe('torrent ratio limits', function () {
     }
   })
 
-  it('sets ratio target from context menu', async function () {
+  it('sets ratio limit from context menu', async function () {
     const ratioLimit = 1.5
     await torrent.setRatioLimit(ratioLimit)
 
-    await browser.waitUntil(async () => await torrent.getRatioModalValue() === String(ratioLimit), {
+    await browser.waitUntil(async () => await torrent.getColumn('ratioLimit') === ratioLimit.toFixed(2), {
       timeout: 10 * 1000,
-      timeoutMsg: `Expected ratio modal to show ratio target ${ratioLimit}`,
+      timeoutMsg: `Expected ratio limit column to show ${ratioLimit.toFixed(2)}`,
     })
+
+    assert.equal(await torrent.getRatioModalValue(), String(ratioLimit))
   })
 })

--- a/test/specs/standard/torrent-ratio-limits.spec.ts
+++ b/test/specs/standard/torrent-ratio-limits.spec.ts
@@ -33,12 +33,5 @@ describe('torrent ratio limits', function () {
       timeout: 10 * 1000,
       timeoutMsg: `Expected ratio modal to show ratio target ${ratioLimit}`,
     })
-
-    if (client.clientId !== 'utorrent') {
-      await browser.waitUntil(async () => await torrent.getColumn('ratioLimit') === ratioLimit.toFixed(2), {
-        timeout: 10 * 1000,
-        timeoutMsg: `Expected ratio target column to become ${ratioLimit.toFixed(2)}`,
-      })
-    }
   })
 })


### PR DESCRIPTION
## Summary
- add per-torrent ratio target support for qBittorrent, Transmission, Deluge, and µTorrent
- add Set Ratio context action, modal, and Ratio Target column
- add cross-client ratio target e2e coverage

## Research
Supported API-backed clients:
- qBittorrent: POST /api/v2/torrents/setShareLimits
- Transmission: torrent-set with seedRatioMode/seedRatioLimit
- Deluge: core.set_torrent_stop_at_ratio + core.set_torrent_stop_ratio
- µTorrent: /gui/?action=setprops seed_override + seed_ratio

Unsupported for now:
- rTorrent: no direct per-torrent ratio target setter; ratio groups only
- Synology: no documented per-task ratio target API

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-ratio-limits.spec.ts"
- npm run test -- --client "qbittorrent:4" --spec "test/specs/standard/torrent-ratio-limits.spec.ts"
- npm run test -- --client "qbittorrent:5" --spec "test/specs/standard/torrent-ratio-limits.spec.ts"
- npm run test -- --client "transmission" --spec "test/specs/standard/torrent-ratio-limits.spec.ts"
- npm run test -- --client "deluge:1" --spec "test/specs/standard/torrent-ratio-limits.spec.ts"
- npm run test -- --client "deluge:2" --spec "test/specs/standard/torrent-ratio-limits.spec.ts"
- npm run test -- --client "utorrent" --spec "test/specs/standard/torrent-ratio-limits.spec.ts"