### PR TITLE
test: verify remove and delete removes files

### DIFF
--- a/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
+++ b/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
@@ -168,7 +168,6 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
       label: "Remove",
       click: this.remove,
       icon: "remove",
-      role: "delete",
     },
     {
       label: "Remove And",
@@ -184,6 +183,7 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
         {
           label: "Delete All",
           click: this.removedatatorrent,
+          role: "delete",
         },
       ],
     },

--- a/test/clients/deluge/index.ts
+++ b/test/clients/deluge/index.ts
@@ -31,6 +31,7 @@ export default {
     username: "admin",
     password: "deluge",
     stopLabel: "Paused",
+    downloadRoot: "/downloads",
   }),
   "deluge:2": defineClient({
     key: "deluge:2",
@@ -46,5 +47,6 @@ export default {
     username: "admin",
     password: "deluge",
     stopLabel: "Paused",
+    downloadRoot: "/downloads",
   }),
 } satisfies Record<string, TestClient>

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -37,6 +37,7 @@ export default {
     containerPort: 8080,
     username: "admin",
     password: "adminadmin",
+    downloadRoot: "/downloads",
   }),
   "qbittorrent:5": defineClient({
     key: "qbittorrent:5",
@@ -48,6 +49,7 @@ export default {
     containerPort: 8080,
     username: "admin",
     password: "adminadmin",
+    downloadRoot: "/downloads",
   }),
   "qbittorrent:latest": defineClient({
     key: "qbittorrent:latest",
@@ -59,5 +61,6 @@ export default {
     containerPort: 8080,
     username: "admin",
     password: "adminadmin",
+    downloadRoot: "/downloads",
   }),
 } satisfies Record<string, TestClient>

--- a/test/clients/rtorrent/index.ts
+++ b/test/clients/rtorrent/index.ts
@@ -28,6 +28,7 @@ export default {
     authProxyHostPort: 48081,
     username: "admin",
     password: "admin",
+    downloadRoot: "/downloads",
     saveLocation: "/downloads/custom/save/location",
   }),
   "rtorrent:latest": defineClient({
@@ -43,6 +44,7 @@ export default {
     authProxyHostPort: 48083,
     username: "admin",
     password: "admin",
+    downloadRoot: "/downloads",
     saveLocation: "/downloads/custom/save/location",
   }),
 } satisfies Record<string, TestClient>

--- a/test/clients/transmission/index.ts
+++ b/test/clients/transmission/index.ts
@@ -34,5 +34,6 @@ export default {
     username: "username",
     password: "password",
     acceptHttpStatus: 401,
+    downloadRoot: "/downloads",
   }),
 } satisfies Record<string, TestClient>

--- a/test/clients/types.ts
+++ b/test/clients/types.ts
@@ -18,9 +18,10 @@ export interface TestClient {
   acceptHttpStatus: number
   stopLabel: string
   downloadLabel: string
+  downloadRoot?: string
   saveLocation?: string
   specs?: string[]
 }
 
-export type TestClientInput = Omit<TestClient, "host" | "acceptHttpStatus" | "stopLabel" | "downloadLabel">
-  & Partial<Pick<TestClient, "host" | "acceptHttpStatus" | "stopLabel" | "downloadLabel">>
+export type TestClientInput = Omit<TestClient, "host" | "acceptHttpStatus" | "stopLabel" | "downloadLabel" | "downloadRoot">
+  & Partial<Pick<TestClient, "host" | "acceptHttpStatus" | "stopLabel" | "downloadLabel" | "downloadRoot">>

--- a/test/clients/utorrent/index.ts
+++ b/test/clients/utorrent/index.ts
@@ -24,6 +24,7 @@ export default {
     username: "admin",
     password: "",
     acceptHttpStatus: 400,
+    downloadRoot: "/data",
     saveLocation: "/utorrent/custom/save/location",
   }),
 } satisfies Record<string, TestClient>

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -15,6 +15,14 @@ const client = fixture.client
 const backend = fixture.backend
 const tracker = fixture.tracker
 
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+function findDownloadedContentCommand(downloadRoot: string, contentName: string) {
+  return `find ${shellQuote(downloadRoot)} -maxdepth 5 -type f -name ${shellQuote(contentName)} -print -quit`
+}
+
 describe("torrent actions", function () {
   configureSpec()
 
@@ -80,6 +88,45 @@ describe("torrent actions", function () {
     await torrent.resume({ waitForState: false })
     await torrent.waitForDownloading({ timeout: 20 * 1000 })
     await torrent.checkInState(["all", "downloading"])
+  })
+
+  it("remove and delete removes downloaded content from disk", async function () {
+    this.timeout(300 * 1000)
+    if (!backend || !client.downloadRoot) {
+      return this.skip()
+    }
+
+    const torrentName = createUniqueLabel("delete-files")
+    const torrentPath = await createTorrentFile(tracker, { fileSize: 1, torrentName })
+    const torrentInfo = parseTorrent(fs.readFileSync(torrentPath))
+    const contentName = String(torrentInfo.name || torrentName)
+    const findContentCommand = findDownloadedContentCommand(client.downloadRoot, contentName)
+    const contentExistsCommand = `${findContentCommand} | grep -q .`
+    const contentMissingCommand = `[ -z "$(${findContentCommand})" ]`
+    const torrentToDelete = await this.app.uploadTorrent({ filename: torrentPath })
+
+    try {
+      await torrentToDelete.waitForExist({ timeout: 20 * 1000 })
+      await torrentToDelete.waitForStates(["Seeding", "Finished"], { timeout: 120 * 1000 })
+      await backend.waitForExec(["sh", "-lc", contentExistsCommand], 20 * 1000)
+      await $("#page-torrents li[data-state=all]").click()
+      await torrentToDelete.waitForExist()
+
+      const modal = await torrentToDelete.openDeleteConfirmation()
+      const approveButton = modal.$("button.approve")
+      await approveButton.waitForDisplayed()
+      await approveButton.waitForClickable()
+      await approveButton.click()
+      await waitForModalClose(modal)
+      await torrentToDelete.waitForGone()
+
+      await backend.waitForExec(["sh", "-lc", contentMissingCommand], 60 * 1000)
+    } finally {
+      if (await torrentToDelete.isExisting()) {
+        await $("#page-torrents li[data-state=all]").click()
+        await torrentToDelete.delete()
+      }
+    }
   })
 
   it("moves downloaded content via Set Location", async function () {


### PR DESCRIPTION
## Summary
- add per-client download roots for backend disk assertions
- cover Remove and Delete by verifying downloaded content exists, then disappears from disk
- make rTorrent remove-and-delete explicitly delete the resolved data path before erasing the torrent

## Verification
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-actions.spec.ts"
- npm run test -- --client "rtorrent" --spec "test/specs/standard/torrent-actions.spec.ts"