### PR TITLE
fix: toggle active sidebar filters

### DIFF
--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.directive.ts
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.directive.ts
@@ -15,7 +15,7 @@ export class TorrentSidebarSectionController {
     }
 
     select(item: string) {
-        this.onSelect?.({ item });
+        this.onSelect?.({ item: this.isActive(item) ? undefined : item });
     }
 
     clear() {

--- a/test/specs/standard/tracker-filters.spec.ts
+++ b/test/specs/standard/tracker-filters.spec.ts
@@ -52,6 +52,12 @@ describe("tracker filters", function () {
         }
       }
 
+      await this.app.filterTracker(torrentCases[0].tracker)
+      await this.app.filterTracker(torrentCases[0].tracker)
+      for (const torrent of torrents) {
+        await torrent.waitForExist()
+      }
+
       await this.app.filterTracker()
       await torrents[1].delete()
       await eventually(() => this.app.getAllSidebarTrackers())


### PR DESCRIPTION
## Summary
- Clear a sidebar section filter when the already-selected item is clicked again
- Applies to label and tracker filters through the shared sidebar section controller
- Add tracker filter coverage for re-clicking the active tracker

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/tracker-filters.spec.ts"`