### PR TITLE
feat: filter unlabeled torrents from sidebar

### DIFF
--- a/src/renderer/app/directives/torrent-sidebar/torrent-label-filter.ts
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-label-filter.ts
@@ -1,0 +1,13 @@
+export const NO_LABEL_FILTER = "__electorrent_no_label__";
+
+export function matchesLabelFilter(torrentLabel: string | null | undefined, filterLabel?: string) {
+    if (!filterLabel) {
+        return true;
+    }
+
+    if (filterLabel === NO_LABEL_FILTER) {
+        return !torrentLabel;
+    }
+
+    return torrentLabel === filterLabel;
+}

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.directive.ts
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.directive.ts
@@ -8,10 +8,24 @@ export class TorrentSidebarSectionController {
     clearRole = "";
     emptyText = "";
     itemAttribute = "";
+    specialItemValue?: string;
+    specialItemText?: string;
     onSelect?: (locals: { item?: string }) => void;
 
     isActive(item: string) {
         return this.active === item;
+    }
+
+    itemText(item: string) {
+        return item === this.specialItemValue && this.specialItemText ? this.specialItemText : item;
+    }
+
+    hasSpecialItem() {
+        return !!this.specialItemValue;
+    }
+
+    displayEmpty() {
+        return this.items.length === 0 && !this.hasSpecialItem();
     }
 
     select(item: string) {
@@ -32,6 +46,8 @@ export class TorrentSidebarSectionDirective implements IDirective {
         clearRole: "@",
         emptyText: "@",
         itemAttribute: "@",
+        specialItemValue: "@",
+        specialItemText: "@",
         onSelect: "&",
     };
     bindToController = true;

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.template.html
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.template.html
@@ -3,10 +3,15 @@
     <a data-role="{{ctl.clearRole}}" class="ui gray basic mini clear button" ng-click="ctl.clear()">Clear</a>
 </div>
 <ul class="filter label">
-    <span ng-if="ctl.items.length == 0" class="meta text">{{ctl.emptyText}}</span>
+    <span ng-if="ctl.displayEmpty()" class="meta text">{{ctl.emptyText}}</span>
+    <li ng-if="ctl.hasSpecialItem()" ng-attr-data-label="{{ctl.itemAttribute == 'label' ? ctl.specialItemValue : undefined}}" ng-attr-data-tracker="{{ctl.itemAttribute == 'tracker' ? ctl.specialItemValue : undefined}}">
+        <div class="ui fluid torrent tag label" ng-click="ctl.select(ctl.specialItemValue)" ng-class="{blue: ctl.isActive(ctl.specialItemValue)}">
+            {{ctl.itemText(ctl.specialItemValue)}}
+        </div>
+    </li>
     <li ng-attr-data-label="{{ctl.itemAttribute == 'label' ? item : undefined}}" ng-attr-data-tracker="{{ctl.itemAttribute == 'tracker' ? item : undefined}}" ng-repeat="item in ctl.items track by item">
         <div class="ui fluid torrent tag label" ng-click="ctl.select(item)" ng-class="{blue: ctl.isActive(item)}">
-            {{item}}
+            {{ctl.itemText(item)}}
         </div>
     </li>
 </ul>

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar.directive.ts
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar.directive.ts
@@ -1,4 +1,5 @@
 import { IDirective, IDirectiveFactory } from "angular";
+import { matchesLabelFilter, NO_LABEL_FILTER } from "./torrent-label-filter";
 import html from "./torrent-sidebar.template.html";
 
 interface TorrentSidebarFilters {
@@ -37,6 +38,7 @@ export class TorrentSidebarController {
     filters: TorrentSidebarFilters = {};
     labels: string[] = [];
     trackers: string[] = [];
+    noLabelFilter = NO_LABEL_FILTER;
     onStatus?: (locals: { status: string }) => void;
     onLabel?: (locals: { label?: string }) => void;
     onTracker?: (locals: { tracker?: string }) => void;
@@ -91,7 +93,7 @@ export class TorrentSidebarController {
         ];
 
         if (filterLabel) {
-            filters.push((torrent) => torrent.label === filterLabel);
+            filters.push((torrent) => matchesLabelFilter(torrent.label, filterLabel));
         }
 
         if (filterTracker) {

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar.template.html
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar.template.html
@@ -52,6 +52,8 @@
                 item-attribute="label"
                 items="ctl.labels"
                 active="ctl.filters.label"
+                special-item-value="{{ctl.noLabelFilter}}"
+                special-item-text="No label"
                 on-select="ctl.selectLabel(item)">
             </torrent-sidebar-section>
         </div>
@@ -80,6 +82,8 @@
                     item-attribute="label"
                     items="ctl.labels"
                     active="ctl.filters.label"
+                    special-item-value="{{ctl.noLabelFilter}}"
+                    special-item-text="No label"
                     on-select="ctl.selectLabel(item)">
                 </torrent-sidebar-section>
             </div>

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -2,6 +2,7 @@ import Fuse from "fuse.js";
 import { TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { PendingTorrentUploadItem, PendingTorrentUploadList } from "@renderer/app/directives/add-torrent-modal/add-torrent-modal.directive";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
+import { matchesLabelFilter } from "@renderer/app/directives/torrent-sidebar/torrent-label-filter";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 
 interface TorrentControllerScope extends angular.IScope {
@@ -779,7 +780,7 @@ export class TorrentsPageController {
             }
 
             if (filterLabel) {
-                filters.push((torrent) => torrent.label === filterLabel);
+                filters.push((torrent) => matchesLabelFilter(torrent.label, filterLabel));
             }
 
             if (filterTracker) {

--- a/test/specs/standard/torrent-labels.spec.ts
+++ b/test/specs/standard/torrent-labels.spec.ts
@@ -4,6 +4,7 @@ import * as e2e from "../../e2e"
 import { configureSpec, createUniqueLabel, requireFeature } from "../../framework/fixture"
 
 const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const noLabelFilter = "__electorrent_no_label__"
 
 describe("torrent labels", function () {
   configureSpec()
@@ -13,17 +14,24 @@ describe("torrent labels", function () {
   const secondLabel = createUniqueLabel("someotherlabel")
   let initialLabelCount = 0
   let torrent: e2e.Torrent
+  let unlabeledTorrent: e2e.Torrent
 
   before(async function () {
     const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const unlabeledFilename = path.join(testDir, "shared/opentracker/data/shared/test-torrent-n86j8t6d.torrent")
     torrent = await this.app.uploadTorrent({ filename })
+    unlabeledTorrent = await this.app.uploadTorrent({ filename: unlabeledFilename })
     await torrent.waitForExist()
+    await unlabeledTorrent.waitForExist()
     initialLabelCount = (await this.app.getAllSidebarLabels()).length
   })
 
   after(async function () {
     if (torrent && await torrent.isExisting()) {
       await torrent.delete()
+    }
+    if (unlabeledTorrent && await unlabeledTorrent.isExisting()) {
+      await unlabeledTorrent.delete()
     }
   })
 
@@ -43,6 +51,13 @@ describe("torrent labels", function () {
     labels.should.include(firstLabel)
     labels.should.include(secondLabel)
     labels.should.have.length(initialLabelCount + 2)
+  })
+
+  it("filters torrents without a label", async function () {
+    await this.app.filterLabel(noLabelFilter)
+    await unlabeledTorrent.waitForExist()
+    await torrent.waitForGone()
+    await this.app.filterLabel()
   })
 
   it("changes back to a previous label", async function () {

--- a/test/specs/standard/torrent-labels.spec.ts
+++ b/test/specs/standard/torrent-labels.spec.ts
@@ -1,9 +1,11 @@
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import * as e2e from "../../e2e"
-import { configureSpec, createUniqueLabel, requireFeature } from "../../framework/fixture"
+import { configureSpec, createUniqueLabel, getTestFixture, requireFeature } from "../../framework/fixture"
+import { createTorrentFile } from "../../torrent"
 
 const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const tracker = getTestFixture().tracker
 const noLabelFilter = "__electorrent_no_label__"
 
 describe("torrent labels", function () {
@@ -18,7 +20,7 @@ describe("torrent labels", function () {
 
   before(async function () {
     const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
-    const unlabeledFilename = path.join(testDir, "shared/opentracker/data/shared/test-torrent-n86j8t6d.torrent")
+    const unlabeledFilename = await createTorrentFile(tracker, { torrentName: createUniqueLabel("unlabeled") })
     torrent = await this.app.uploadTorrent({ filename })
     unlabeledTorrent = await this.app.uploadTorrent({ filename: unlabeledFilename })
     await torrent.waitForExist()


### PR DESCRIPTION
## Summary

- Add a persistent **No label** option to the Labels sidebar filter.
- Reuse the same label matching logic for sidebar counts and torrent table filtering so unlabeled torrents are shown consistently.
- Extend the torrent labels e2e spec to verify the unlabeled filter shows unlabeled torrents and hides labeled torrents.

## Tests

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-labels.spec.ts"`
