### PR TITLE
feat: support forced title bar menu mode

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -14,6 +14,7 @@ import * as updater from './update'
 
 interface RegisterHandlersOptions {
     isDebug: boolean
+    forceTitleBarMenu?: boolean
     getWindow: () => BrowserWindow | null
     consumePendingLaunchPayload: () => Promise<{
         magnets: PendingTorrentUploadLink[]
@@ -24,7 +25,7 @@ interface RegisterHandlersOptions {
     onBittorrentConnected?: () => void | Promise<void>
 }
 
-function getAppMeta(isDebug: boolean) {
+function getAppMeta(isDebug: boolean, requestedForceTitleBarMenu = false) {
     return {
         appName: app.name,
         appVersion: getAppVersion(),
@@ -32,6 +33,7 @@ function getAppMeta(isDebug: boolean) {
         isWindows: is.windows(),
         isLinux: is.linux(),
         isDebug,
+        forceTitleBarMenu: requestedForceTitleBarMenu,
         platform: process.platform,
         versions: {
             node: process.versions.node,
@@ -95,11 +97,11 @@ function runEditCommand(window: BrowserWindow, command: EditCommand) {
     }
 }
 
-export function registerHandlers({ isDebug, getWindow, consumePendingLaunchPayload, onSettingsSaved, onSystemThemeChanged, onBittorrentConnected }: RegisterHandlersOptions) {
+export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consumePendingLaunchPayload, onSettingsSaved, onSystemThemeChanged, onBittorrentConnected }: RegisterHandlersOptions) {
     menu.configure({ isDebug })
 
     ipcMain.handle(IPC_CHANNELS.app.getMeta, async function() {
-        return getAppMeta(isDebug)
+        return getAppMeta(isDebug, forceTitleBarMenu)
     })
 
     ipcMain.handle(IPC_CHANNELS.app.getDefaultProtocolStatus, async function(_event: IpcMainInvokeEvent, { protocol }) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -39,6 +39,7 @@ async function bootstrap() {
     parser.usage(`Electorrent ${app.getVersion()}`)
     parser.boolean('v').alias('v', 'verbose').describe('v', 'Enable verbose logging')
     parser.boolean('d').alias('d', 'debug').describe('d', 'Start in debug mode')
+    parser.boolean('force-title-bar-menu')
 
     const [
         { IPC_CHANNELS },
@@ -75,7 +76,7 @@ async function bootstrap() {
     logger.debug('Starting Electorrent in debug mode')
     logger.verbose('Verbose logging enabled')
 
-    const program = parser.parse(process.argv.slice(1)) as { debug?: boolean; verbose?: boolean }
+    const program = parser.parse(process.argv.slice(1)) as { debug?: boolean; verbose?: boolean; forceTitleBarMenu?: boolean }
 
     if (!app.isPackaged) {
         try {
@@ -411,6 +412,7 @@ async function bootstrap() {
 
     ipcHandlers.registerHandlers({
         isDebug: !!program.debug,
+        forceTitleBarMenu: !!program.forceTitleBarMenu,
         getWindow: () => torrentWindow,
         consumePendingLaunchPayload,
         onSettingsSaved: async (newSettings) => {

--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -64,7 +64,7 @@ export class AppShellController {
 
         $rootScope.$on("ready", () => {
             Promise.all([settingsService.whenReady(), electorrent.app.getMeta()]).then(([_, meta]: [unknown, AppMeta]) => {
-                $scope.isWindows = meta.isWindows;
+                $scope.isWindows = meta.isWindows || meta.forceTitleBarMenu;
                 const settings = settingsService.getAllSettings();
                 const automaticUpdates = settings?.automaticUpdates;
                 if (!meta.isDebug && automaticUpdates !== false) {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -11,6 +11,7 @@ export interface AppMeta {
     isWindows: boolean
     isLinux: boolean
     isDebug: boolean
+    forceTitleBarMenu: boolean
     platform: string
     versions: {
         node: string


### PR DESCRIPTION
## Summary
- Add a `force-title-bar-menu` CLI flag and pass it through app metadata
- Surface the flag in the renderer so the Windows menu UI can be enabled when forced
- Extend the shared `AppMeta` contract to include the new field

## Testing
- Not run (not requested)