### PR TITLE
feat: add Windows title bar menu

### DIFF
--- a/.github/workflows/electorrent-workflow.yml
+++ b/.github/workflows/electorrent-workflow.yml
@@ -101,6 +101,13 @@ jobs:
     - name: Build distribution
       run: npm run dist
       if: github.ref != 'refs/heads/master'
+    - name: Upload distribution
+      uses: actions/upload-artifact@v4
+      if: github.event_name == 'pull_request'
+      with:
+        name: electorrent-dist-${{ runner.os }}
+        path: dist/**
+        if-no-files-found: error
     - name: Release artifacts
       if: github.ref == 'refs/heads/master'
       run: npm run release

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -1,8 +1,8 @@
-import { app, dialog, ipcMain, nativeTheme, shell, type BrowserWindow, type IpcMainInvokeEvent } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, nativeTheme, shell, type IpcMainInvokeEvent } from 'electron'
 import is from 'electron-is'
 
 import { IPC_CHANNELS } from '@shared/ipc'
-import type { AppSettings, PendingTorrentUploadLink } from '@shared/ipc-contract'
+import type { AppSettings, EditCommand, PendingTorrentUploadLink, WindowCommand } from '@shared/ipc-contract'
 import { getAppVersion } from './app-meta'
 import { bittorrentManager } from './bittorrent'
 import * as certificates from './certificates'
@@ -41,6 +41,60 @@ function getAppMeta(isDebug: boolean) {
     }
 }
 
+function getCommandWindow(event: IpcMainInvokeEvent, getWindow: () => BrowserWindow | null) {
+    const eventWindow = BrowserWindow.fromWebContents(event.sender)
+    if (eventWindow && !eventWindow.isDestroyed()) {
+        return eventWindow
+    }
+
+    const window = getWindow()
+    return window && !window.isDestroyed() ? window : null
+}
+
+function runWindowCommand(window: BrowserWindow, command: WindowCommand) {
+    switch (command) {
+        case 'reload':
+            window.reload()
+            break
+        case 'toggle-full-screen':
+            window.setFullScreen(!window.isFullScreen())
+            break
+        case 'toggle-dev-tools':
+            window.webContents.toggleDevTools()
+            break
+        case 'minimize':
+            window.minimize()
+            break
+        case 'close':
+            window.close()
+            break
+        default:
+            break
+    }
+}
+
+function runEditCommand(window: BrowserWindow, command: EditCommand) {
+    switch (command) {
+        case 'undo':
+            window.webContents.undo()
+            break
+        case 'redo':
+            window.webContents.redo()
+            break
+        case 'cut':
+            window.webContents.cut()
+            break
+        case 'copy':
+            window.webContents.copy()
+            break
+        case 'paste':
+            window.webContents.paste()
+            break
+        default:
+            break
+    }
+}
+
 export function registerHandlers({ isDebug, getWindow, consumePendingLaunchPayload, onSettingsSaved, onSystemThemeChanged, onBittorrentConnected }: RegisterHandlersOptions) {
     menu.configure({ isDebug })
 
@@ -66,6 +120,24 @@ export function registerHandlers({ isDebug, getWindow, consumePendingLaunchPaylo
 
     ipcMain.handle(IPC_CHANNELS.app.reportCorruptSettings, async function() {
         settings.showCorruptDialog()
+    })
+
+    ipcMain.handle(IPC_CHANNELS.window.command, async function(event: IpcMainInvokeEvent, { command }) {
+        if (!isDebug && (command === 'reload' || command === 'toggle-dev-tools')) {
+            return
+        }
+
+        const window = getCommandWindow(event, getWindow)
+        if (window) {
+            runWindowCommand(window, command)
+        }
+    })
+
+    ipcMain.handle(IPC_CHANNELS.edit.command, async function(event: IpcMainInvokeEvent, { command }) {
+        const window = getCommandWindow(event, getWindow)
+        if (window) {
+            runEditCommand(window, command)
+        }
     })
 
     ipcMain.handle(IPC_CHANNELS.shell.openExternal, async function(_event: IpcMainInvokeEvent, { url }) {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,7 +1,7 @@
 import { clipboard, contextBridge, ipcRenderer, webUtils } from 'electron'
 
 import { IPC_CHANNELS } from '@shared/ipc'
-import type { ColorTheme, PendingTorrentUploadFile, PendingTorrentUploadLink } from '@shared/ipc-contract'
+import type { ColorTheme, EditCommand, PendingTorrentUploadFile, PendingTorrentUploadLink, WindowCommand } from '@shared/ipc-contract'
 
 const INITIAL_THEME_ARGUMENT = '--theme='
 const initialThemeArgument = process.argv.find((argument) => argument.startsWith(INITIAL_THEME_ARGUMENT))
@@ -75,6 +75,12 @@ contextBridge.exposeInMainWorld('electorrent', {
     },
     notifications: {
         onPush: (callback: (notification: unknown) => void) => subscribe(IPC_CHANNELS.notifications.push, callback),
+    },
+    edit: {
+        command: (command: EditCommand) => invoke(IPC_CHANNELS.edit.command, { command }),
+    },
+    window: {
+        command: (command: WindowCommand) => invoke(IPC_CHANNELS.window.command, { command }),
     },
     menu: {
         onAction: (callback: (action: unknown) => void) => subscribe(IPC_CHANNELS.menu.action, callback),

--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -1,7 +1,28 @@
 import { IScope } from "angular";
 import { PendingTorrentUploadFile, PendingTorrentUploadLink } from "@renderer/app/directives/add-torrent-modal/add-torrent-modal.directive";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
-import type { AppMeta, LaunchPayload, MenuAction } from "@shared/ipc-contract";
+import type { AppMeta, EditCommand, LaunchPayload, MenuAction, WindowCommand } from "@shared/ipc-contract";
+
+type TitleBarMenuAction =
+    | MenuAction
+    | { type: "quit" }
+    | { type: "edit-command"; command: EditCommand }
+    | { type: "window-command"; command: WindowCommand };
+
+interface TitleBarMenuItem {
+    label: string;
+    accelerator?: string;
+    separator?: boolean;
+    checked?: boolean;
+    enabled?: boolean;
+    visible?: () => boolean;
+    action?: TitleBarMenuAction;
+}
+
+interface TitleBarMenu {
+    label: string;
+    items: () => TitleBarMenuItem[];
+}
 
 interface AppShellScope extends IScope {
     servers: any[];
@@ -16,6 +37,14 @@ interface AppShellScope extends IScope {
     showSettings: () => boolean;
     showWelcome: () => boolean;
     showServers: () => boolean;
+    isWindows: boolean;
+    activeTitleBarMenu: number | null;
+    titleBarMenus: TitleBarMenu[];
+    visibleTitleBarMenuItems: (menu: TitleBarMenu) => TitleBarMenuItem[];
+    toggleTitleBarMenu: (index: number, $event: Event) => void;
+    openTitleBarMenu: (index: number) => void;
+    closeTitleBarMenu: () => void;
+    runTitleBarMenuItem: (item: TitleBarMenuItem, $event: Event) => void;
     [key: string]: any;
 }
 
@@ -42,6 +71,230 @@ export class AppShellController {
         let page: string | null = null;
         let pendingMagnets: Array<PendingTorrentUploadLink & { askUploadOptions?: boolean }> = [];
         let pendingTorrentFiles: Array<PendingTorrentUploadFile & { askUploadOptions?: boolean }> = [];
+        let isDebug = false;
+
+        const getActiveTextInput = () => {
+            return document.activeElement instanceof HTMLInputElement || document.activeElement instanceof HTMLTextAreaElement
+                ? document.activeElement
+                : null;
+        };
+
+        const supportsUploadOptions = () => {
+            return Object.values($rootScope.$btclient?.features.uploadOptions || {}).some(Boolean);
+        };
+
+        const hasActiveServer = () => {
+            return !!$rootScope.$server?.id;
+        };
+
+        const serverAccelerator = (index: number) => {
+            return index > 0 && index <= 10 ? `Ctrl+${index % 10}` : undefined;
+        };
+
+        const getServerLabel = (server: any) => {
+            if (typeof server?.getDisplayName === "function") {
+                return server.getDisplayName();
+            }
+
+            return server?.name || server?.ip || "Server";
+        };
+
+        const handleMenuAction = (action: MenuAction) => {
+            switch (action.type) {
+                case "show-settings":
+                    $scope.$emit("show:settings");
+                    break;
+                case "show-servers":
+                    $scope.$emit("show:servers");
+                    break;
+                case "search-torrent":
+                    $rootScope.$broadcast("search:torrent");
+                    break;
+                case "select-all":
+                    {
+                        const activeTextInput = getActiveTextInput();
+                        if (activeTextInput) {
+                            activeTextInput.select();
+                        } else if (page === PAGE_TORRENTS) {
+                            $scope.$broadcast("select:torrents");
+                        }
+                    }
+                    break;
+                case "remove-selected":
+                    if (document.activeElement?.nodeName !== "INPUT" && page === PAGE_TORRENTS) {
+                        $scope.$broadcast("remove:torrents");
+                    }
+                    break;
+                case "open-add-torrent":
+                    electorrent.torrents.openFiles(!!action.askUploadOptions).then((files: Array<PendingTorrentUploadFile & { askUploadOptions?: boolean }>) => {
+                        files.forEach((item) => broadcastTorrentFile(item, !!item.askUploadOptions));
+                    });
+                    break;
+                case "paste-torrent-url":
+                    $bittorrent.uploadFromClipboard(!!action.askUploadOptions);
+                    break;
+                case "open-external":
+                    electorrent.shell.openExternal(action.url);
+                    break;
+                case "check-for-updates":
+                    electorrent.updates.check(!!action.verbose);
+                    break;
+                case "connect-server":
+                    {
+                        const server = settingsService.getServer(action.serverId);
+                        if (server) {
+                            connectToServer(server);
+                        }
+                    }
+                    break;
+                case "set-current-default-server":
+                    settingsService.setCurrentServerAsDefault();
+                    break;
+                case "add-server":
+                    $scope.$emit("add:server");
+                    break;
+                default:
+                    break;
+            }
+            $scope.$applyAsync();
+        };
+
+        const runTitleBarAction = (action: TitleBarMenuAction) => {
+            switch (action.type) {
+                case "quit":
+                    electorrent.app.quit();
+                    break;
+                case "edit-command":
+                    electorrent.edit.command(action.command);
+                    break;
+                case "window-command":
+                    electorrent.window.command(action.command);
+                    break;
+                default:
+                    handleMenuAction(action);
+                    break;
+            }
+        };
+
+        const fileMenuItems = (): TitleBarMenuItem[] => [
+            {
+                label: "Add Torrent",
+                accelerator: "Ctrl+O",
+                action: { type: "open-add-torrent", askUploadOptions: false },
+            },
+            {
+                label: "Add Torrent (Advanced)",
+                accelerator: "Ctrl+Shift+O",
+                visible: supportsUploadOptions,
+                action: { type: "open-add-torrent", askUploadOptions: true },
+            },
+            {
+                label: "Paste Torrent URL",
+                accelerator: "Ctrl+I",
+                action: { type: "paste-torrent-url", askUploadOptions: false },
+            },
+            {
+                label: "Paste Torrent URL (Advanced)",
+                accelerator: "Ctrl+Shift+I",
+                visible: supportsUploadOptions,
+                action: { type: "paste-torrent-url", askUploadOptions: true },
+            },
+            { label: "", separator: true },
+            {
+                label: "Settings",
+                accelerator: "Ctrl+,",
+                action: { type: "show-settings" },
+            },
+            { label: "", separator: true },
+            {
+                label: "Exit",
+                action: { type: "quit" },
+            },
+        ];
+
+        const editMenuItems = (): TitleBarMenuItem[] => [
+            { label: "Undo", accelerator: "Ctrl+Z", action: { type: "edit-command", command: "undo" } },
+            { label: "Redo", accelerator: "Shift+Ctrl+Z", action: { type: "edit-command", command: "redo" } },
+            { label: "", separator: true },
+            { label: "Find", accelerator: "Ctrl+F", action: { type: "search-torrent" } },
+            { label: "Cut", accelerator: "Ctrl+X", action: { type: "edit-command", command: "cut" } },
+            { label: "Copy", accelerator: "Ctrl+C", action: { type: "edit-command", command: "copy" } },
+            { label: "Paste", accelerator: "Ctrl+V", action: { type: "edit-command", command: "paste" } },
+            { label: "Remove", accelerator: "Delete", action: { type: "remove-selected" } },
+            { label: "Select All", accelerator: "Ctrl+A", action: { type: "select-all" } },
+        ];
+
+        const viewMenuItems = (): TitleBarMenuItem[] => [
+            {
+                label: "Reload",
+                accelerator: "Ctrl+R",
+                visible: () => isDebug,
+                action: { type: "window-command", command: "reload" },
+            },
+            {
+                label: "Toggle Full Screen",
+                accelerator: "F11",
+                action: { type: "window-command", command: "toggle-full-screen" },
+            },
+            {
+                label: "Toggle Developer Tools",
+                accelerator: "Ctrl+Shift+I",
+                visible: () => isDebug,
+                action: { type: "window-command", command: "toggle-dev-tools" },
+            },
+        ];
+
+        const serverMenuItems = (): TitleBarMenuItem[] => {
+            const items: TitleBarMenuItem[] = [
+                { label: "Add new server...", accelerator: "Ctrl+N", action: { type: "add-server" } },
+                {
+                    label: "Set current as default",
+                    enabled: hasActiveServer(),
+                    action: { type: "set-current-default-server" },
+                },
+                { label: "", separator: true },
+            ];
+
+            if (!hasActiveServer()) {
+                items.push({ label: "Disabled...", enabled: false });
+                return items;
+            }
+
+            $scope.servers.forEach((server, index) => {
+                items.push({
+                    label: getServerLabel(server),
+                    accelerator: serverAccelerator(index + 1),
+                    checked: server.id === $rootScope.$server?.id,
+                    action: { type: "connect-server", serverId: server.id },
+                });
+            });
+
+            return items;
+        };
+
+        const windowMenuItems = (): TitleBarMenuItem[] => [
+            {
+                label: "Minimize",
+                accelerator: "Ctrl+M",
+                action: { type: "window-command", command: "minimize" },
+            },
+            {
+                label: "Close",
+                accelerator: "Ctrl+W",
+                action: { type: "window-command", command: "close" },
+            },
+        ];
+
+        const helpMenuItems = (): TitleBarMenuItem[] => [
+            {
+                label: "Learn More",
+                action: { type: "open-external", url: "https://github.com/tympanix/Electorrent" },
+            },
+            {
+                label: "Check For Updates",
+                action: { type: "check-for-updates", verbose: true },
+            },
+        ];
 
         $scope.servers = settingsService.getServers();
         $scope.connectedServerName = () => $rootScope.$server?.getDisplayName() || "";
@@ -56,9 +309,62 @@ export class AppShellController {
         $scope.showTorrents = false;
         $scope.showLoading = true;
         $scope.statusText = "Loading";
+        $scope.isWindows = false;
+        $scope.activeTitleBarMenu = null;
+        $scope.titleBarMenus = [
+            { label: "File", items: fileMenuItems },
+            { label: "Edit", items: editMenuItems },
+            { label: "View", items: viewMenuItems },
+            { label: "Servers", items: serverMenuItems },
+            { label: "Window", items: windowMenuItems },
+            { label: "Help", items: helpMenuItems },
+        ];
+        $scope.visibleTitleBarMenuItems = (menu: TitleBarMenu) => {
+            return menu.items().filter((item) => item.visible ? item.visible() : true);
+        };
+        $scope.toggleTitleBarMenu = (index: number, $event: Event) => {
+            $event.stopPropagation();
+            $scope.activeTitleBarMenu = $scope.activeTitleBarMenu === index ? null : index;
+        };
+        $scope.openTitleBarMenu = (index: number) => {
+            if ($scope.activeTitleBarMenu !== null) {
+                $scope.activeTitleBarMenu = index;
+            }
+        };
+        $scope.closeTitleBarMenu = () => {
+            $scope.activeTitleBarMenu = null;
+        };
+        $scope.runTitleBarMenuItem = (item: TitleBarMenuItem, $event: Event) => {
+            $event.stopPropagation();
+            if (item.separator || item.enabled === false || !item.action) {
+                return;
+            }
+
+            $scope.activeTitleBarMenu = null;
+            runTitleBarAction(item.action);
+        };
+
+        const onDocumentClick = () => {
+            $scope.closeTitleBarMenu();
+            $scope.$applyAsync();
+        };
+        const onDocumentKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                $scope.closeTitleBarMenu();
+                $scope.$applyAsync();
+            }
+        };
+        document.addEventListener("click", onDocumentClick);
+        document.addEventListener("keydown", onDocumentKeyDown);
+        $scope.$on("$destroy", () => {
+            document.removeEventListener("click", onDocumentClick);
+            document.removeEventListener("keydown", onDocumentKeyDown);
+        });
 
         $rootScope.$on("ready", () => {
             Promise.all([settingsService.whenReady(), electorrent.app.getMeta()]).then(([_, meta]: [unknown, AppMeta]) => {
+                $scope.isWindows = meta.isWindows;
+                isDebug = meta.isDebug;
                 const settings = settingsService.getAllSettings();
                 const automaticUpdates = settings?.automaticUpdates;
                 if (!meta.isDebug && automaticUpdates !== false) {
@@ -167,60 +473,7 @@ export class AppShellController {
         });
 
         electorrent.menu.onAction((action: MenuAction) => {
-            switch (action.type) {
-                case "show-settings":
-                    $scope.$emit("show:settings");
-                    break;
-                case "show-servers":
-                    $scope.$emit("show:servers");
-                    break;
-                case "search-torrent":
-                    $rootScope.$broadcast("search:torrent");
-                    break;
-                case "select-all":
-                    if (document.activeElement instanceof HTMLInputElement || document.activeElement instanceof HTMLTextAreaElement) {
-                        document.activeElement.select();
-                    } else if (page === PAGE_TORRENTS) {
-                        $scope.$broadcast("select:torrents");
-                    }
-                    break;
-                case "remove-selected":
-                    if (document.activeElement?.nodeName !== "INPUT" && page === PAGE_TORRENTS) {
-                        $scope.$broadcast("remove:torrents");
-                    }
-                    break;
-                case "open-add-torrent":
-                    electorrent.torrents.openFiles(!!action.askUploadOptions).then((files: Array<PendingTorrentUploadFile & { askUploadOptions?: boolean }>) => {
-                        files.forEach((item) => broadcastTorrentFile(item, !!item.askUploadOptions));
-                    });
-                    break;
-                case "paste-torrent-url":
-                    $bittorrent.uploadFromClipboard(!!action.askUploadOptions);
-                    break;
-                case "open-external":
-                    electorrent.shell.openExternal(action.url);
-                    break;
-                case "check-for-updates":
-                    electorrent.updates.check(!!action.verbose);
-                    break;
-                case "connect-server":
-                    {
-                        const server = settingsService.getServer(action.serverId);
-                        if (server) {
-                            connectToServer(server);
-                        }
-                    }
-                    break;
-                case "set-current-default-server":
-                    settingsService.setCurrentServerAsDefault();
-                    break;
-                case "add-server":
-                    $scope.$emit("add:server");
-                    break;
-                default:
-                    break;
-            }
-            $scope.$applyAsync();
+            handleMenuAction(action);
         });
 
         const pageTorrents = (fullupdate?: boolean) => {

--- a/src/renderer/app/directives/app-shell/app-shell.template.html
+++ b/src/renderer/app/directives/app-shell/app-shell.template.html
@@ -1,5 +1,38 @@
 <div class="main wrapper">
     <header class="title-bar" aria-label="Window title bar">
+        <nav ng-if="isWindows" class="title-bar-menu" aria-label="Application menu">
+            <div class="title-bar-menu-root" ng-repeat="menu in titleBarMenus track by menu.label">
+                <button
+                    type="button"
+                    class="title-bar-menu-trigger"
+                    ng-class="{ active: activeTitleBarMenu === $index }"
+                    ng-click="toggleTitleBarMenu($index, $event)"
+                    ng-mousedown="$event.preventDefault()"
+                    ng-mouseenter="openTitleBarMenu($index)"
+                    aria-haspopup="true"
+                    ng-attr-aria-expanded="{{activeTitleBarMenu === $index}}">
+                    {{menu.label}}
+                </button>
+                <div class="title-bar-menu-dropdown" ng-if="activeTitleBarMenu === $index" ng-click="$event.stopPropagation()" role="menu">
+                    <div ng-repeat="item in visibleTitleBarMenuItems(menu) track by $index">
+                        <div ng-if="item.separator" class="title-bar-menu-divider" role="separator"></div>
+                        <button
+                            ng-if="!item.separator"
+                            type="button"
+                            class="title-bar-menu-item"
+                            ng-class="{ disabled: item.enabled === false, checked: item.checked }"
+                            ng-click="runTitleBarMenuItem(item, $event)"
+                            ng-mousedown="$event.preventDefault()"
+                            role="menuitem"
+                            ng-disabled="item.enabled === false">
+                            <span class="title-bar-menu-check"></span>
+                            <span class="title-bar-menu-label">{{item.label}}</span>
+                            <span class="title-bar-menu-accelerator">{{item.accelerator}}</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </nav>
         <span class="title-bar-server-name-anchor">
             <span class="title-bar-server-name">{{connectedServerName()}}</span>
             <span

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -21,6 +21,101 @@ html, body {
     border-bottom: 1px solid @borderColor;
     app-region: drag;
 }
+.title-bar-menu {
+    position: absolute;
+    top: 0;
+    left: 8px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    app-region: no-drag;
+}
+.title-bar-menu-root {
+    position: relative;
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+.title-bar-menu-trigger,
+.title-bar-menu-item {
+    border: 0;
+    font: inherit;
+    color: @textColor;
+    background: transparent;
+    cursor: default;
+    outline: 0;
+    app-region: no-drag;
+}
+.title-bar-menu-trigger {
+    height: 28px;
+    min-width: 42px;
+    padding: 0 12px;
+    border-radius: @defaultBorderRadius;
+    line-height: 28px;
+}
+.title-bar-menu-trigger:hover,
+.title-bar-menu-trigger.active {
+    color: @hoveredTextColor;
+    background-color: @highlightBackground;
+}
+.title-bar-menu-dropdown {
+    position: absolute;
+    top: 34px;
+    left: 0;
+    min-width: 270px;
+    padding: 6px 0;
+    color: @textColor;
+    background-color: @pageForeground;
+    border: 1px solid @borderColor;
+    border-radius: @defaultBorderRadius;
+    box-shadow: @subtleShadow;
+    z-index: 1002;
+    app-region: no-drag;
+}
+.title-bar-menu-item {
+    display: grid;
+    grid-template-columns: 18px minmax(0, 1fr) auto;
+    column-gap: 8px;
+    align-items: center;
+    width: 100%;
+    min-height: 30px;
+    padding: 6px 12px;
+    text-align: left;
+    white-space: nowrap;
+}
+.title-bar-menu-item:hover,
+.title-bar-menu-item:focus {
+    color: @hoveredTextColor;
+    background-color: @highlightBackground;
+}
+.title-bar-menu-item.disabled,
+.title-bar-menu-item:disabled {
+    color: @disabledTextColor;
+    background: transparent;
+}
+.title-bar-menu-check {
+    text-align: center;
+}
+.title-bar-menu-item.checked .title-bar-menu-check::before {
+    content: "\2713";
+}
+.title-bar-menu-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.title-bar-menu-accelerator {
+    color: @lightTextColor;
+    font-size: 0.9em;
+}
+.title-bar-menu-item.disabled .title-bar-menu-accelerator,
+.title-bar-menu-item:disabled .title-bar-menu-accelerator {
+    color: @disabledTextColor;
+}
+.title-bar-menu-divider {
+    height: 1px;
+    margin: 6px 0;
+    background-color: @borderColor;
+}
 .title-bar-server-name-anchor {
     position: relative;
     display: flex;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -300,6 +300,20 @@ export type MenuAction =
     | { type: "set-current-default-server" }
     | { type: "add-server" }
 
+export type WindowCommand =
+    | "reload"
+    | "toggle-full-screen"
+    | "toggle-dev-tools"
+    | "minimize"
+    | "close"
+
+export type EditCommand =
+    | "undo"
+    | "redo"
+    | "cut"
+    | "copy"
+    | "paste"
+
 export interface ElectorrentBridge {
     app: {
         initialTheme: ColorTheme
@@ -356,6 +370,12 @@ export interface ElectorrentBridge {
     }
     notifications: {
         onPush(callback: (notification: NotificationPayload) => void): Unsubscribe
+    }
+    edit: {
+        command(command: EditCommand): Promise<void>
+    }
+    window: {
+        command(command: WindowCommand): Promise<void>
     }
     menu: {
         onAction(callback: (action: MenuAction) => void): Unsubscribe

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -52,6 +52,12 @@ export const IPC_CHANNELS = {
     notifications: {
         push: 'notifications:push',
     },
+    edit: {
+        command: 'edit:command',
+    },
+    window: {
+        command: 'window:command',
+    },
     menu: {
         action: 'menu:action',
     },


### PR DESCRIPTION
## Summary
- Add a Windows-only in-app menu to the custom title bar with File, Edit, View, Servers, Window, and Help actions
- Route edit and window commands through new preload and main-process IPC handlers
- Extend shared IPC contracts to cover the new bridge commands

## Testing
- Not run (not requested)