### PR TITLE
test: add rtorrent auth proxy specs

### DIFF
--- a/src/renderer/app/directives/torrent-sidebar/torrent-label-filter.ts
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-label-filter.ts
@@ -1,0 +1,13 @@
+export const NO_LABEL_FILTER = "__electorrent_no_label__";
+
+export function matchesLabelFilter(torrentLabel: string | null | undefined, filterLabel?: string) {
+    if (!filterLabel) {
+        return true;
+    }
+
+    if (filterLabel === NO_LABEL_FILTER) {
+        return !torrentLabel;
+    }
+
+    return torrentLabel === filterLabel;
+}

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.directive.ts
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.directive.ts
@@ -8,10 +8,24 @@ export class TorrentSidebarSectionController {
     clearRole = "";
     emptyText = "";
     itemAttribute = "";
+    specialItemValue?: string;
+    specialItemText?: string;
     onSelect?: (locals: { item?: string }) => void;
 
     isActive(item: string) {
         return this.active === item;
+    }
+
+    itemText(item: string) {
+        return item === this.specialItemValue && this.specialItemText ? this.specialItemText : item;
+    }
+
+    hasSpecialItem() {
+        return !!this.specialItemValue;
+    }
+
+    displayEmpty() {
+        return this.items.length === 0 && !this.hasSpecialItem();
     }
 
     select(item: string) {
@@ -32,6 +46,8 @@ export class TorrentSidebarSectionDirective implements IDirective {
         clearRole: "@",
         emptyText: "@",
         itemAttribute: "@",
+        specialItemValue: "@",
+        specialItemText: "@",
         onSelect: "&",
     };
     bindToController = true;

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.template.html
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.template.html
@@ -3,10 +3,15 @@
     <a data-role="{{ctl.clearRole}}" class="ui gray basic mini clear button" ng-click="ctl.clear()">Clear</a>
 </div>
 <ul class="filter label">
-    <span ng-if="ctl.items.length == 0" class="meta text">{{ctl.emptyText}}</span>
+    <span ng-if="ctl.displayEmpty()" class="meta text">{{ctl.emptyText}}</span>
+    <li ng-if="ctl.hasSpecialItem()" ng-attr-data-label="{{ctl.itemAttribute == 'label' ? ctl.specialItemValue : undefined}}" ng-attr-data-tracker="{{ctl.itemAttribute == 'tracker' ? ctl.specialItemValue : undefined}}">
+        <div class="ui fluid torrent tag label" ng-click="ctl.select(ctl.specialItemValue)" ng-class="{blue: ctl.isActive(ctl.specialItemValue)}">
+            {{ctl.itemText(ctl.specialItemValue)}}
+        </div>
+    </li>
     <li ng-attr-data-label="{{ctl.itemAttribute == 'label' ? item : undefined}}" ng-attr-data-tracker="{{ctl.itemAttribute == 'tracker' ? item : undefined}}" ng-repeat="item in ctl.items track by item">
         <div class="ui fluid torrent tag label" ng-click="ctl.select(item)" ng-class="{blue: ctl.isActive(item)}">
-            {{item}}
+            {{ctl.itemText(item)}}
         </div>
     </li>
 </ul>

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar.directive.ts
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar.directive.ts
@@ -1,4 +1,5 @@
 import { IDirective, IDirectiveFactory } from "angular";
+import { matchesLabelFilter, NO_LABEL_FILTER } from "./torrent-label-filter";
 import html from "./torrent-sidebar.template.html";
 
 interface TorrentSidebarFilters {
@@ -37,6 +38,7 @@ export class TorrentSidebarController {
     filters: TorrentSidebarFilters = {};
     labels: string[] = [];
     trackers: string[] = [];
+    noLabelFilter = NO_LABEL_FILTER;
     onStatus?: (locals: { status: string }) => void;
     onLabel?: (locals: { label?: string }) => void;
     onTracker?: (locals: { tracker?: string }) => void;
@@ -91,7 +93,7 @@ export class TorrentSidebarController {
         ];
 
         if (filterLabel) {
-            filters.push((torrent) => torrent.label === filterLabel);
+            filters.push((torrent) => matchesLabelFilter(torrent.label, filterLabel));
         }
 
         if (filterTracker) {

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar.template.html
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar.template.html
@@ -52,6 +52,8 @@
                 item-attribute="label"
                 items="ctl.labels"
                 active="ctl.filters.label"
+                special-item-value="{{ctl.noLabelFilter}}"
+                special-item-text="No label"
                 on-select="ctl.selectLabel(item)">
             </torrent-sidebar-section>
         </div>
@@ -80,6 +82,8 @@
                     item-attribute="label"
                     items="ctl.labels"
                     active="ctl.filters.label"
+                    special-item-value="{{ctl.noLabelFilter}}"
+                    special-item-text="No label"
                     on-select="ctl.selectLabel(item)">
                 </torrent-sidebar-section>
             </div>

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -2,6 +2,7 @@ import Fuse from "fuse.js";
 import { TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { PendingTorrentUploadItem, PendingTorrentUploadList } from "@renderer/app/directives/add-torrent-modal/add-torrent-modal.directive";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
+import { matchesLabelFilter } from "@renderer/app/directives/torrent-sidebar/torrent-label-filter";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 
 interface TorrentControllerScope extends angular.IScope {
@@ -779,7 +780,7 @@ export class TorrentsPageController {
             }
 
             if (filterLabel) {
-                filters.push((torrent) => torrent.label === filterLabel);
+                filters.push((torrent) => matchesLabelFilter(torrent.label, filterLabel));
             }
 
             if (filterTracker) {

--- a/test/clients/rtorrent/index.ts
+++ b/test/clients/rtorrent/index.ts
@@ -26,6 +26,12 @@ export default {
     containerHostPort: 48080,
     proxyPort: 80,
     authProxyHostPort: 48081,
+    digestAuthProxyHostPort: 48082,
+    additionalComposeServices: ["apache"],
+    specs: [
+      "test/specs/standard/**/*.spec.ts",
+      "test/specs/rtorrent/**/*.spec.ts",
+    ],
     username: "admin",
     password: "admin",
     saveLocation: "/downloads/custom/save/location",

--- a/test/clients/types.ts
+++ b/test/clients/types.ts
@@ -15,6 +15,8 @@ export interface TestClient {
   containerHostPort?: number
   proxyPort?: number
   authProxyHostPort?: number
+  digestAuthProxyHostPort?: number
+  additionalComposeServices?: string[]
   acceptHttpStatus: number
   stopLabel: string
   downloadLabel: string

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -42,6 +42,15 @@ services:
       - PROXY_PORT=${PROXY_PORT}
       - NGINX_AUTH_PORT=${NGINX_AUTH_PORT:-8081}
 
+  apache:
+    build: ./shared/apache
+    ports:
+      - ${APACHE_AUTH_HOST_PORT:-8082}:${APACHE_AUTH_PORT:-8082}
+    environment:
+      - PROXY_HOST=${PROXY_HOST}
+      - PROXY_PORT=${PROXY_PORT}
+      - APACHE_AUTH_PORT=${APACHE_AUTH_PORT:-8082}
+
   deluge:
     image: linuxserver/deluge:${VERSION:-latest}
     environment:

--- a/test/framework/service.ts
+++ b/test/framework/service.ts
@@ -31,7 +31,7 @@ export default class ElectorrentTestService {
         const { composeOptions } = this.getClientEnvironment(client)
 
         await compose.upMany(
-          ["tracker", "peer", this.getClientServiceName(client), "nginx"],
+          ["tracker", "peer", this.getClientServiceName(client), "nginx", ...(client.additionalComposeServices ?? [])],
           composeOptions,
         )
         await waitForHttp({
@@ -89,6 +89,8 @@ export default class ElectorrentTestService {
       NGINX_HOST_PORT: String(proxyPort),
       NGINX_AUTH_HOST_PORT: String(authProxyPort),
       NGINX_AUTH_PORT: "8081",
+      APACHE_AUTH_HOST_PORT: String(client.digestAuthProxyHostPort ?? 56000 + clientIndex),
+      APACHE_AUTH_PORT: "8082",
       PROXY_HOST: this.getClientServiceName(client),
       PROXY_PORT: String(client.proxyPort ?? client.containerPort ?? client.port),
       RPC_PORT: String(52000 + clientIndex),

--- a/test/shared/apache/Dockerfile
+++ b/test/shared/apache/Dockerfile
@@ -1,0 +1,10 @@
+FROM httpd:2.4-alpine
+
+RUN apk add --no-cache gettext
+
+COPY rootfs/ /
+
+RUN chmod +x /docker-entrypoint.sh /docker-entrypoint.d/*.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["httpd-foreground"]

--- a/test/shared/apache/rootfs/docker-entrypoint.d/40-render-httpd-conf.sh
+++ b/test/shared/apache/rootfs/docker-entrypoint.d/40-render-httpd-conf.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+envsubst '${APACHE_AUTH_PORT} ${PROXY_HOST} ${PROXY_PORT}' \
+  < /usr/local/apache2/conf/templates/httpd.conf.template \
+  > /usr/local/apache2/conf/httpd.conf

--- a/test/shared/apache/rootfs/docker-entrypoint.sh
+++ b/test/shared/apache/rootfs/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+for script in /docker-entrypoint.d/*.sh; do
+  if [ -x "$script" ]; then
+    "$script"
+  fi
+done
+
+exec "$@"

--- a/test/shared/apache/rootfs/usr/local/apache2/conf.d/rtorrent-digest-auth.htdigest
+++ b/test/shared/apache/rootfs/usr/local/apache2/conf.d/rtorrent-digest-auth.htdigest
@@ -1,0 +1,1 @@
+admin:Electorrent test fixture:6a7b1b4b7d360bbbe120ba91efc722e6

--- a/test/shared/apache/rootfs/usr/local/apache2/conf/templates/httpd.conf.template
+++ b/test/shared/apache/rootfs/usr/local/apache2/conf/templates/httpd.conf.template
@@ -1,0 +1,37 @@
+ServerRoot "/usr/local/apache2"
+ServerName localhost
+Listen ${APACHE_AUTH_PORT}
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule auth_digest_module modules/mod_auth_digest.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule unixd_module modules/mod_unixd.so
+
+User daemon
+Group daemon
+PidFile logs/httpd.pid
+ErrorLog /proc/self/fd/2
+TransferLog /proc/self/fd/1
+LogLevel warn
+
+<VirtualHost *:${APACHE_AUTH_PORT}>
+  ProxyPreserveHost On
+
+  <Location />
+    AuthType Digest
+    AuthName "Electorrent test fixture"
+    AuthDigestDomain /
+    AuthDigestProvider file
+    AuthUserFile /usr/local/apache2/conf.d/rtorrent-digest-auth.htdigest
+    Require valid-user
+
+    ProxyPass http://${PROXY_HOST}:${PROXY_PORT}/
+    ProxyPassReverse http://${PROXY_HOST}:${PROXY_PORT}/
+  </Location>
+</VirtualHost>

--- a/test/specs/rtorrent/basic-auth.spec.ts
+++ b/test/specs/rtorrent/basic-auth.spec.ts
@@ -1,0 +1,21 @@
+import { configureSpec, getTestFixture } from "../../framework/fixture"
+
+const fixture = getTestFixture()
+const client = fixture.client
+
+describe("rtorrent basic authentication", function () {
+  configureSpec({ login: false })
+
+  it("logs in through HTTP basic auth", async function () {
+    if (!client.authProxyHostPort) {
+      throw new Error("The rtorrent basic auth proxy port is not configured")
+    }
+
+    await this.app.login({
+      ...client,
+      port: client.authProxyHostPort,
+    })
+
+    await this.app.torrentsPageIsVisible()
+  })
+})

--- a/test/specs/rtorrent/digest-auth.spec.ts
+++ b/test/specs/rtorrent/digest-auth.spec.ts
@@ -1,0 +1,21 @@
+import { configureSpec, getTestFixture } from "../../framework/fixture"
+
+const fixture = getTestFixture()
+const client = fixture.client
+
+describe("rtorrent digest authentication", function () {
+  configureSpec({ login: false })
+
+  it("logs in through HTTP digest auth", async function () {
+    if (!client.digestAuthProxyHostPort) {
+      throw new Error("The rtorrent digest auth proxy port is not configured")
+    }
+
+    await this.app.login({
+      ...client,
+      port: client.digestAuthProxyHostPort,
+    })
+
+    await this.app.torrentsPageIsVisible()
+  })
+})

--- a/test/specs/standard/torrent-labels.spec.ts
+++ b/test/specs/standard/torrent-labels.spec.ts
@@ -4,6 +4,7 @@ import * as e2e from "../../e2e"
 import { configureSpec, createUniqueLabel, requireFeature } from "../../framework/fixture"
 
 const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const noLabelFilter = "__electorrent_no_label__"
 
 describe("torrent labels", function () {
   configureSpec()
@@ -13,17 +14,24 @@ describe("torrent labels", function () {
   const secondLabel = createUniqueLabel("someotherlabel")
   let initialLabelCount = 0
   let torrent: e2e.Torrent
+  let unlabeledTorrent: e2e.Torrent
 
   before(async function () {
     const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const unlabeledFilename = path.join(testDir, "shared/opentracker/data/shared/test-torrent-n86j8t6d.torrent")
     torrent = await this.app.uploadTorrent({ filename })
+    unlabeledTorrent = await this.app.uploadTorrent({ filename: unlabeledFilename })
     await torrent.waitForExist()
+    await unlabeledTorrent.waitForExist()
     initialLabelCount = (await this.app.getAllSidebarLabels()).length
   })
 
   after(async function () {
     if (torrent && await torrent.isExisting()) {
       await torrent.delete()
+    }
+    if (unlabeledTorrent && await unlabeledTorrent.isExisting()) {
+      await unlabeledTorrent.delete()
     }
   })
 
@@ -43,6 +51,13 @@ describe("torrent labels", function () {
     labels.should.include(firstLabel)
     labels.should.include(secondLabel)
     labels.should.have.length(initialLabelCount + 2)
+  })
+
+  it("filters torrents without a label", async function () {
+    await this.app.filterLabel(noLabelFilter)
+    await unlabeledTorrent.waitForExist()
+    await torrent.waitForGone()
+    await this.app.filterLabel()
   })
 
   it("changes back to a previous label", async function () {

--- a/test/specs/standard/torrent-labels.spec.ts
+++ b/test/specs/standard/torrent-labels.spec.ts
@@ -1,9 +1,11 @@
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import * as e2e from "../../e2e"
-import { configureSpec, createUniqueLabel, requireFeature } from "../../framework/fixture"
+import { createTorrentFile } from "../../torrent"
+import { configureSpec, createUniqueLabel, getTestFixture, requireFeature } from "../../framework/fixture"
 
 const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const tracker = getTestFixture().tracker
 const noLabelFilter = "__electorrent_no_label__"
 
 describe("torrent labels", function () {
@@ -18,7 +20,9 @@ describe("torrent labels", function () {
 
   before(async function () {
     const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
-    const unlabeledFilename = path.join(testDir, "shared/opentracker/data/shared/test-torrent-n86j8t6d.torrent")
+    const unlabeledFilename = await createTorrentFile(tracker, {
+      torrentName: createUniqueLabel("unlabeled"),
+    })
     torrent = await this.app.uploadTorrent({ filename })
     unlabeledTorrent = await this.app.uploadTorrent({ filename: unlabeledFilename })
     await torrent.waitForExist()


### PR DESCRIPTION
## Summary
- add an Apache digest-auth proxy fixture for rtorrent tests
- start additional compose services from client definitions and enable Apache only for rtorrent
- add rtorrent-specific basic and digest auth login specs

## Validation
- npm run lint
- npm run build
- npm run test -- --client rtorrent --spec test/specs/rtorrent/*.spec.ts