### PR TITLE
feat: add remove label action

### DIFF
--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -474,7 +474,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
 
     label(hashes: string[], label: string): Promise<void> {
         return this.doAction('torrent-set', hashes, {
-            labels: [label],
+            labels: label ? [label] : [],
         }).then((response) => this.ensureSuccess(response)).then(() => undefined)
     }
 

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -290,7 +290,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
                 token: this.data.token,
                 hash: hashes,
                 s: 'label',
-                v: label,
+                v: label === '' ? ' ' : label,
                 action: 'setprops',
                 t: Date.now(),
             },

--- a/src/renderer/app/bittorrent/qbittorrent/torrentq.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/torrentq.ts
@@ -66,7 +66,7 @@ export class QBittorrentTorrent extends Torrent {
             uploadLimit: data.up_limit,
             downloadLimit: data.dl_limit,
             eta: data.eta,
-            label: data.category || data.label,
+            label: data.category !== undefined ? data.category : data.label,
             peersConnected: data.num_leechs,
             peersInSwarm: data.num_incomplete,
             seedsConnected: data.num_seeds,

--- a/src/renderer/app/directives/labels-menu/labels-menu.template.html
+++ b/src/renderer/app/directives/labels-menu/labels-menu.template.html
@@ -5,9 +5,11 @@
             <i class="search icon"></i>
             <input type="text" placeholder="Search labels...">
         </div>
+        <div data-role="remove-label" class="item" ng-click="action('')"><i class="remove icon"></i> Remove Label</div>
         <div data-role="new-label" class="item" ng-click="openNewLabelModal()"><i class="edit icon"></i> New Label</div>
+        <div class="divider"></div>
         <div class="scrolling menu">
-            <div class="item" data-label="{{label}}" ng-repeat="label in labels" ng-click="action(label)">{{label}}</div>
+            <div class="item" data-role="label-option" data-label="{{label}}" ng-repeat="label in labels" ng-click="action(label)">{{label}}</div>
             <div></div>
         </div>
     </div>

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -327,6 +327,17 @@ export class Torrent {
     await eventually(() => this.getLabel()).equals(labelName)
   }
 
+  async removeLabel() {
+    const labelsElem = await this.openLabelsDropdown()
+
+    const removeLabelElem = labelsElem.$("div[data-role=remove-label]")
+    await removeLabelElem.waitForDisplayed()
+    await removeLabelElem.click()
+    await removeLabelElem.waitForDisplayed({ reverse: true })
+
+    await eventually(async () => (await this.getLabel()).trim()).equals("")
+  }
+
   async click(options: ClickOptions) {
     const elem = $(this.query)
     await elem.click(options)

--- a/test/specs/standard/torrent-labels.spec.ts
+++ b/test/specs/standard/torrent-labels.spec.ts
@@ -49,4 +49,10 @@ describe("torrent labels", function () {
     await torrent.changeLabel(firstLabel)
     await torrent.checkInFilterLabel(firstLabel)
   })
+
+  it("removes the label", async function () {
+    await torrent.removeLabel()
+    const label = await torrent.getLabel()
+    label.trim().should.equal("")
+  })
 })


### PR DESCRIPTION
## Summary
- add a distinct Remove Label option to the labels dropdown
- clear Transmission labels with an empty labels array
- preserve empty qBittorrent categories when rendering labels
- extend label E2E coverage to remove and assert an empty label

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-labels.spec.ts"