### PR TITLE
fix: handle native menu actions on macOS

### DIFF
--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -1,7 +1,8 @@
 import { IScope } from "angular";
 import { PendingTorrentUploadFile, PendingTorrentUploadLink } from "@renderer/app/directives/add-torrent-modal/add-torrent-modal.directive";
+import { createMenuActionHandler } from "@renderer/app/lib/menu-action-handler";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
-import type { AppMeta, LaunchPayload } from "@shared/ipc-contract";
+import type { AppMeta, LaunchPayload, MenuAction } from "@shared/ipc-contract";
 
 interface AppShellScope extends IScope {
     servers: any[];
@@ -23,12 +24,13 @@ interface AppShellScope extends IScope {
 }
 
 export class AppShellController {
-    static $inject = ["$rootScope", "$scope", "$timeout", "settingsService", "notificationService"];
+    static $inject = ["$rootScope", "$scope", "$timeout", "$bittorrent", "settingsService", "notificationService"];
 
     constructor(
         $rootScope: ElectorrentRootScope,
         $scope: AppShellScope,
         $timeout: angular.ITimeoutService,
+        $bittorrent: any,
         settingsService: any,
         $notify: any,
     ) {
@@ -159,6 +161,18 @@ export class AppShellController {
             drainPendingLaunchPayloads();
             $scope.$applyAsync();
         });
+
+        const handleMenuAction = createMenuActionHandler({
+            $rootScope,
+            $scope,
+            $bittorrent,
+            settingsService,
+            currentPage: () => page,
+        });
+        const unsubscribeMenuActions = electorrent.menu.onAction((action: MenuAction) => {
+            handleMenuAction(action);
+        });
+        $scope.$on("$destroy", unsubscribeMenuActions);
 
         const pageTorrents = (fullupdate?: boolean) => {
             $scope.showTorrents = true;

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
@@ -1,5 +1,5 @@
 import { IScope } from "angular";
-import type { PendingTorrentUploadFile } from "@renderer/app/directives/add-torrent-modal/add-torrent-modal.directive";
+import { createMenuActionHandler } from "@renderer/app/lib/menu-action-handler";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import type { EditCommand, MenuAction, WindowCommand } from "@shared/ipc-contract";
 
@@ -45,14 +45,14 @@ export class TitleBarMenuController {
         settingsService: any,
     ) {
         const electorrent = window.electorrent;
-        const PAGE_TORRENTS = "torrents";
         let isDebug = false;
-
-        const getActiveTextInput = () => {
-            return document.activeElement instanceof HTMLInputElement || document.activeElement instanceof HTMLTextAreaElement
-                ? document.activeElement
-                : null;
-        };
+        const handleMenuAction = createMenuActionHandler({
+            $rootScope,
+            $scope,
+            $bittorrent,
+            settingsService,
+            currentPage: $scope.currentPage,
+        });
 
         const supportsUploadOptions = () => {
             return Object.values($rootScope.$btclient?.features.uploadOptions || {}).some(Boolean);
@@ -60,77 +60,6 @@ export class TitleBarMenuController {
 
         const hasActiveServer = () => {
             return !!$rootScope.$server?.id;
-        };
-
-        const broadcastTorrentFile = (file: PendingTorrentUploadFile, askUploadOptions: boolean) => {
-            const pendingFile: PendingTorrentUploadFile = {
-                type: "file",
-                data: new Uint8Array(file.data),
-                filename: file.filename,
-                metadata: file.metadata,
-                sourcePath: file.sourcePath,
-            };
-            $rootScope.$broadcast("torrents:add", pendingFile, askUploadOptions);
-        };
-
-        const handleMenuAction = (action: MenuAction) => {
-            switch (action.type) {
-                case "show-settings":
-                    $scope.$emit("show:settings");
-                    break;
-                case "show-servers":
-                    $scope.$emit("show:servers");
-                    break;
-                case "search-torrent":
-                    $rootScope.$broadcast("search:torrent");
-                    break;
-                case "select-all":
-                    {
-                        const activeTextInput = getActiveTextInput();
-                        if (activeTextInput) {
-                            activeTextInput.select();
-                        } else if ($scope.currentPage() === PAGE_TORRENTS) {
-                            $rootScope.$broadcast("select:torrents");
-                        }
-                    }
-                    break;
-                case "remove-selected":
-                    if (document.activeElement?.nodeName !== "INPUT" && $scope.currentPage() === PAGE_TORRENTS) {
-                        $rootScope.$broadcast("remove:torrents");
-                    }
-                    break;
-                case "open-add-torrent":
-                    electorrent.torrents.openFiles(!!action.askUploadOptions).then((files: Array<PendingTorrentUploadFile & { askUploadOptions?: boolean }>) => {
-                        files.forEach((item) => broadcastTorrentFile(item, !!item.askUploadOptions));
-                    });
-                    break;
-                case "paste-torrent-url":
-                    $bittorrent.uploadFromClipboard(!!action.askUploadOptions);
-                    break;
-                case "open-external":
-                    electorrent.shell.openExternal(action.url);
-                    break;
-                case "check-for-updates":
-                    electorrent.updates.check(!!action.verbose);
-                    break;
-                case "connect-server":
-                    {
-                        const server = settingsService.getServer(action.serverId);
-                        if (server) {
-                            $scope.$emit("connect:server", server);
-                        }
-                    }
-                    break;
-                case "set-current-default-server":
-                    settingsService.setCurrentServerAsDefault();
-                    break;
-                case "add-server":
-                    $scope.$emit("add:server");
-                    break;
-                default:
-                    break;
-            }
-            $scope.$applyAsync();
         };
 
         const serverAccelerator = (index: number) => {
@@ -319,10 +248,6 @@ export class TitleBarMenuController {
         electorrent.app.getMeta().then((meta) => {
             isDebug = meta.isDebug;
             $scope.$applyAsync();
-        });
-
-        electorrent.menu.onAction((action: MenuAction) => {
-            handleMenuAction(action);
         });
 
         const onDocumentClick = () => {

--- a/src/renderer/app/lib/menu-action-handler.ts
+++ b/src/renderer/app/lib/menu-action-handler.ts
@@ -1,0 +1,101 @@
+import { IScope } from "angular";
+import type { PendingTorrentUploadFile } from "@renderer/app/directives/add-torrent-modal/add-torrent-modal.directive";
+import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
+import type { MenuAction } from "@shared/ipc-contract";
+
+interface MenuActionHandlerOptions {
+    $rootScope: ElectorrentRootScope;
+    $scope: IScope;
+    $bittorrent: any;
+    settingsService: any;
+    currentPage: () => string | null;
+}
+
+const PAGE_TORRENTS = "torrents";
+
+export function createMenuActionHandler({
+    $rootScope,
+    $scope,
+    $bittorrent,
+    settingsService,
+    currentPage,
+}: MenuActionHandlerOptions) {
+    const electorrent = window.electorrent;
+
+    const getActiveTextInput = () => {
+        return document.activeElement instanceof HTMLInputElement || document.activeElement instanceof HTMLTextAreaElement
+            ? document.activeElement
+            : null;
+    };
+
+    const broadcastTorrentFile = (file: PendingTorrentUploadFile, askUploadOptions: boolean) => {
+        const pendingFile: PendingTorrentUploadFile = {
+            type: "file",
+            data: new Uint8Array(file.data),
+            filename: file.filename,
+            metadata: file.metadata,
+            sourcePath: file.sourcePath,
+        };
+        $rootScope.$broadcast("torrents:add", pendingFile, askUploadOptions);
+    };
+
+    return (action: MenuAction) => {
+        switch (action.type) {
+            case "show-settings":
+                $scope.$emit("show:settings");
+                break;
+            case "show-servers":
+                $scope.$emit("show:servers");
+                break;
+            case "search-torrent":
+                $rootScope.$broadcast("search:torrent");
+                break;
+            case "select-all":
+                {
+                    const activeTextInput = getActiveTextInput();
+                    if (activeTextInput) {
+                        activeTextInput.select();
+                    } else if (currentPage() === PAGE_TORRENTS) {
+                        $rootScope.$broadcast("select:torrents");
+                    }
+                }
+                break;
+            case "remove-selected":
+                if (document.activeElement?.nodeName !== "INPUT" && currentPage() === PAGE_TORRENTS) {
+                    $rootScope.$broadcast("remove:torrents");
+                }
+                break;
+            case "open-add-torrent":
+                electorrent.torrents.openFiles(!!action.askUploadOptions).then((files: Array<PendingTorrentUploadFile & { askUploadOptions?: boolean }>) => {
+                    files.forEach((item) => broadcastTorrentFile(item, !!item.askUploadOptions));
+                });
+                break;
+            case "paste-torrent-url":
+                $bittorrent.uploadFromClipboard(!!action.askUploadOptions);
+                break;
+            case "open-external":
+                electorrent.shell.openExternal(action.url);
+                break;
+            case "check-for-updates":
+                electorrent.updates.check(!!action.verbose);
+                break;
+            case "connect-server":
+                {
+                    const server = settingsService.getServer(action.serverId);
+                    if (server) {
+                        $scope.$emit("connect:server", server);
+                    }
+                }
+                break;
+            case "set-current-default-server":
+                settingsService.setCurrentServerAsDefault();
+                break;
+            case "add-server":
+                $scope.$emit("add:server");
+                break;
+            default:
+                break;
+        }
+        $scope.$applyAsync();
+    };
+}


### PR DESCRIPTION
## Summary
- Move menu action handling into a shared renderer helper
- Register native menu IPC actions from the always-mounted app shell
- Keep the custom title bar menu using the same shared handler without duplicate native subscriptions

## Root cause
On macOS the custom title bar menu is not mounted, but it was the only renderer component subscribing to native menu IPC actions. Electron still highlighted accelerator menu items, but the sent action had no renderer listener.

## Validation
- npm run lint
- npm run build
- npm run smoketest