### PR TITLE
fix: prevent stale server connections

### DIFF
--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -66,6 +66,12 @@ class BittorrentManager {
 
             const runtime = createRuntime(server.client)
             const connection = await runtime.connect(server)
+            if (this.pendingConnections.get(senderId) !== pendingConnect) {
+                if (typeof runtime.disconnect === "function") {
+                    await runtime.disconnect()
+                }
+                throw new Error("Stale bittorrent connection")
+            }
             this.sessions.set(senderId, runtime)
             return connection
         })()

--- a/src/main/lib/menu.ts
+++ b/src/main/lib/menu.ts
@@ -79,9 +79,9 @@ function serverMenuItems(): MenuItemConstructorOptions[] {
         { type: 'separator' },
     ]
 
-    if (!hasActiveServer()) {
+    if (!menuSettings.servers.length) {
         submenu.push({
-            label: 'Disabled...',
+            label: 'No servers',
             enabled: false,
         })
         return submenu

--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -44,6 +44,7 @@ export class AppShellController {
 
         let loadingTimer: angular.IPromise<void> | undefined;
         let page: string | null = null;
+        let activeConnectionId = 0;
         let pendingMagnets: Array<PendingTorrentUploadLink & { askUploadOptions?: boolean }> = [];
         let pendingTorrentFiles: Array<PendingTorrentUploadFile & { askUploadOptions?: boolean }> = [];
 
@@ -205,6 +206,9 @@ export class AppShellController {
         };
 
         const connectToServer = (server: any) => {
+            const connectionId = ++activeConnectionId;
+            const isCurrentConnection = () => connectionId === activeConnectionId;
+
             pageLoading();
             $scope.$broadcast("stop:torrents");
             $scope.$broadcast("wipe:torrents");
@@ -216,17 +220,27 @@ export class AppShellController {
             $scope.statusText = "Connecting to " + serverName;
 
             server.connect().then(() => {
+                if (!isCurrentConnection()) {
+                    return;
+                }
+
                 $scope.statusText = "Loading Torrents";
                 settingsService.updateServer(server);
                 pageTorrents(true);
                 return electorrent.launch.getPending().then((payload: LaunchPayload) => {
+                    if (!isCurrentConnection()) {
+                        return;
+                    }
+
                     queueMagnetLinks(payload.magnets || []);
                     queueTorrentFiles(payload.torrentFiles || []);
                     drainPendingLaunchPayloads();
                 });
             }).catch((err: unknown) => {
                 console.error(err);
-                pageSettings("connection", server.id);
+                if (isCurrentConnection()) {
+                    pageSettings("connection", server.id);
+                }
             }).then(() => {
                 $scope.$apply();
             });

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
@@ -153,12 +153,13 @@ export class TitleBarMenuController {
                 { label: "", separator: true },
             ];
 
-            if (!hasActiveServer()) {
-                items.push({ label: "Disabled...", enabled: false });
+            const servers = settingsService.getServers();
+            if (!servers.length) {
+                items.push({ label: "No servers", enabled: false });
                 return items;
             }
 
-            settingsService.getServers().forEach((server: any, index: number) => {
+            servers.forEach((server: any, index: number) => {
                 items.push({
                     label: getServerLabel(server),
                     accelerator: serverAccelerator(index + 1),

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -47,6 +47,10 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
             return err?.name === "AggregateError" || message.includes("aggregateerror")
         }
 
+        function isStaleConnectionError(err: any) {
+            return String(err?.message || err).toLowerCase().includes("stale bittorrent connection")
+        }
+
         /**
          * Constructor, with class name
          */
@@ -209,7 +213,9 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                         return self.connect()
                     })
                 }
-                $notify.alertAuth(err)
+                if (!isStaleConnectionError(err)) {
+                    $notify.alertAuth(err)
+                }
                 return $q.reject(err, this)
             }).then(function() {
                 self.isConnected = true


### PR DESCRIPTION
## Summary
- prevent older in-flight server connections from replacing newer sessions
- ignore stale connection completions/failures in the renderer
- keep the Servers menu populated when servers exist and show "No servers" only when empty

## Validation
- npm run lint
- npm run build
- npm run smoketest