### PR TITLE
feat: add upload file selection

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,7 @@
 import request from "request"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
 import {
     defer,
     HTTP_LOGIN_TIMEOUT,
@@ -82,6 +82,16 @@ export class DelugeRuntime implements BittorrentRuntime {
             return {}
         }
 
+        const fileSelection = Array.isArray(options.fileSelection)
+            ? options.fileSelection as BittorrentFileSelection[]
+            : []
+        const filePriorities = fileSelection.length > 0
+            ? fileSelection.reduce<number[]>((priorities, file) => {
+                priorities[file.index] = file.wanted ? 1 : 0
+                return priorities
+            }, [])
+            : undefined
+
         return Object.fromEntries(
             Object.entries({
                 download_location: options.saveLocation || undefined,
@@ -91,6 +101,7 @@ export class DelugeRuntime implements BittorrentRuntime {
                 max_upload_speed: options.uploadSpeedLimit,
                 prioritize_first_last_pieces: options.firstAndLastPiecePrio,
                 label: options.category,
+                file_priorities: filePriorities,
             }).filter(([, value]) => value !== undefined && value !== null),
         )
     }
@@ -245,6 +256,7 @@ export class DelugeRuntime implements BittorrentRuntime {
             features: {
                 magnetLinks: Array.isArray(methods) && methods.includes("core.add_torrent_magnet"),
                 labels: this.supportsLabels,
+                uploadFileSelection: true,
                 torrentDetails: true,
                 speedLimits: true,
                 ratioLimits: true,

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -5,6 +5,7 @@ import type {
     TorrentClientConnection,
 } from "@shared/ipc-contract"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
+import parseTorrent from "parse-torrent"
 
 const PRIORITY_SKIP = 0
 const PRIORITY_NORMAL = 1
@@ -82,6 +83,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
                 magnetLinks: true,
                 labels: true,
                 fileSelection: true,
+                uploadFileSelection: true,
                 setLocation: true,
                 torrentDetails: true,
                 ratioLimits: true,
@@ -123,12 +125,28 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {
         this.assertConnected()
-        await this.addTorrent(options?.renameTorrent || uri.replace(/^magnet:\?xt=urn:btih:/, "Mock Magnet "))
+        try {
+            const parsed = parseTorrent(uri)
+            await this.addTorrent(options?.renameTorrent || parsed.name || uri.replace(/^magnet:\?xt=urn:btih:/, "Mock Magnet "), {
+                hash: parsed.infoHash,
+                files: this.createFilesFromUploadSelection(options?.fileSelection),
+            })
+        } catch {
+            await this.addTorrent(options?.renameTorrent || uri.replace(/^magnet:\?xt=urn:btih:/, "Mock Magnet "), {
+                files: this.createFilesFromUploadSelection(options?.fileSelection),
+            })
+        }
     }
 
-    async uploadTorrent(_buffer: Uint8Array, filename: string, options?: Record<string, any>): Promise<void> {
+    async uploadTorrent(buffer: Uint8Array, filename: string, options?: Record<string, any>): Promise<void> {
         this.assertConnected()
-        await this.addTorrent(options?.renameTorrent || filename.replace(/\.torrent$/i, ""))
+        const parsed = parseTorrent(Buffer.from(buffer))
+        const parsedFiles = "files" in parsed && Array.isArray(parsed.files) ? parsed.files : undefined
+        await this.addTorrent(options?.renameTorrent || parsed.name || filename.replace(/\.torrent$/i, ""), {
+            hash: parsed.infoHash,
+            files: this.createFilesFromUploadSelection(options?.fileSelection)
+                || this.createFilesFromTorrentMetadata(parsedFiles),
+        })
     }
 
     async addMockedTorrent(_hashes: string[], input: MockTorrentInput = {}): Promise<string> {
@@ -370,6 +388,38 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         ]
     }
 
+    private createFilesFromUploadSelection(files: unknown): MockTorrentFile[] | undefined {
+        if (!Array.isArray(files) || files.length === 0) {
+            return undefined
+        }
+
+        return files.map((file: BittorrentFileSelection, index: number) => ({
+            index: file.index ?? index,
+            name: file.path || file.name || `file-${index + 1}`,
+            size: file.size || 0,
+            progress: 0,
+            availability: 1,
+            priority: file.wanted ? PRIORITY_NORMAL : PRIORITY_SKIP,
+            is_seed: false,
+        }))
+    }
+
+    private createFilesFromTorrentMetadata(files: any[] | undefined): MockTorrentFile[] | undefined {
+        if (!Array.isArray(files) || files.length === 0) {
+            return undefined
+        }
+
+        return files.map((file, index) => ({
+            index,
+            name: file.path || file.name || `file-${index + 1}`,
+            size: typeof file.length === "number" ? file.length : 0,
+            progress: 0,
+            availability: 1,
+            priority: PRIORITY_NORMAL,
+            is_seed: false,
+        }))
+    }
+
     private getCategories() {
         return Object.fromEntries(
             Array.from(new Set(Array.from(this.torrents.values()).map((torrent) => torrent.category)))
@@ -378,8 +428,9 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         )
     }
 
-    private async addTorrent(name: string) {
+    private async addTorrent(name: string, input: MockTorrentInput = {}) {
         await this.addMockedTorrent([], {
+            ...input,
             added_on: Math.floor(Date.now() / 1000),
             category: "mock-label-new",
             dl_speed: 512 * 1024,

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -1,5 +1,6 @@
 import { URL } from "node:url"
 import request from "request"
+import parseTorrent from "parse-torrent"
 
 import type {
     BittorrentFileSelection,
@@ -88,6 +89,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 magnetLinks: true,
                 labels: true,
                 fileSelection: true,
+                uploadFileSelection: true,
                 setLocation: true,
                 torrentDetails: true,
                 trackerFilter: true,
@@ -259,10 +261,16 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         }
     }
 
-    private getHttpUploadOptions(options?: Record<string, any>) {
+    private getUploadFileSelection(options?: Record<string, any>): BittorrentFileSelection[] {
+        return Array.isArray(options?.fileSelection) ? options.fileSelection : []
+    }
+
+    private getHttpUploadOptions(options?: Record<string, any>, includeFilePriorities = true) {
         if (!options) {
             return undefined
         }
+
+        const filePriorities = includeFilePriorities ? this.getUploadFilePriorities(options.fileSelection) : undefined
 
         return Object.fromEntries(
             Object.entries({
@@ -276,10 +284,35 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 dlLimit: options.downloadSpeedLimit === undefined ? undefined : Number(options.downloadSpeedLimit) * 1024,
                 sequentialDownload: options.sequentialDownload,
                 firstLastPiecePrio: options.firstAndLastPiecePrio,
+                filePriorities,
             })
                 .filter(([, value]) => value !== undefined && value !== null)
                 .map(([key, value]) => [key, value.toString()]),
         )
+    }
+
+    private getUploadFilePriorities(fileSelection: unknown) {
+        if (!Array.isArray(fileSelection) || fileSelection.length === 0) {
+            return undefined
+        }
+        if (!fileSelection.some((file) => file?.wanted === false)) {
+            return undefined
+        }
+
+        const files = (fileSelection as BittorrentFileSelection[])
+            .map((file) => ({ ...file, index: Number(file.index) }))
+            .filter((file) => Number.isInteger(file.index) && file.index >= 0)
+        const maxIndex = files.reduce((max, file) => Math.max(max, file.index), -1)
+        if (maxIndex < 0) {
+            return undefined
+        }
+
+        const priorities = new Array(maxIndex + 1).fill(QBITTORRENT_PRIORITY_NORMAL)
+        files.forEach((file) => {
+            priorities[file.index] = file.wanted === false ? QBITTORRENT_PRIORITY_SKIP : QBITTORRENT_PRIORITY_NORMAL
+        })
+
+        return priorities.join(",")
     }
 
     addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {
@@ -287,9 +320,25 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         return defer((done) => api.addTorrentURL(uri, this.getHttpUploadOptions(options), done))
     }
 
-    uploadTorrent(buffer: Uint8Array, filename: string, options?: Record<string, any>): Promise<void> {
+    async uploadTorrent(buffer: Uint8Array, filename: string, options?: Record<string, any>): Promise<void> {
         const api = this.getApi()
-        return defer((done) => api.addTorrentFileContent(Buffer.from(buffer), filename, this.getHttpUploadOptions(options), done))
+        const fileSelection = this.getUploadFileSelection(options)
+        if (fileSelection.length > 0) {
+            const hash = parseTorrent(Buffer.from(buffer)).infoHash
+            await defer((done) => api.addTorrentFileContent(
+                Buffer.from(buffer),
+                filename,
+                this.getHttpUploadOptions({ ...options, startTorrent: false }, false),
+                done,
+            ))
+            await this.setTorrentFileSelection(hash, fileSelection)
+            if (options?.startTorrent !== false) {
+                await this.resume([hash])
+            }
+            return
+        }
+
+        return defer((done) => api.addTorrentFileContent(Buffer.from(buffer), filename, this.getHttpUploadOptions(options, false), done))
     }
 
     resume(hashes: string[]): Promise<void> {

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -1,8 +1,9 @@
 import path from "node:path"
 import { URL } from "node:url"
 import xmlrpc from "@electorrent/xmlrpc"
+import parseTorrent from "parse-torrent"
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
 import { defer, HTTP_LOGIN_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { doubleArrayToHash, postfix, rtorrentFields, stringsToBooleans, stringsToNumbers, urlHostname } from "./helpers"
@@ -56,6 +57,28 @@ export class RtorrentRuntime implements BittorrentRuntime {
             return shouldStart ? "load.start" : "load.normal"
         }
         return shouldStart ? "load.raw_start" : "load.raw"
+    }
+
+    private getUploadFileSelection(options?: Record<string, any>): BittorrentFileSelection[] {
+        return Array.isArray(options?.fileSelection) ? options.fileSelection : []
+    }
+
+    private async setUploadFileSelection(hash: string, files: BittorrentFileSelection[]) {
+        const unwantedFiles = files.filter((file) => !file.wanted)
+        if (unwantedFiles.length === 0) {
+            return
+        }
+
+        await this.call("system.multicall", [[
+            ...unwantedFiles.map((file): RtorrentMethodCall => ({
+                methodName: "f.priority.set",
+                params: [`${hash}:f${file.index}`, 0],
+            })),
+            {
+                methodName: "d.update_priorities",
+                params: [hash],
+            },
+        ]])
     }
 
     private async getMulticall(method: string, params: any[], commands: Record<string, string>): Promise<Record<string, any>[]> {
@@ -192,6 +215,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
             features: {
                 magnetLinks: true,
                 labels: true,
+                uploadFileSelection: true,
                 torrentDetails: true,
                 trackerFilter: true,
                 speedLimits: true,
@@ -380,6 +404,22 @@ export class RtorrentRuntime implements BittorrentRuntime {
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {
+        const fileSelection = this.getUploadFileSelection(options)
+        if (fileSelection.length > 0) {
+            const hash = parseTorrent(uri).infoHash
+            const method = "load.normal"
+            if (options?.saveLocation) {
+                await this.loadTorrentWithSaveLocation(method, uri, options.saveLocation)
+            } else {
+                await this.call(method, ["", uri])
+            }
+            await this.setUploadFileSelection(hash, fileSelection)
+            if (options?.startTorrent !== false) {
+                await this.start([hash])
+            }
+            return
+        }
+
         const method = this.getLoadMethod("url", options)
         if (options?.saveLocation) {
             await this.loadTorrentWithSaveLocation(method, uri, options.saveLocation)
@@ -390,6 +430,22 @@ export class RtorrentRuntime implements BittorrentRuntime {
     }
 
     async uploadTorrent(buffer: Uint8Array, _filename: string, options?: Record<string, any>): Promise<void> {
+        const fileSelection = this.getUploadFileSelection(options)
+        if (fileSelection.length > 0) {
+            const hash = parseTorrent(Buffer.from(buffer)).infoHash
+            const method = "load.raw"
+            if (options?.saveLocation) {
+                await this.loadTorrentWithSaveLocation(method, buffer, options.saveLocation)
+            } else {
+                await this.call(method, ["", Buffer.from(buffer)])
+            }
+            await this.setUploadFileSelection(hash, fileSelection)
+            if (options?.startTorrent !== false) {
+                await this.start([hash])
+            }
+            return
+        }
+
         const method = this.getLoadMethod("file", options)
         if (options?.saveLocation) {
             await this.loadTorrentWithSaveLocation(method, buffer, options.saveLocation)

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -198,6 +198,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
             features: {
                 magnetLinks: true,
                 labels: true,
+                uploadFileSelection: true,
                 setLocation: true,
                 torrentDetails: true,
                 trackerFilter: true,
@@ -338,6 +339,9 @@ export class TransmissionRuntime implements BittorrentRuntime {
             'download-dir': uploadOptions.saveLocation || undefined,
             labels: uploadOptions.category ? [uploadOptions.category] : undefined,
             paused: uploadOptions.startTorrent === undefined ? undefined : !uploadOptions.startTorrent,
+            'files-unwanted': Array.isArray(uploadOptions.fileSelection)
+                ? uploadOptions.fileSelection.filter((file: any) => !file.wanted).map((file: any) => file.index)
+                : undefined,
         })
     }
 

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -200,6 +200,8 @@ import { AddTorrentModalDirective } from "@renderer/app/directives/add-torrent-m
 torrentApp.directive('addTorrentModal', AddTorrentModalDirective.getInstance())
 import { TorrentUploadFormDirective } from "@renderer/app/directives/torrent-upload-form/torrent-upload-form.directive";
 torrentApp.directive('torrentUploadForm', TorrentUploadFormDirective.getInstance())
+import { TorrentUploadFileSelectionDirective } from "@renderer/app/directives/torrent-upload-file-selection/torrent-upload-file-selection.directive";
+torrentApp.directive('torrentUploadFileSelection', TorrentUploadFileSelectionDirective.getInstance())
 import { TorrentFilesTreeDirective } from "@renderer/app/directives/torrent-files-tree/torrent-files-tree.directive";
 torrentApp.directive('torrentFilesTree', TorrentFilesTreeDirective.getInstance())
 import { indeterminateValueDirective } from "@renderer/app/directives/torrent-files-tree/indeterminate-value.directive";

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -48,12 +48,14 @@ const DEFAULT_UPLOAD_OPTIONS: ResolvedTorrentClientFeatures["uploadOptions"] = O
     firstAndLastPiecePrio: false,
     downloadSpeedLimit: false,
     uploadSpeedLimit: false,
+    fileSelection: false,
 })
 
 const DEFAULT_FEATURES: ResolvedTorrentClientFeatures = Object.freeze({
     magnetLinks: false,
     labels: false,
     fileSelection: false,
+    uploadFileSelection: false,
     setLocation: false,
     torrentDetails: false,
     trackerFilter: false,
@@ -373,6 +375,7 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
             { id: "name", label: "Name", format: "text", sortType: "alphabetical" },
             { id: "size", label: "Size", format: "bytes", sortType: "numeric" },
             { id: "progress", label: "Progress", format: "progress", sortType: "numeric" },
+            { id: "wanted", label: "Wanted", format: "text", sortType: "alphabetical" },
             { id: "availability", label: "Availability", format: "percent", sortType: "numeric" },
             { id: "priority", label: "Priority", format: "number", sortType: "numeric" },
             { id: "path", label: "Path", format: "text", sortType: "alphabetical" },

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
@@ -1,26 +1,13 @@
-import { ITimeoutService } from "angular";
 import { TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
 import { SavedLocationModalController } from "@renderer/app/directives/saved-location-modal/saved-location-modal.controller";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import { AddTorrentModalScope } from "./add-torrent-modal.directive";
-import type { BittorrentFileSelection, TorrentMetadataFile } from "@shared/ipc-contract";
-
-interface UploadFileTreeNode {
-    id: string
-    name: string
-    path: string
-    size: number
-    level: number
-    fileIndex?: number
-    children: UploadFileTreeNode[]
-    selected: boolean
-    partial: boolean
-}
+import type { BittorrentFileSelection } from "@shared/ipc-contract";
 
 export class AddTorrentModalController {
 
-    static $inject = ["$scope", "$rootScope", "$timeout"]
+    static $inject = ["$scope", "$rootScope"]
 
     static defaultTorrentUploadOptions: TorrentUploadOptions = {
         startTorrent: true,
@@ -32,13 +19,11 @@ export class AddTorrentModalController {
     savedLocationModalRef: SavedLocationModalController
     uploadOptions: TorrentUploadOptions
     isLoading: boolean
-    activeTab = "general"
-    fileTree: UploadFileTreeNode[] = []
-    visibleFileTree: UploadFileTreeNode[] = []
+    activeTab: "general" | "files" = "general"
     private preserveUploadsOnHide: boolean
     private restoreUploadOptionsOnShow: boolean
 
-    constructor(scope: AddTorrentModalScope, rootScope: ElectorrentRootScope, private readonly $timeout: ITimeoutService) {
+    constructor(scope: AddTorrentModalScope, rootScope: ElectorrentRootScope) {
         this.scope = scope
         this.rootScope = rootScope
         this.isLoading = false
@@ -49,7 +34,6 @@ export class AddTorrentModalController {
             return this.scope.torrents && this.scope.torrents.length
         }, (newVal, oldVal) => {
             if (newVal > 0) {
-                this.refreshUploadFiles()
                 this.modalref.showModal()
             } else if (oldVal > 0 && newVal === 0) {
                 this.modalref.hideModal()
@@ -74,7 +58,6 @@ export class AddTorrentModalController {
             configuredOptions || {},
         )
         this.activeTab = "general"
-        this.refreshUploadFiles()
     }
 
     onHidden() {
@@ -82,8 +65,6 @@ export class AddTorrentModalController {
             return
         }
         this.scope.torrents = []
-        this.fileTree = []
-        this.visibleFileTree = []
     }
 
     supportsSavedLocations() {
@@ -111,8 +92,13 @@ export class AddTorrentModalController {
         return metadata?.length || metadata?.files.reduce((size, file) => size + (file.length || 0), 0) || 0
     }
 
+    getCurrentTorrentUploadFiles() {
+        return this.getCurrentTorrentUpload()?.metadata?.files
+    }
+
     hasFilesTab() {
-        return !!this.rootScope.$btclient?.features.uploadFileSelection && this.visibleFileTree.length > 0
+        return !!this.rootScope.$btclient?.features.uploadFileSelection
+            && !!this.getCurrentTorrentUploadFiles()?.length
     }
 
     switchTab(tab: "general" | "files") {
@@ -120,13 +106,14 @@ export class AddTorrentModalController {
             return
         }
         this.activeTab = tab
-        this.updateIndeterminateCheckboxes()
     }
 
-    toggleFileNode(node: UploadFileTreeNode) {
-        this.setNodeSelection(node, node.partial ? true : !node.selected)
-        this.syncFileSelectionOptions()
-        this.updateIndeterminateCheckboxes()
+    updateFileSelection(selection?: BittorrentFileSelection[]) {
+        if (selection) {
+            this.uploadOptions.fileSelection = selection
+        } else {
+            delete this.uploadOptions.fileSelection
+        }
     }
 
     getPendingUploadCountLabel() {
@@ -199,135 +186,6 @@ export class AddTorrentModalController {
         } else {
             await this.rootScope.$btclient.uploadTorrent(torrent, filename, options, sourcePath)
         }
-    }
-
-    private refreshUploadFiles() {
-        const torrent = this.getCurrentTorrentUpload()
-        const files = torrent?.metadata?.files || []
-        if (!this.rootScope.$btclient?.features.uploadFileSelection || files.length === 0) {
-            delete this.uploadOptions.fileSelection
-            this.fileTree = []
-            this.visibleFileTree = []
-            this.activeTab = "general"
-            return
-        }
-
-        this.fileTree = this.buildFileTree(files)
-        this.visibleFileTree = this.flattenFileTree(this.fileTree)
-        this.syncFileSelectionOptions()
-        this.updateIndeterminateCheckboxes()
-    }
-
-    private buildFileTree(files: TorrentMetadataFile[]) {
-        const roots: UploadFileTreeNode[] = []
-        const folders = new Map<string, UploadFileTreeNode>()
-
-        files.forEach((file, index) => {
-            const normalizedPath = file.path || file.name || `file-${index + 1}`
-            const parts = normalizedPath.split(/[\\/]+/).filter(Boolean)
-            let siblings = roots
-            let folderPath = ""
-
-            parts.forEach((part, partIndex) => {
-                const isFile = partIndex === parts.length - 1
-                folderPath = folderPath ? `${folderPath}/${part}` : part
-                if (isFile) {
-                    siblings.push({
-                        id: `file-${index}`,
-                        name: part,
-                        path: normalizedPath,
-                        size: file.length || 0,
-                        level: partIndex,
-                        fileIndex: index,
-                        children: [],
-                        selected: true,
-                        partial: false,
-                    })
-                    return
-                }
-
-                let folder = folders.get(folderPath)
-                if (!folder) {
-                    folder = {
-                        id: `folder-${encodeURIComponent(folderPath)}`,
-                        name: part,
-                        path: folderPath,
-                        size: 0,
-                        level: partIndex,
-                        children: [],
-                        selected: true,
-                        partial: false,
-                    }
-                    folders.set(folderPath, folder)
-                    siblings.push(folder)
-                }
-                siblings = folder.children
-            })
-        })
-
-        this.refreshFolderState(roots)
-        return roots
-    }
-
-    private flattenFileTree(nodes: UploadFileTreeNode[]): UploadFileTreeNode[] {
-        return nodes.flatMap((node) => [node, ...this.flattenFileTree(node.children)])
-    }
-
-    private setNodeSelection(node: UploadFileTreeNode, selected: boolean) {
-        node.selected = selected
-        node.partial = false
-        node.children.forEach((child) => this.setNodeSelection(child, selected))
-        this.refreshFolderState(this.fileTree)
-    }
-
-    private refreshFolderState(nodes: UploadFileTreeNode[]) {
-        nodes.forEach((node) => {
-            if (node.children.length === 0) {
-                return
-            }
-
-            this.refreshFolderState(node.children)
-            node.size = node.children.reduce((size, child) => size + child.size, 0)
-            const selectedCount = node.children.filter((child) => child.selected && !child.partial).length
-            const partialCount = node.children.filter((child) => child.partial).length
-            node.selected = selectedCount === node.children.length && partialCount === 0
-            node.partial = (selectedCount > 0 || partialCount > 0) && !node.selected
-        })
-    }
-
-    private syncFileSelectionOptions() {
-        if (!this.hasFilesTab()) {
-            delete this.uploadOptions.fileSelection
-            return
-        }
-
-        const fileSelection = this.visibleFileTree
-            .filter((node) => node.fileIndex !== undefined)
-            .map((node): BittorrentFileSelection => ({
-                index: node.fileIndex!,
-                path: node.path,
-                name: node.name,
-                size: node.size,
-                wanted: node.selected,
-            }))
-
-        if (fileSelection.every((file) => file.wanted)) {
-            delete this.uploadOptions.fileSelection
-            return
-        }
-
-        this.uploadOptions.fileSelection = fileSelection
-    }
-
-    private updateIndeterminateCheckboxes() {
-        this.$timeout(() => {
-            this.visibleFileTree.forEach((node) => {
-                const element = document.getElementById(`upload-file-cb-${node.id}`) as HTMLInputElement | null
-                if (element) {
-                    element.indeterminate = node.partial
-                }
-            })
-        })
     }
 
 }

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.controller.ts
@@ -1,12 +1,26 @@
+import { ITimeoutService } from "angular";
 import { TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
 import { SavedLocationModalController } from "@renderer/app/directives/saved-location-modal/saved-location-modal.controller";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import { AddTorrentModalScope } from "./add-torrent-modal.directive";
+import type { BittorrentFileSelection, TorrentMetadataFile } from "@shared/ipc-contract";
+
+interface UploadFileTreeNode {
+    id: string
+    name: string
+    path: string
+    size: number
+    level: number
+    fileIndex?: number
+    children: UploadFileTreeNode[]
+    selected: boolean
+    partial: boolean
+}
 
 export class AddTorrentModalController {
 
-    static $inject = ["$scope", "$rootScope"]
+    static $inject = ["$scope", "$rootScope", "$timeout"]
 
     static defaultTorrentUploadOptions: TorrentUploadOptions = {
         startTorrent: true,
@@ -18,10 +32,13 @@ export class AddTorrentModalController {
     savedLocationModalRef: SavedLocationModalController
     uploadOptions: TorrentUploadOptions
     isLoading: boolean
+    activeTab = "general"
+    fileTree: UploadFileTreeNode[] = []
+    visibleFileTree: UploadFileTreeNode[] = []
     private preserveUploadsOnHide: boolean
     private restoreUploadOptionsOnShow: boolean
 
-    constructor(scope: AddTorrentModalScope, rootScope: ElectorrentRootScope) {
+    constructor(scope: AddTorrentModalScope, rootScope: ElectorrentRootScope, private readonly $timeout: ITimeoutService) {
         this.scope = scope
         this.rootScope = rootScope
         this.isLoading = false
@@ -32,6 +49,7 @@ export class AddTorrentModalController {
             return this.scope.torrents && this.scope.torrents.length
         }, (newVal, oldVal) => {
             if (newVal > 0) {
+                this.refreshUploadFiles()
                 this.modalref.showModal()
             } else if (oldVal > 0 && newVal === 0) {
                 this.modalref.hideModal()
@@ -55,6 +73,8 @@ export class AddTorrentModalController {
             AddTorrentModalController.defaultTorrentUploadOptions,
             configuredOptions || {},
         )
+        this.activeTab = "general"
+        this.refreshUploadFiles()
     }
 
     onHidden() {
@@ -62,6 +82,8 @@ export class AddTorrentModalController {
             return
         }
         this.scope.torrents = []
+        this.fileTree = []
+        this.visibleFileTree = []
     }
 
     supportsSavedLocations() {
@@ -83,6 +105,30 @@ export class AddTorrentModalController {
         return torrent.metadata?.name || (torrent.type === "file" ? torrent.filename : torrent.uri)
     }
 
+    getCurrentTorrentUploadSize() {
+        const torrent = this.getCurrentTorrentUpload()
+        const metadata = torrent?.metadata
+        return metadata?.length || metadata?.files.reduce((size, file) => size + (file.length || 0), 0) || 0
+    }
+
+    hasFilesTab() {
+        return !!this.rootScope.$btclient?.features.uploadFileSelection && this.visibleFileTree.length > 0
+    }
+
+    switchTab(tab: "general" | "files") {
+        if (tab === "files" && !this.hasFilesTab()) {
+            return
+        }
+        this.activeTab = tab
+        this.updateIndeterminateCheckboxes()
+    }
+
+    toggleFileNode(node: UploadFileTreeNode) {
+        this.setNodeSelection(node, node.partial ? true : !node.selected)
+        this.syncFileSelectionOptions()
+        this.updateIndeterminateCheckboxes()
+    }
+
     getPendingUploadCountLabel() {
         const torrentCount = this.scope.torrents?.length || 0
         return `${torrentCount} ${torrentCount === 1 ? "torrent" : "torrents"} remaining`
@@ -92,6 +138,8 @@ export class AddTorrentModalController {
         this.scope.torrents.shift()
         if (this.scope.torrents.length === 0) {
             this.modalref.hideModal()
+        } else {
+            this.onShow()
         }
     }
 
@@ -107,6 +155,8 @@ export class AddTorrentModalController {
             this.scope.torrents.shift()
             if (this.scope.torrents.length === 0) {
                 this.modalref.hideModal()
+            } else {
+                this.onShow()
             }
         } finally {
             this.isLoading = false
@@ -149,6 +199,135 @@ export class AddTorrentModalController {
         } else {
             await this.rootScope.$btclient.uploadTorrent(torrent, filename, options, sourcePath)
         }
+    }
+
+    private refreshUploadFiles() {
+        const torrent = this.getCurrentTorrentUpload()
+        const files = torrent?.metadata?.files || []
+        if (!this.rootScope.$btclient?.features.uploadFileSelection || files.length === 0) {
+            delete this.uploadOptions.fileSelection
+            this.fileTree = []
+            this.visibleFileTree = []
+            this.activeTab = "general"
+            return
+        }
+
+        this.fileTree = this.buildFileTree(files)
+        this.visibleFileTree = this.flattenFileTree(this.fileTree)
+        this.syncFileSelectionOptions()
+        this.updateIndeterminateCheckboxes()
+    }
+
+    private buildFileTree(files: TorrentMetadataFile[]) {
+        const roots: UploadFileTreeNode[] = []
+        const folders = new Map<string, UploadFileTreeNode>()
+
+        files.forEach((file, index) => {
+            const normalizedPath = file.path || file.name || `file-${index + 1}`
+            const parts = normalizedPath.split(/[\\/]+/).filter(Boolean)
+            let siblings = roots
+            let folderPath = ""
+
+            parts.forEach((part, partIndex) => {
+                const isFile = partIndex === parts.length - 1
+                folderPath = folderPath ? `${folderPath}/${part}` : part
+                if (isFile) {
+                    siblings.push({
+                        id: `file-${index}`,
+                        name: part,
+                        path: normalizedPath,
+                        size: file.length || 0,
+                        level: partIndex,
+                        fileIndex: index,
+                        children: [],
+                        selected: true,
+                        partial: false,
+                    })
+                    return
+                }
+
+                let folder = folders.get(folderPath)
+                if (!folder) {
+                    folder = {
+                        id: `folder-${encodeURIComponent(folderPath)}`,
+                        name: part,
+                        path: folderPath,
+                        size: 0,
+                        level: partIndex,
+                        children: [],
+                        selected: true,
+                        partial: false,
+                    }
+                    folders.set(folderPath, folder)
+                    siblings.push(folder)
+                }
+                siblings = folder.children
+            })
+        })
+
+        this.refreshFolderState(roots)
+        return roots
+    }
+
+    private flattenFileTree(nodes: UploadFileTreeNode[]): UploadFileTreeNode[] {
+        return nodes.flatMap((node) => [node, ...this.flattenFileTree(node.children)])
+    }
+
+    private setNodeSelection(node: UploadFileTreeNode, selected: boolean) {
+        node.selected = selected
+        node.partial = false
+        node.children.forEach((child) => this.setNodeSelection(child, selected))
+        this.refreshFolderState(this.fileTree)
+    }
+
+    private refreshFolderState(nodes: UploadFileTreeNode[]) {
+        nodes.forEach((node) => {
+            if (node.children.length === 0) {
+                return
+            }
+
+            this.refreshFolderState(node.children)
+            node.size = node.children.reduce((size, child) => size + child.size, 0)
+            const selectedCount = node.children.filter((child) => child.selected && !child.partial).length
+            const partialCount = node.children.filter((child) => child.partial).length
+            node.selected = selectedCount === node.children.length && partialCount === 0
+            node.partial = (selectedCount > 0 || partialCount > 0) && !node.selected
+        })
+    }
+
+    private syncFileSelectionOptions() {
+        if (!this.hasFilesTab()) {
+            delete this.uploadOptions.fileSelection
+            return
+        }
+
+        const fileSelection = this.visibleFileTree
+            .filter((node) => node.fileIndex !== undefined)
+            .map((node): BittorrentFileSelection => ({
+                index: node.fileIndex!,
+                path: node.path,
+                name: node.name,
+                size: node.size,
+                wanted: node.selected,
+            }))
+
+        if (fileSelection.every((file) => file.wanted)) {
+            delete this.uploadOptions.fileSelection
+            return
+        }
+
+        this.uploadOptions.fileSelection = fileSelection
+    }
+
+    private updateIndeterminateCheckboxes() {
+        this.$timeout(() => {
+            this.visibleFileTree.forEach((node) => {
+                const element = document.getElementById(`upload-file-cb-${node.id}`) as HTMLInputElement | null
+                if (element) {
+                    element.indeterminate = node.partial
+                }
+            })
+        })
     }
 
 }

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
@@ -8,18 +8,40 @@
     </div>
     <div class="content">
         <form id="upload-torrent-form" ng-submit="ctl.uploadCurrentTorrent()">
-            <h4 class="ui header">
-                <div class="content">
-                    Add a New Torrent
-                    <div class="sub header">{{ ctl.getCurrentTorrentUploadLabel() }}</div>
-                </div>
+            <h4 class="ui header upload-torrent-heading">
+                <span class="upload-torrent-name">{{ ctl.getCurrentTorrentUploadLabel() }}</span>
+                <span class="upload-torrent-size">{{ ctl.getCurrentTorrentUploadSize() | bytes }}</span>
             </h4>
-            <torrent-upload-form
-                loading="ctl.isLoading"
-                options="ctl.uploadOptions"
-                labels="labels"
-                can-add-saved-location="!!ctl.rootScope.$server"
-                on-add-saved-location="ctl.openSavedLocationModal()"></torrent-upload-form>
+            <div class="ui secondary pointing menu" ng-if="ctl.hasFilesTab()">
+                <a class="item" ng-class="{active: ctl.activeTab === 'general'}" ng-click="ctl.switchTab('general')">General</a>
+                <a class="item" ng-class="{active: ctl.activeTab === 'files'}" ng-click="ctl.switchTab('files')">Files</a>
+            </div>
+            <div ng-show="ctl.activeTab === 'general' || !ctl.hasFilesTab()">
+                <torrent-upload-form
+                    loading="ctl.isLoading"
+                    options="ctl.uploadOptions"
+                    labels="labels"
+                    can-add-saved-location="!!ctl.rootScope.$server"
+                    on-add-saved-location="ctl.openSavedLocationModal()"></torrent-upload-form>
+            </div>
+            <div ng-if="ctl.hasFilesTab()" ng-show="ctl.activeTab === 'files'">
+                <div class="ui relaxed divided list upload-files-list upload-files-scroll">
+                    <div class="item upload-file-row" ng-repeat="node in ctl.visibleFileTree track by node.id" ng-style="{'padding-left': (node.level * 1.5) + 'rem'}" data-upload-file-path="{{ node.path }}">
+                        <div class="right floated content upload-file-meta">
+                            <span class="upload-file-size">{{ node.size | bytes }}</span>
+                        </div>
+                        <div class="content">
+                            <div class="ui checkbox">
+                                <input id="upload-file-cb-{{ node.id }}" type="checkbox" ng-checked="node.selected" ng-click="ctl.toggleFileNode(node)">
+                                <label for="upload-file-cb-{{ node.id }}">
+                                    <i class="icon" ng-class="node.children.length ? 'folder' : 'file outline'"></i>
+                                    {{ node.name }}
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </form>
     </div>
     <div class="actions">

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
@@ -24,24 +24,11 @@
                     can-add-saved-location="!!ctl.rootScope.$server"
                     on-add-saved-location="ctl.openSavedLocationModal()"></torrent-upload-form>
             </div>
-            <div ng-if="ctl.hasFilesTab()" ng-show="ctl.activeTab === 'files'">
-                <div class="ui relaxed divided list upload-files-list upload-files-scroll">
-                    <div class="item upload-file-row" ng-repeat="node in ctl.visibleFileTree track by node.id" ng-style="{'padding-left': (node.level * 1.5) + 'rem'}" data-upload-file-path="{{ node.path }}">
-                        <div class="right floated content upload-file-meta">
-                            <span class="upload-file-size">{{ node.size | bytes }}</span>
-                        </div>
-                        <div class="content">
-                            <div class="ui checkbox">
-                                <input id="upload-file-cb-{{ node.id }}" type="checkbox" ng-checked="node.selected" ng-click="ctl.toggleFileNode(node)">
-                                <label for="upload-file-cb-{{ node.id }}">
-                                    <i class="icon" ng-class="node.children.length ? 'folder' : 'file outline'"></i>
-                                    {{ node.name }}
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <torrent-upload-file-selection
+                ng-if="ctl.hasFilesTab()"
+                ng-show="ctl.activeTab === 'files'"
+                files="ctl.getCurrentTorrentUploadFiles()"
+                on-selection-change="ctl.updateFileSelection(selection)"></torrent-upload-file-selection>
         </form>
     </div>
     <div class="actions">

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -93,14 +93,22 @@
                 rz-col="column.id"
                 sort="column.id"
               >
-                {{ column.label }}
+                <span class="torrent-details-files-header-label">{{ column.label }}</span>
               </th>
             </tr>
           </thead>
           <tbody>
             <tr ng-repeat="file in ctl.scope.sortedFiles track by file.index" data-file-index="{{ file.index }}">
               <td ng-repeat="column in ctl.scope.panel.files.columns track by column.id" data-col="{{ column.id }}">
-                <div ng-switch="column.format">
+                <div ng-if="column.id === 'wanted'" class="torrent-details-file-cell">
+                  <i
+                    ng-if="file.wanted"
+                    class="tiny check icon"
+                    data-role="torrent-details-file-wanted-check"
+                    aria-label="Wanted"
+                  ></i>
+                </div>
+                <div ng-if="column.id !== 'wanted'" ng-switch="column.format" class="torrent-details-file-cell">
                   <div ng-switch-when="progress" class="torrent-details-file-progress">
                     <div class="ui tiny indicating progress">
                       <div class="bar" ng-style="{ width: ctl.fileProgressPercent(file) + '%' }"></div>

--- a/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.controller.ts
+++ b/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.controller.ts
@@ -51,7 +51,8 @@ export class TorrentSpeedModalController {
       return null;
     }
 
-    return Math.floor(Number(firstLimit) / 1024);
+    const numericLimit = Number(firstLimit);
+    return Number.isFinite(numericLimit) && numericLimit > 0 ? Math.floor(numericLimit / 1024) : null;
   }
 
   open(torrents: any[]) {

--- a/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.template.html
+++ b/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.template.html
@@ -19,7 +19,7 @@
                     type="number"
                     min="0"
                     placeholder="Leave unchanged"
-                    ng-model="ctl.scope.downloadSpeedLimit">
+                    ng-model="downloadSpeedLimit">
             </div>
             <div class="field">
                 <label for="torrent-speed-limit-upload">Upload limit (KB/s)</label>
@@ -29,7 +29,7 @@
                     type="number"
                     min="0"
                     placeholder="Leave unchanged"
-                    ng-model="ctl.scope.uploadSpeedLimit">
+                    ng-model="uploadSpeedLimit">
             </div>
             <div class="ui negative message" ng-if="ctl.scope.error">
                 <p>{{ ctl.scope.error }}</p>

--- a/src/renderer/app/directives/torrent-upload-file-selection/torrent-upload-file-selection.controller.ts
+++ b/src/renderer/app/directives/torrent-upload-file-selection/torrent-upload-file-selection.controller.ts
@@ -1,0 +1,136 @@
+import type { BittorrentFileSelection, TorrentMetadataFile } from "@shared/ipc-contract";
+import type { TorrentUploadFileSelectionScope } from "./torrent-upload-file-selection.directive";
+
+interface UploadFileTreeNode {
+    id: string
+    name: string
+    path: string
+    size: number
+    level: number
+    fileIndex?: number
+    children: UploadFileTreeNode[]
+    selected: boolean
+    partial: boolean
+}
+
+export class TorrentUploadFileSelectionController {
+    static $inject = ["$scope"]
+
+    visibleFileTree: UploadFileTreeNode[] = []
+    private fileTree: UploadFileTreeNode[] = []
+
+    constructor(private readonly scope: TorrentUploadFileSelectionScope) {
+        scope.$watch(() => scope.files, () => this.refreshFiles())
+    }
+
+    toggleFileNode(node: UploadFileTreeNode) {
+        this.setNodeSelection(node, node.partial ? true : !node.selected)
+        this.emitSelection()
+    }
+
+    private refreshFiles() {
+        if (!this.scope.files?.length) {
+            this.fileTree = []
+            this.visibleFileTree = []
+            this.scope.onSelectionChange({ selection: undefined })
+            return
+        }
+
+        this.fileTree = this.buildFileTree(this.scope.files)
+        this.visibleFileTree = this.flattenFileTree(this.fileTree)
+        this.emitSelection()
+    }
+
+    private buildFileTree(files: TorrentMetadataFile[]) {
+        const roots: UploadFileTreeNode[] = []
+        const folders = new Map<string, UploadFileTreeNode>()
+
+        files.forEach((file, index) => {
+            const normalizedPath = file.path || file.name || `file-${index + 1}`
+            const parts = normalizedPath.split(/[\\/]+/).filter(Boolean)
+            let siblings = roots
+            let folderPath = ""
+
+            parts.forEach((part, partIndex) => {
+                const isFile = partIndex === parts.length - 1
+                folderPath = folderPath ? `${folderPath}/${part}` : part
+                if (isFile) {
+                    siblings.push({
+                        id: `file-${index}`,
+                        name: part,
+                        path: normalizedPath,
+                        size: file.length || 0,
+                        level: partIndex,
+                        fileIndex: index,
+                        children: [],
+                        selected: true,
+                        partial: false,
+                    })
+                    return
+                }
+
+                let folder = folders.get(folderPath)
+                if (!folder) {
+                    folder = {
+                        id: `folder-${encodeURIComponent(folderPath)}`,
+                        name: part,
+                        path: folderPath,
+                        size: 0,
+                        level: partIndex,
+                        children: [],
+                        selected: true,
+                        partial: false,
+                    }
+                    folders.set(folderPath, folder)
+                    siblings.push(folder)
+                }
+                siblings = folder.children
+            })
+        })
+
+        this.refreshFolderState(roots)
+        return roots
+    }
+
+    private flattenFileTree(nodes: UploadFileTreeNode[]): UploadFileTreeNode[] {
+        return nodes.flatMap((node) => [node, ...this.flattenFileTree(node.children)])
+    }
+
+    private setNodeSelection(node: UploadFileTreeNode, selected: boolean) {
+        node.selected = selected
+        node.partial = false
+        node.children.forEach((child) => this.setNodeSelection(child, selected))
+        this.refreshFolderState(this.fileTree)
+    }
+
+    private refreshFolderState(nodes: UploadFileTreeNode[]) {
+        nodes.forEach((node) => {
+            if (node.children.length === 0) {
+                return
+            }
+
+            this.refreshFolderState(node.children)
+            node.size = node.children.reduce((size, child) => size + child.size, 0)
+            const selectedCount = node.children.filter((child) => child.selected && !child.partial).length
+            const partialCount = node.children.filter((child) => child.partial).length
+            node.selected = selectedCount === node.children.length && partialCount === 0
+            node.partial = (selectedCount > 0 || partialCount > 0) && !node.selected
+        })
+    }
+
+    private emitSelection() {
+        const selection = this.visibleFileTree
+            .filter((node) => node.fileIndex !== undefined)
+            .map((node): BittorrentFileSelection => ({
+                index: node.fileIndex!,
+                path: node.path,
+                name: node.name,
+                size: node.size,
+                wanted: node.selected,
+            }))
+
+        this.scope.onSelectionChange({
+            selection: selection.every((file) => file.wanted) ? undefined : selection,
+        })
+    }
+}

--- a/src/renderer/app/directives/torrent-upload-file-selection/torrent-upload-file-selection.directive.ts
+++ b/src/renderer/app/directives/torrent-upload-file-selection/torrent-upload-file-selection.directive.ts
@@ -1,0 +1,24 @@
+import { IDirective, IDirectiveFactory, IScope } from "angular";
+import type { BittorrentFileSelection, TorrentMetadataFile } from "@shared/ipc-contract";
+import { TorrentUploadFileSelectionController } from "./torrent-upload-file-selection.controller";
+import html from "./torrent-upload-file-selection.template.html";
+
+export interface TorrentUploadFileSelectionScope extends IScope {
+    files?: TorrentMetadataFile[]
+    onSelectionChange: (locals: { selection?: BittorrentFileSelection[] }) => void
+}
+
+export class TorrentUploadFileSelectionDirective implements IDirective {
+    template = html
+    restrict = "E"
+    scope = {
+        files: "<",
+        onSelectionChange: "&",
+    }
+    controller = TorrentUploadFileSelectionController
+    controllerAs = "ctl"
+
+    static getInstance(): IDirectiveFactory {
+        return () => new TorrentUploadFileSelectionDirective()
+    }
+}

--- a/src/renderer/app/directives/torrent-upload-file-selection/torrent-upload-file-selection.template.html
+++ b/src/renderer/app/directives/torrent-upload-file-selection/torrent-upload-file-selection.template.html
@@ -1,0 +1,16 @@
+<div class="ui relaxed divided list upload-files-list upload-files-scroll">
+    <div class="item upload-file-row" ng-repeat="node in ctl.visibleFileTree track by node.id" ng-style="{'padding-left': (node.level * 1.5) + 'rem'}" data-upload-file-path="{{ node.path }}">
+        <div class="right floated content upload-file-meta">
+            <span class="upload-file-size">{{ node.size | bytes }}</span>
+        </div>
+        <div class="content">
+            <div class="ui checkbox">
+                <input id="upload-file-cb-{{ node.id }}" type="checkbox" ng-checked="node.selected" indeterminate-value="node.partial" ng-click="ctl.toggleFileNode(node)">
+                <label for="upload-file-cb-{{ node.id }}">
+                    <i class="icon" ng-class="node.children.length ? 'folder' : 'file outline'"></i>
+                    {{ node.name }}
+                </label>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -7,6 +7,44 @@ html, body {
     flex: 1 1 0;
     min-width: 0;
 }
+.upload-files-scroll {
+    max-height: 50vh;
+    overflow: auto;
+}
+.upload-torrent-heading {
+    display: flex;
+    gap: 1em;
+    align-items: baseline;
+}
+.upload-torrent-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.upload-torrent-size {
+    flex-shrink: 0;
+    margin-left: auto;
+    color: @lightTextColor;
+    font-weight: normal;
+}
+.upload-file-meta {
+    display: flex;
+    gap: 0.75em;
+    align-items: center;
+}
+.upload-file-size {
+    color: @lightTextColor;
+}
+.upload-file-row .content {
+    min-width: 0;
+}
+.upload-file-row label {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .title-bar {
     position: absolute;
     top: 0;
@@ -648,7 +686,7 @@ torrent-sidebar + .main-panel {
             gap: 1rem;
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
             padding: 0.75rem 1rem;
-            overflow-y: auto;
+            overflow-y: hidden;
         }
 
         .torrent-details-section {
@@ -680,13 +718,35 @@ torrent-sidebar + .main-panel {
         }
 
         .torrent-details-files-content {
+            flex: 1 1 auto;
+            min-height: 0;
             overflow-x: auto;
             overflow-y: auto;
+        }
+
+        .torrent-details-files {
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
         }
 
         .torrent-details-files.table,
         .torrent-details-files-content .torrent.table {
             margin: 0;
+        }
+
+        .torrent-details-files-content .torrent.table td,
+        .torrent-details-files-header-label,
+        .torrent-details-file-cell,
+        .torrent-details-file-cell > span {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .torrent-details-files-header-label,
+        .torrent-details-file-cell > span {
+            display: block;
         }
 
         .torrent-details-file-progress {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -177,6 +177,7 @@ export interface TorrentUploadOptions {
     firstAndLastPiecePrio?: boolean
     downloadSpeedLimit?: number
     uploadSpeedLimit?: number
+    fileSelection?: BittorrentFileSelection[]
 }
 
 export interface TorrentSpeedLimitOptions {
@@ -190,6 +191,7 @@ export interface TorrentClientFeatures {
     readonly magnetLinks?: boolean
     readonly labels?: boolean
     readonly fileSelection?: boolean
+    readonly uploadFileSelection?: boolean
     readonly setLocation?: boolean
     readonly torrentDetails?: boolean
     readonly trackerFilter?: boolean
@@ -230,6 +232,7 @@ export interface ResolvedTorrentClientFeatures {
     readonly magnetLinks: boolean
     readonly labels: boolean
     readonly fileSelection: boolean
+    readonly uploadFileSelection: boolean
     readonly setLocation: boolean
     readonly torrentDetails: boolean
     readonly trackerFilter: boolean

--- a/test/clients/deluge/index.ts
+++ b/test/clients/deluge/index.ts
@@ -4,6 +4,7 @@ import { defineClient } from "../define"
 
 const baseFeatures = {
   labels: true,
+  uploadFileSelection: true,
   torrentDetails: true,
   speedLimits: true,
   ratioLimits: true,

--- a/test/clients/mock/index.ts
+++ b/test/clients/mock/index.ts
@@ -5,6 +5,7 @@ const features = {
   magnetLinks: true,
   labels: true,
   fileSelection: true,
+  uploadFileSelection: true,
   setLocation: true,
   torrentDetails: true,
   freeDiskSpace: true,

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -6,6 +6,7 @@ const features = {
   magnetLinks: true,
   labels: true,
   fileSelection: true,
+  uploadFileSelection: true,
   setLocation: true,
   torrentDetails: true,
   trackerFilter: true,

--- a/test/clients/rtorrent/index.ts
+++ b/test/clients/rtorrent/index.ts
@@ -5,6 +5,7 @@ import { defineClient } from "../define"
 const features = {
   magnetLinks: true,
   labels: true,
+  uploadFileSelection: true,
   torrentDetails: true,
   trackerFilter: true,
   speedLimits: true,

--- a/test/clients/transmission/index.ts
+++ b/test/clients/transmission/index.ts
@@ -5,6 +5,7 @@ import { defineClient } from "../define"
 const features = {
   magnetLinks: true,
   labels: true,
+  uploadFileSelection: true,
   setLocation: true,
   torrentDetails: true,
   trackerFilter: true,

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -245,6 +245,7 @@ export class App {
     firstAndLastPiecePrio?: boolean
     downloadSpeedLimit?: number
     uploadSpeedLimit?: number
+    disabledFileIndexes?: number[]
   }) {
     const modal = await this.uploadTorrentModalVisible()
     await browser.pause(200)
@@ -300,6 +301,19 @@ export class App {
       const labelItemElem = labelElem.$(`div[data-label='${options.label}']`)
       await labelItemElem.waitForDisplayed()
       await labelItemElem.click()
+    }
+
+    for (const fileIndex of options?.disabledFileIndexes || []) {
+      const filesTab = modal.$("a=Files")
+      await filesTab.waitForDisplayed()
+      await filesTab.click()
+      const fileCheckbox = modal.$(`#upload-file-cb-file-${fileIndex}`)
+      await fileCheckbox.waitForExist({ timeout: 10_000 })
+      await fileCheckbox.scrollIntoView()
+      if (await fileCheckbox.isSelected()) {
+        await fileCheckbox.click()
+        await eventually(() => fileCheckbox.isSelected()).equals(false, { timeout: 5_000 })
+      }
     }
 
     await browser.pause(250)

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -373,7 +373,9 @@ export class App {
 
   async uploadTorrentModalLabel() {
     const modal = await this.uploadTorrentModalVisible()
-    return modal.$(".content .sub.header").getText()
+    const label = modal.$(".upload-torrent-name")
+    await label.waitForDisplayed()
+    return label.getText()
   }
 
   async uploadTorrentModalPendingCountLabel() {

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -193,9 +193,13 @@ export class Torrent {
     const panel = $("[data-role='torrent-details-panel']")
     await panel.waitForDisplayed({ timeout: this.timeout })
 
-    const field = panel.$(`[data-role='torrent-details-field'][data-field-id='${fieldId}'] .value`)
+    const field = $(`[data-role='torrent-details-field'][data-field-id='${fieldId}'] .value`)
     await field.waitForDisplayed({ timeout: this.timeout })
-    return await field.getText()
+    const text = await field.getText()
+    if (text) {
+      return text
+    }
+    return (await field.getHTML()).replace(/<[^>]*>/g, "").trim()
   }
 
   async setLocation(location: string) {
@@ -221,20 +225,38 @@ export class Torrent {
     if (downloadSpeedLimit !== undefined) {
       const input = modal.$("input[data-role='torrent-speed-limit-download']");
       await input.waitForDisplayed();
+      await input.click();
       await input.clearValue();
       await input.setValue(String(downloadSpeedLimit));
+      await eventually(() => input.getValue()).equals(String(downloadSpeedLimit));
     }
     if (uploadSpeedLimit !== undefined) {
       const input = modal.$("input[data-role='torrent-speed-limit-upload']");
       await input.waitForDisplayed();
+      await input.click();
       await input.clearValue();
       await input.setValue(String(uploadSpeedLimit));
+      await eventually(() => input.getValue()).equals(String(uploadSpeedLimit));
     }
 
     const approve = modal.$("button[data-role='torrent-speed-limit-apply']");
     await approve.waitForEnabled();
     await approve.click();
     await waitForModalClose(modal, this.timeout);
+
+    await eventually(() => this.getSpeedLimitModalValues()).satisfies(
+      "reflect the requested speed limits",
+      (values) => {
+        if (downloadSpeedLimit !== undefined && values.download !== String(downloadSpeedLimit)) {
+          return false
+        }
+        if (uploadSpeedLimit !== undefined && values.upload !== String(uploadSpeedLimit)) {
+          return false
+        }
+        return true
+      },
+      { timeout: 20 * 1000 },
+    )
   }
 
   async getSpeedLimitModalValues() {

--- a/test/shared/multifile.torrent
+++ b/test/shared/multifile.torrent
@@ -1,0 +1,1 @@
+d8:announce28:http://tracker:6969/announce4:infod5:filesld6:lengthi1e4:pathl10:file-1.bineed6:lengthi1e4:pathl10:file-2.bineee4:name11:multi-files12:piece lengthi16384e6:pieces20:aaaaaaaaaaaaaaaaaaaaee

--- a/test/shared/multifile.torrent
+++ b/test/shared/multifile.torrent
@@ -1,1 +1,0 @@
-d8:announce28:http://tracker:6969/announce4:infod5:filesld6:lengthi1e4:pathl10:file-1.bineed6:lengthi1e4:pathl10:file-2.bineee4:name11:multi-files12:piece lengthi16384e6:pieces20:aaaaaaaaaaaaaaaaaaaaee

--- a/test/specs/standard/upload-file-selection.spec.ts
+++ b/test/specs/standard/upload-file-selection.spec.ts
@@ -1,0 +1,47 @@
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { $ } from "@wdio/globals"
+import * as e2e from "../../e2e"
+import { eventually } from "../../e2e/eventually"
+import { configureSpec, requireFeature } from "../../framework/fixture"
+
+const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+
+describe("upload file selection", function () {
+  configureSpec()
+  requireFeature(({ features }) => features.uploadFileSelection === true && features.torrentDetails === true)
+
+  let torrent: e2e.Torrent | undefined
+
+  afterEach(async function () {
+    if (torrent && await torrent.isExisting()) {
+      await torrent.delete()
+    }
+    torrent = undefined
+  })
+
+  it("adds a torrent with one file disabled from advanced upload options", async function () {
+    this.timeout(60 * 1000)
+
+    const torrentPath = path.join(testDir, "shared/multifile.torrent")
+
+    torrent = await this.app.uploadTorrent({ filename: torrentPath, askUploadOptions: true })
+    await this.app.uploadTorrentModalSubmit({ disabledFileIndexes: [0] })
+    await torrent.waitForExist({ timeout: 20 * 1000 })
+
+    await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("files")
+
+    const firstFileWanted = $("[data-role='torrent-details-files-table'] tbody tr[data-file-index='0'] td[data-col='wanted']")
+    await firstFileWanted.waitForDisplayed({ timeout: 30 * 1000 })
+    await eventually(() => firstFileWanted.getText()).equals("", { timeout: 30 * 1000 })
+    const firstFileWantedIconExists = await firstFileWanted.$("[data-role='torrent-details-file-wanted-check']").isExisting()
+    firstFileWantedIconExists.should.equal(false)
+
+    const secondFileWanted = $("[data-role='torrent-details-files-table'] tbody tr[data-file-index='1'] td[data-col='wanted']")
+    await secondFileWanted.waitForDisplayed({ timeout: 30 * 1000 })
+    await secondFileWanted.$("[data-role='torrent-details-file-wanted-check']").waitForDisplayed({ timeout: 30 * 1000 })
+
+    await torrent.closeDetailsPanel()
+  })
+})

--- a/test/specs/standard/upload-file-selection.spec.ts
+++ b/test/specs/standard/upload-file-selection.spec.ts
@@ -1,11 +1,10 @@
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import { $ } from "@wdio/globals"
 import * as e2e from "../../e2e"
 import { eventually } from "../../e2e/eventually"
-import { configureSpec, requireFeature } from "../../framework/fixture"
+import { configureSpec, createUniqueLabel, getTestFixture, requireFeature } from "../../framework/fixture"
+import { createTorrentFile } from "../../torrent"
 
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const tracker = getTestFixture().tracker
 
 describe("upload file selection", function () {
   configureSpec()
@@ -23,7 +22,17 @@ describe("upload file selection", function () {
   it("adds a torrent with one file disabled from advanced upload options", async function () {
     this.timeout(60 * 1000)
 
-    const torrentPath = path.join(testDir, "shared/multifile.torrent")
+    const torrentPath = await createTorrentFile(tracker, {
+      torrentName: createUniqueLabel("upload-file-selection"),
+      files: {
+        "documents/notes.txt": 1,
+        "documents/report.pdf": 2,
+        "media/audio/theme.mp3": 3,
+        "media/images/cover.jpg": 4,
+        "media/images/thumbnail.png": 5,
+        "README.md": 1,
+      },
+    })
 
     torrent = await this.app.uploadTorrent({ filename: torrentPath, askUploadOptions: true })
     await this.app.uploadTorrentModalSubmit({ disabledFileIndexes: [0] })


### PR DESCRIPTION
## Summary
- add uploadFileSelection client feature flag for add-time file selection support
- keep General/Files navigation and form visibility in the add-torrent modal
- isolate file-tree state and checkbox UI in a standalone directive with `files` and `on-selection-change` bindings
- map selected upload files into Transmission, Deluge, rTorrent, and Mock add flows while leaving unsupported clients hidden
- generate a six-file torrent during the e2e spec instead of committing a static torrent fixture
- add e2e coverage for disabling one file during advanced upload

## Research scope
- In scope: Transmission, Deluge, rTorrent, qBittorrent, Mock
- Out of scope for this implementation: µTorrent, Synology

## Verification
- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/upload-file-selection.spec.ts"`