### PR TITLE
fix: keep Angular modal fields in sync

### DIFF
--- a/src/renderer/app/directives/modal/modal.directive.ts
+++ b/src/renderer/app/directives/modal/modal.directive.ts
@@ -112,7 +112,9 @@ export class ModalDirective implements IDirective {
 
     static clearForm(element: IAugmentedJQuery) {
         let form: any = $(element)
-        form.form('clear');
+        if (!form.find('[ng-model], [data-ng-model], [x-ng-model]').length) {
+            form.form('clear');
+        }
         form.find('.error.message').empty()
     }
 

--- a/test/specs/standard/settings.spec.ts
+++ b/test/specs/standard/settings.spec.ts
@@ -75,6 +75,7 @@ describe("settings", function () {
 
     const nextName = `Renamed ${Date.now()}`
     await this.app.renameSettingsServer(0, nextName)
+    assert.equal(await this.app.getRenameSettingsServerValue(0), nextName)
 
     await this.app.settingsSave()
     await this.app.torrentsPageIsVisible()


### PR DESCRIPTION
## Summary
- Extend the server rename test to reopen the modal and verify the renamed value is shown
- Avoid clearing Semantic UI modal forms that contain Angular-managed fields, preventing DOM/model desync on reopen

## Validation
- Red: `npm run test -- --client mock --spec settings.spec.ts --mochaOpts.grep "can rename a server"` failed before the fix
- `npm run lint`
- `npm run build`
- `npm run test -- --client mock --spec settings.spec.ts --mochaOpts.grep "can rename a server"`