### PR TITLE
fix: sync disconnected menu state

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -210,8 +210,9 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
     })
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }) {
+        menu.setActiveServer(server, false)
         const connection = await bittorrentManager.connect(event.sender, server)
-        menu.setActiveServer(server)
+        menu.setActiveServer(server, true)
         await onBittorrentConnected?.()
         return connection
     })

--- a/src/main/lib/menu.ts
+++ b/src/main/lib/menu.ts
@@ -9,6 +9,7 @@ type MenuSessionState = {
     isDebug: boolean
     activeServerId: string | null
     activeClientId: string | null
+    isConnected: boolean
 }
 
 let mainWindow: BrowserWindow | null = null
@@ -16,6 +17,7 @@ let menuState: MenuSessionState = {
     isDebug: false,
     activeServerId: null,
     activeClientId: null,
+    isConnected: false,
 }
 const defaultMenuSettings: AppSettings = settings.getDefaultSettings()
 let menuSettings: AppSettings = defaultMenuSettings
@@ -60,8 +62,16 @@ function hasActiveServer() {
     return !!menuState.activeServerId
 }
 
-function advancedUploadEnabled() {
+function hasConnectedServer() {
+    return hasActiveServer() && menuState.isConnected
+}
+
+function advancedUploadVisible() {
     return !!menuState.activeClientId && !!CLIENT_METADATA[menuState.activeClientId]?.showAdvancedUploadMenu
+}
+
+function advancedUploadEnabled() {
+    return hasConnectedServer() && advancedUploadVisible()
 }
 
 function serverMenuItems(): MenuItemConstructorOptions[] {
@@ -105,24 +115,26 @@ function fileMenuItems(): MenuItemConstructorOptions[] {
         {
             label: 'Add Torrent',
             accelerator: 'CmdOrCtrl+O',
+            enabled: hasConnectedServer(),
             click: () => sendAction({ type: 'open-add-torrent', askUploadOptions: false }),
         },
         {
             label: 'Add Torrent (Advanced)',
             accelerator: process.platform === 'darwin' ? 'CmdOrCtrl+Alt+O' : 'CmdOrCtrl+Shift+O',
-            visible: advancedUploadEnabled(),
+            visible: advancedUploadVisible(),
             enabled: advancedUploadEnabled(),
             click: () => sendAction({ type: 'open-add-torrent', askUploadOptions: true }),
         },
         {
             label: 'Paste Torrent URL',
             accelerator: 'CmdOrCtrl+I',
+            enabled: hasConnectedServer(),
             click: () => sendAction({ type: 'paste-torrent-url', askUploadOptions: false }),
         },
         {
             label: 'Paste Torrent URL (Advanced)',
             accelerator: process.platform === 'darwin' ? 'CmdOrCtrl+Alt+I' : 'CmdOrCtrl+Shift+I',
-            visible: advancedUploadEnabled(),
+            visible: advancedUploadVisible(),
             enabled: advancedUploadEnabled(),
             click: () => sendAction({ type: 'paste-torrent-url', askUploadOptions: true }),
         },
@@ -320,10 +332,11 @@ export function configure(state: Pick<MenuSessionState, 'isDebug'>) {
     refresh()
 }
 
-export function setActiveServer(server?: { id?: string | null; client?: string | null } | null) {
+export function setActiveServer(server?: { id?: string | null; client?: string | null } | null, isConnected = !!server) {
     menuState = Object.assign({}, menuState, {
         activeServerId: server?.id || null,
         activeClientId: server?.client || null,
+        isConnected: !!server && isConnected,
     })
     buildMenu()
 }

--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -212,6 +212,7 @@ export class AppShellController {
             pageLoading();
             $scope.$broadcast("stop:torrents");
             $scope.$broadcast("wipe:torrents");
+            ($rootScope as any).$activeServer = server;
             $rootScope.$btclient = null;
             $rootScope.$server = null;
             const serverName = typeof server?.getDisplayName === "function"
@@ -248,6 +249,7 @@ export class AppShellController {
 
         $scope.$on("add:server", () => {
             $scope.$broadcast("stop:torrents");
+            ($rootScope as any).$activeServer = null;
             $rootScope.$btclient = null;
             pageWelcome();
             $scope.$apply();

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
@@ -1,5 +1,6 @@
 import { IScope } from "angular";
 import { createMenuActionHandler } from "@renderer/app/lib/menu-action-handler";
+import { CLIENT_METADATA } from "@shared/client-metadata";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import type { EditCommand, MenuAction, WindowCommand } from "@shared/ipc-contract";
 
@@ -54,12 +55,21 @@ export class TitleBarMenuController {
             currentPage: $scope.currentPage,
         });
 
+        const activeServer = () => {
+            return ($rootScope as any).$activeServer || $rootScope.$server;
+        };
+
         const supportsUploadOptions = () => {
-            return Object.values($rootScope.$btclient?.features.uploadOptions || {}).some(Boolean);
+            const clientId = activeServer()?.client;
+            return !!clientId && !!CLIENT_METADATA[clientId]?.showAdvancedUploadMenu;
         };
 
         const hasActiveServer = () => {
-            return !!$rootScope.$server?.id;
+            return !!activeServer()?.id;
+        };
+
+        const hasConnectedServer = () => {
+            return hasActiveServer() && !!$rootScope.$server?.isConnected && !!$rootScope.$btclient;
         };
 
         const serverAccelerator = (index: number) => {
@@ -78,23 +88,27 @@ export class TitleBarMenuController {
             {
                 label: "Add Torrent",
                 accelerator: "Ctrl+O",
+                enabled: hasConnectedServer(),
                 action: { type: "open-add-torrent", askUploadOptions: false },
             },
             {
                 label: "Add Torrent (Advanced)",
                 accelerator: "Ctrl+Shift+O",
                 visible: supportsUploadOptions,
+                enabled: hasConnectedServer(),
                 action: { type: "open-add-torrent", askUploadOptions: true },
             },
             {
                 label: "Paste Torrent URL",
                 accelerator: "Ctrl+I",
+                enabled: hasConnectedServer(),
                 action: { type: "paste-torrent-url", askUploadOptions: false },
             },
             {
                 label: "Paste Torrent URL (Advanced)",
                 accelerator: "Ctrl+Shift+I",
                 visible: supportsUploadOptions,
+                enabled: hasConnectedServer(),
                 action: { type: "paste-torrent-url", askUploadOptions: true },
             },
             { label: "", separator: true },
@@ -163,7 +177,7 @@ export class TitleBarMenuController {
                 items.push({
                     label: getServerLabel(server),
                     accelerator: serverAccelerator(index + 1),
-                    checked: server.id === $rootScope.$server?.id,
+                    checked: server.id === activeServer()?.id,
                     action: { type: "connect-server", serverId: server.id },
                 });
             });


### PR DESCRIPTION
## Summary
- track selected servers separately from connected servers for both native and title-bar menus
- keep the selected server checked after failed connection attempts
- disable add/paste torrent menu actions while disconnected while preserving advanced menu visibility for supported clients

## Validation
- npm run lint
- npm run build
- npm run smoketest