### PR TITLE
fix: delete rtorrent data directly

### DIFF
--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -1,3 +1,4 @@
+import path from "node:path"
 import { URL } from "node:url"
 import xmlrpc from "@electorrent/xmlrpc"
 
@@ -14,7 +15,6 @@ type RtorrentMethodCall = {
 type RtorrentDeleteMetadata = {
     basePath: string
     isMultiFile: boolean
-    filePaths: string[]
 }
 
 type RtorrentMulticallCommand = string | [string, ...any[]]
@@ -87,40 +87,23 @@ export class RtorrentRuntime implements BittorrentRuntime {
         }
     }
 
-    private parseFrozenPaths(rows: any): string[] {
-        let unwrappedRows = rows
-
-        while (Array.isArray(unwrappedRows) && unwrappedRows.length === 1 && Array.isArray(unwrappedRows[0]) && Array.isArray(unwrappedRows[0][0])) {
-            unwrappedRows = unwrappedRows[0]
-        }
-
-        const fileRows = Array.isArray(unwrappedRows) ? unwrappedRows : []
-
-        return fileRows
-            .map((row) => this.unwrapMulticallResult(row))
-            .filter((filePath): filePath is string => typeof filePath === "string" && filePath.length > 0)
-    }
-
-    private async getDeleteMetadata(hash: string): Promise<RtorrentDeleteMetadata | null> {
+    private async getDeleteMetadata(hash: string): Promise<RtorrentDeleteMetadata> {
         const metadataCalls: RtorrentMethodCall[] = [
             { methodName: "d.base_path", params: [hash] },
             { methodName: "d.is_multi_file", params: [hash] },
-            { methodName: "f.multicall", params: [hash, "", "f.frozen_path="] },
         ]
         const result = await this.call<any[]>("system.multicall", [metadataCalls])
         this.assertMulticallSuccess(result, `Failed to read rTorrent delete metadata for ${hash}`)
         const basePath = this.unwrapScalarMulticallResult(result[0])
         const isMultiFile = Number(this.unwrapScalarMulticallResult(result[1])) > 0
-        const filePaths = this.parseFrozenPaths(result[2])
 
-        if (typeof basePath !== "string" || !basePath || filePaths.length === 0) {
-            return null
+        if (typeof basePath !== "string" || !basePath || !path.posix.isAbsolute(basePath)) {
+            throw new Error(`Invalid rTorrent base path for ${hash}`)
         }
 
         return {
             basePath,
             isMultiFile,
-            filePaths,
         }
     }
 
@@ -133,20 +116,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         ]])
         this.assertMulticallSuccess(eraseResult, `Failed to erase rTorrent torrent ${hash}`)
 
-        if (!metadata) {
-            return
-        }
-
-        const fileDeleteCalls: RtorrentMethodCall[] = metadata.filePaths.map((filePath) => ({
-            methodName: "execute.throw",
-            params: ["", "rm", "-f", "--", filePath],
-        }))
-        const fileDeleteResult = await this.call<any[]>("system.multicall", [fileDeleteCalls])
-        this.assertMulticallSuccess(fileDeleteResult, `Failed to delete rTorrent payload data for ${hash}`)
-
-        if (metadata.isMultiFile) {
-            await this.call("execute.throw", ["", "find", metadata.basePath, "-depth", "-type", "d", "-exec", "rmdir", "{}", ";"])
-        }
+        await this.call("execute.throw", ["", "rm", metadata.isMultiFile ? "-rf" : "-f", "--", metadata.basePath])
     }
 
     private async getTorrentFields(hash: string, commands: Record<string, RtorrentMulticallCommand>): Promise<Record<string, any>> {

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -87,7 +87,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         }
     }
 
-    private async getDeleteMetadata(hash: string): Promise<RtorrentDeleteMetadata> {
+    private async getDeleteMetadata(hash: string): Promise<RtorrentDeleteMetadata | null> {
         const metadataCalls: RtorrentMethodCall[] = [
             { methodName: "d.base_path", params: [hash] },
             { methodName: "d.is_multi_file", params: [hash] },
@@ -98,7 +98,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         const isMultiFile = Number(this.unwrapScalarMulticallResult(result[1])) > 0
 
         if (typeof basePath !== "string" || !basePath || !path.posix.isAbsolute(basePath)) {
-            throw new Error(`Invalid rTorrent base path for ${hash}`)
+            return null
         }
 
         return {
@@ -115,6 +115,10 @@ export class RtorrentRuntime implements BittorrentRuntime {
             { methodName: "d.erase", params: [hash] },
         ]])
         this.assertMulticallSuccess(eraseResult, `Failed to erase rTorrent torrent ${hash}`)
+
+        if (!metadata) {
+            return
+        }
 
         await this.call("execute.throw", ["", "rm", metadata.isMultiFile ? "-rf" : "-f", "--", metadata.basePath])
     }

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -87,39 +87,6 @@ export class RtorrentRuntime implements BittorrentRuntime {
         }
     }
 
-    private parentDirectory(remotePath: string): string | null {
-        const trimmed = remotePath.replace(/\/+$/g, "")
-        const separatorIndex = trimmed.lastIndexOf("/")
-
-        if (separatorIndex <= 0) {
-            return null
-        }
-
-        return trimmed.slice(0, separatorIndex)
-    }
-
-    private isPathInsideDirectory(remotePath: string, directory: string): boolean {
-        const normalizedDirectory = directory.replace(/\/+$/g, "")
-
-        return Boolean(normalizedDirectory) && remotePath.startsWith(`${normalizedDirectory}/`)
-    }
-
-    private getDeleteDirectories(basePath: string, filePaths: string[]): string[] {
-        const directories = new Set<string>()
-        const normalizedBasePath = basePath.replace(/\/+$/g, "")
-
-        for (const filePath of filePaths) {
-            let directory = this.parentDirectory(filePath)
-
-            while (directory && this.isPathInsideDirectory(directory, normalizedBasePath)) {
-                directories.add(directory)
-                directory = this.parentDirectory(directory)
-            }
-        }
-
-        return [...directories].sort((a, b) => b.length - a.length)
-    }
-
     private parseFrozenPaths(rows: any): string[] {
         let unwrappedRows = rows
 
@@ -178,11 +145,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         this.assertMulticallSuccess(fileDeleteResult, `Failed to delete rTorrent payload data for ${hash}`)
 
         if (metadata.isMultiFile) {
-            const directories = this.getDeleteDirectories(metadata.basePath, metadata.filePaths)
-
-            for (const directory of [...directories, metadata.basePath]) {
-                await this.call("execute.throw", ["", "rmdir", "--", directory])
-            }
+            await this.call("execute.throw", ["", "find", metadata.basePath, "-depth", "-type", "d", "-exec", "rmdir", "{}", ";"])
         }
     }
 

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -134,7 +134,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
             .filter((filePath): filePath is string => typeof filePath === "string" && filePath.length > 0)
     }
 
-    private async getDeleteMetadata(hash: string): Promise<RtorrentDeleteMetadata> {
+    private async getDeleteMetadata(hash: string): Promise<RtorrentDeleteMetadata | null> {
         const metadataCalls: RtorrentMethodCall[] = [
             { methodName: "d.base_path", params: [hash] },
             { methodName: "d.is_multi_file", params: [hash] },
@@ -147,7 +147,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         const filePaths = this.parseFrozenPaths(result[2])
 
         if (typeof basePath !== "string" || !basePath || filePaths.length === 0) {
-            throw new Error(`rTorrent did not return delete metadata for ${hash}`)
+            return null
         }
 
         return {
@@ -165,6 +165,10 @@ export class RtorrentRuntime implements BittorrentRuntime {
             { methodName: "d.erase", params: [hash] },
         ]])
         this.assertMulticallSuccess(eraseResult, `Failed to erase rTorrent torrent ${hash}`)
+
+        if (!metadata) {
+            return
+        }
 
         const fsCalls: RtorrentMethodCall[] = metadata.filePaths.map((filePath) => ({
             methodName: "execute.throw",

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -170,26 +170,20 @@ export class RtorrentRuntime implements BittorrentRuntime {
             return
         }
 
-        const fsCalls: RtorrentMethodCall[] = metadata.filePaths.map((filePath) => ({
+        const fileDeleteCalls: RtorrentMethodCall[] = metadata.filePaths.map((filePath) => ({
             methodName: "execute.throw",
             params: ["", "rm", "-f", "--", filePath],
         }))
+        const fileDeleteResult = await this.call<any[]>("system.multicall", [fileDeleteCalls])
+        this.assertMulticallSuccess(fileDeleteResult, `Failed to delete rTorrent payload data for ${hash}`)
 
         if (metadata.isMultiFile) {
             const directories = this.getDeleteDirectories(metadata.basePath, metadata.filePaths)
 
-            fsCalls.push(...directories.map((directory) => ({
-                methodName: "execute",
-                params: ["", "rmdir", "--", directory],
-            })))
-            fsCalls.push({
-                methodName: "execute",
-                params: ["", "rmdir", "--", metadata.basePath],
-            })
+            for (const directory of [...directories, metadata.basePath]) {
+                await this.call("execute.throw", ["", "rmdir", "--", directory])
+            }
         }
-
-        const fsResult = await this.call<any[]>("system.multicall", [fsCalls])
-        this.assertMulticallSuccess(fsResult, `Failed to delete rTorrent payload data for ${hash}`)
     }
 
     private async getTorrentFields(hash: string, commands: Record<string, RtorrentMulticallCommand>): Promise<Record<string, any>> {

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -11,6 +11,12 @@ type RtorrentMethodCall = {
     params: any[]
 }
 
+type RtorrentDeleteMetadata = {
+    basePath: string
+    isMultiFile: boolean
+    filePaths: string[]
+}
+
 type RtorrentMulticallCommand = string | [string, ...any[]]
 
 export class RtorrentRuntime implements BittorrentRuntime {
@@ -61,6 +67,125 @@ export class RtorrentRuntime implements BittorrentRuntime {
 
     private unwrapMulticallResult<T = any>(result: any): T {
         return (Array.isArray(result) ? result[0] : result) as T
+    }
+
+    private unwrapScalarMulticallResult(result: any): any {
+        let value = result
+
+        while (Array.isArray(value) && value.length === 1) {
+            value = value[0]
+        }
+
+        return value
+    }
+
+    private assertMulticallSuccess(results: any[], context: string): void {
+        const fault = results.find((result) => result && typeof result === "object" && "faultCode" in result)
+
+        if (fault) {
+            throw new Error(`${context}: ${fault.faultString || fault.faultCode}`)
+        }
+    }
+
+    private parentDirectory(remotePath: string): string | null {
+        const trimmed = remotePath.replace(/\/+$/g, "")
+        const separatorIndex = trimmed.lastIndexOf("/")
+
+        if (separatorIndex <= 0) {
+            return null
+        }
+
+        return trimmed.slice(0, separatorIndex)
+    }
+
+    private isPathInsideDirectory(remotePath: string, directory: string): boolean {
+        const normalizedDirectory = directory.replace(/\/+$/g, "")
+
+        return Boolean(normalizedDirectory) && remotePath.startsWith(`${normalizedDirectory}/`)
+    }
+
+    private getDeleteDirectories(basePath: string, filePaths: string[]): string[] {
+        const directories = new Set<string>()
+        const normalizedBasePath = basePath.replace(/\/+$/g, "")
+
+        for (const filePath of filePaths) {
+            let directory = this.parentDirectory(filePath)
+
+            while (directory && this.isPathInsideDirectory(directory, normalizedBasePath)) {
+                directories.add(directory)
+                directory = this.parentDirectory(directory)
+            }
+        }
+
+        return [...directories].sort((a, b) => b.length - a.length)
+    }
+
+    private parseFrozenPaths(rows: any): string[] {
+        let unwrappedRows = rows
+
+        while (Array.isArray(unwrappedRows) && unwrappedRows.length === 1 && Array.isArray(unwrappedRows[0]) && Array.isArray(unwrappedRows[0][0])) {
+            unwrappedRows = unwrappedRows[0]
+        }
+
+        const fileRows = Array.isArray(unwrappedRows) ? unwrappedRows : []
+
+        return fileRows
+            .map((row) => this.unwrapMulticallResult(row))
+            .filter((filePath): filePath is string => typeof filePath === "string" && filePath.length > 0)
+    }
+
+    private async getDeleteMetadata(hash: string): Promise<RtorrentDeleteMetadata> {
+        const metadataCalls: RtorrentMethodCall[] = [
+            { methodName: "d.base_path", params: [hash] },
+            { methodName: "d.is_multi_file", params: [hash] },
+            { methodName: "f.multicall", params: [hash, "", "f.frozen_path="] },
+        ]
+        const result = await this.call<any[]>("system.multicall", [metadataCalls])
+        this.assertMulticallSuccess(result, `Failed to read rTorrent delete metadata for ${hash}`)
+        const basePath = this.unwrapScalarMulticallResult(result[0])
+        const isMultiFile = Number(this.unwrapScalarMulticallResult(result[1])) > 0
+        const filePaths = this.parseFrozenPaths(result[2])
+
+        if (typeof basePath !== "string" || !basePath || filePaths.length === 0) {
+            throw new Error(`rTorrent did not return delete metadata for ${hash}`)
+        }
+
+        return {
+            basePath,
+            isMultiFile,
+            filePaths,
+        }
+    }
+
+    private async deleteAndEraseOne(hash: string): Promise<void> {
+        const metadata = await this.getDeleteMetadata(hash)
+
+        const eraseResult = await this.call<any[]>("system.multicall", [[
+            { methodName: "d.delete_tied", params: [hash] },
+            { methodName: "d.erase", params: [hash] },
+        ]])
+        this.assertMulticallSuccess(eraseResult, `Failed to erase rTorrent torrent ${hash}`)
+
+        const fsCalls: RtorrentMethodCall[] = metadata.filePaths.map((filePath) => ({
+            methodName: "execute.throw",
+            params: ["", "rm", "-f", "--", filePath],
+        }))
+
+        if (metadata.isMultiFile) {
+            const directories = this.getDeleteDirectories(metadata.basePath, metadata.filePaths)
+
+            fsCalls.push(...directories.map((directory) => ({
+                methodName: "execute",
+                params: ["", "rmdir", "--", directory],
+            })))
+            fsCalls.push({
+                methodName: "execute",
+                params: ["", "rmdir", "--", metadata.basePath],
+            })
+        }
+
+        const fsResult = await this.call<any[]>("system.multicall", [fsCalls])
+        this.assertMulticallSuccess(fsResult, `Failed to delete rTorrent payload data for ${hash}`)
     }
 
     private async getTorrentFields(hash: string, commands: Record<string, RtorrentMulticallCommand>): Promise<Record<string, any>> {
@@ -357,8 +482,10 @@ export class RtorrentRuntime implements BittorrentRuntime {
         return this.setTorrentHashes(hashes, ["d.erase"], [])
     }
 
-    deleteAndErase(hashes: string[]): Promise<void> {
-        return this.setTorrentHashes(hashes, ["d.custom5.set", "d.delete_tied", "d.erase"], ["1"])
+    async deleteAndErase(hashes: string[]): Promise<void> {
+        for (const hash of hashes) {
+            await this.deleteAndEraseOne(hash)
+        }
     }
 
     recheck(hashes: string[]): Promise<void> {

--- a/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
+++ b/src/renderer/app/bittorrent/utorrent/utorrentservice.ts
@@ -168,7 +168,6 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
       label: "Remove",
       click: this.remove,
       icon: "remove",
-      role: "delete",
     },
     {
       label: "Remove And",
@@ -184,6 +183,7 @@ export class UtorrentClient extends TorrentClient<UtorrentTorrent> {
         {
           label: "Delete All",
           click: this.removedatatorrent,
+          role: "delete",
         },
       ],
     },

--- a/test/clients/deluge/index.ts
+++ b/test/clients/deluge/index.ts
@@ -31,6 +31,7 @@ export default {
     username: "admin",
     password: "deluge",
     stopLabel: "Paused",
+    downloadRoot: "/downloads",
   }),
   "deluge:2": defineClient({
     key: "deluge:2",
@@ -46,5 +47,6 @@ export default {
     username: "admin",
     password: "deluge",
     stopLabel: "Paused",
+    downloadRoot: "/downloads",
   }),
 } satisfies Record<string, TestClient>

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -37,6 +37,7 @@ export default {
     containerPort: 8080,
     username: "admin",
     password: "adminadmin",
+    downloadRoot: "/downloads",
   }),
   "qbittorrent:5": defineClient({
     key: "qbittorrent:5",
@@ -48,6 +49,7 @@ export default {
     containerPort: 8080,
     username: "admin",
     password: "adminadmin",
+    downloadRoot: "/downloads",
   }),
   "qbittorrent:latest": defineClient({
     key: "qbittorrent:latest",
@@ -59,5 +61,6 @@ export default {
     containerPort: 8080,
     username: "admin",
     password: "adminadmin",
+    downloadRoot: "/downloads",
   }),
 } satisfies Record<string, TestClient>

--- a/test/clients/rtorrent/index.ts
+++ b/test/clients/rtorrent/index.ts
@@ -28,6 +28,7 @@ export default {
     authProxyHostPort: 48081,
     username: "admin",
     password: "admin",
+    downloadRoot: "/downloads",
     saveLocation: "/downloads/custom/save/location",
   }),
   "rtorrent:latest": defineClient({
@@ -43,6 +44,7 @@ export default {
     authProxyHostPort: 48083,
     username: "admin",
     password: "admin",
+    downloadRoot: "/downloads",
     saveLocation: "/downloads/custom/save/location",
   }),
 } satisfies Record<string, TestClient>

--- a/test/clients/transmission/index.ts
+++ b/test/clients/transmission/index.ts
@@ -34,5 +34,6 @@ export default {
     username: "username",
     password: "password",
     acceptHttpStatus: 401,
+    downloadRoot: "/downloads",
   }),
 } satisfies Record<string, TestClient>

--- a/test/clients/types.ts
+++ b/test/clients/types.ts
@@ -18,10 +18,11 @@ export interface TestClient {
   acceptHttpStatus: number
   stopLabel: string
   downloadLabel: string
+  downloadRoot?: string
   saveLocation?: string
   specs?: string[]
   appArgs?: string[]
 }
 
-export type TestClientInput = Omit<TestClient, "host" | "acceptHttpStatus" | "stopLabel" | "downloadLabel">
-  & Partial<Pick<TestClient, "host" | "acceptHttpStatus" | "stopLabel" | "downloadLabel">>
+export type TestClientInput = Omit<TestClient, "host" | "acceptHttpStatus" | "stopLabel" | "downloadLabel" | "downloadRoot">
+  & Partial<Pick<TestClient, "host" | "acceptHttpStatus" | "stopLabel" | "downloadLabel" | "downloadRoot">>

--- a/test/clients/utorrent/index.ts
+++ b/test/clients/utorrent/index.ts
@@ -24,6 +24,7 @@ export default {
     username: "admin",
     password: "",
     acceptHttpStatus: 400,
+    downloadRoot: "/data",
     saveLocation: "/utorrent/custom/save/location",
   }),
 } satisfies Record<string, TestClient>

--- a/test/shared/opentracker/peer/rootfs/usr/local/bin/gen-torrent
+++ b/test/shared/opentracker/peer/rootfs/usr/local/bin/gen-torrent
@@ -2,16 +2,20 @@
 
 set -e
 
-# Parse CLI options for upload speed, download speed, file size, torrent file name, and tracker URL
+FILE_PATHS=()
+FILE_SIZES=()
+
+# Parse CLI options for upload speed, download speed, file contents, torrent file name, and tracker URL
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --foreground) FOREGROUND="1" ;;
         --upload-speed) UP_SPEED="$2"; shift ;;
         --download-speed) DL_SPEED="$2"; shift ;;
         --file-size) FILE_SIZE="$2"; shift ;;
+        --file) FILE_PATHS+=("$2"); FILE_SIZES+=("$3"); shift 2 ;;
         --torrent-name) TORRENT_NAME="$2"; shift ;;
         --tracker-url) TRACKER_URL="$2"; shift ;;
-        *) echo >&2 "Usage: $0 [--foreground] --upload-speed <up-speed> --download-speed <dl-speed> --file-size <file-size> --torrent-name <torrent-name> --tracker-url <tracker-url>" >&2; exit 1 ;;
+        *) echo >&2 "Usage: $0 [--foreground] [--upload-speed <up-speed>] [--download-speed <dl-speed>] [--file-size <file-size> | --file <path> <size> ...] --torrent-name <torrent-name> [--tracker-url <tracker-url>]"; exit 1 ;;
     esac
     shift
 done
@@ -19,23 +23,41 @@ done
 # Set default values if not provided
 FILE_SIZE="${FILE_SIZE:-1}"
 TRACKER_URL="${TRACKER_URL:-http://tracker:6969/announce}"
-# Generate a random suffix for unique file names
-RANDOM_SUFFIX=$(date +%s%N | sha256sum | head -c 8)
-# Create a random test file with the specified file size and unique name
-TEST_FILE="/srv/test-file-${RANDOM_SUFFIX}.bin"
-dd if=/dev/urandom of="$TEST_FILE" bs=1k count="$FILE_SIZE" 2>/dev/null
+if [ "${#FILE_PATHS[@]}" -gt 0 ]; then
+    CONTENT_PATH="/srv/$TORRENT_NAME"
+    rm -rf "$CONTENT_PATH"
+    mkdir -p "$CONTENT_PATH"
+
+    for i in "${!FILE_PATHS[@]}"; do
+        FILE_PATH="${FILE_PATHS[$i]}"
+        FILE_SIZE="${FILE_SIZES[$i]}"
+        if [[ "$FILE_PATH" = /* || "$FILE_PATH" = ".." || "$FILE_PATH" = ../* || "$FILE_PATH" = */../* || "$FILE_PATH" = */.. ]]; then
+            echo >&2 "File path must remain inside the torrent directory: $FILE_PATH"
+            exit 1
+        fi
+        mkdir -p "$CONTENT_PATH/$(dirname "$FILE_PATH")"
+        dd if=/dev/urandom of="$CONTENT_PATH/$FILE_PATH" bs=1k count="$FILE_SIZE" 2>/dev/null
+    done
+    SEED_DIR="/srv"
+else
+    # Create a random test file with the specified file size and unique name.
+    RANDOM_SUFFIX=$(date +%s%N | sha256sum | head -c 8)
+    CONTENT_PATH="/srv/test-file-${RANDOM_SUFFIX}.bin"
+    dd if=/dev/urandom of="$CONTENT_PATH" bs=1k count="$FILE_SIZE" 2>/dev/null
+    SEED_DIR="$(dirname "$CONTENT_PATH")"
+fi
 # Set the torrent file name, defaulting to a random name if not provided
 TORRENT_FILE="/shared/${TORRENT_NAME}.torrent"
 # Create a torrent file and save it in the shared folder.
 rm -f "$TORRENT_FILE"
-mktorrent -a "$TRACKER_URL" -o "$TORRENT_FILE" "$TEST_FILE" >/dev/null
+mktorrent -a "$TRACKER_URL" -o "$TORRENT_FILE" "$CONTENT_PATH" >/dev/null
 # Generate a random unprivileged port (1024-65535)
 P2P_PORT=$((1024 + RANDOM % 64512))
 # Seed the torrent file (and contents)
 ARIA2_ARGS=(
     --allow-overwrite=true
     --bt-seed-unverified=true
-    --dir="$(dirname "$TEST_FILE")"
+    --dir="$SEED_DIR"
     --enable-dht=false
     --enable-peer-exchange=false
     --listen-port="$P2P_PORT"

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -15,6 +15,14 @@ const client = fixture.client
 const backend = fixture.backend
 const tracker = fixture.tracker
 
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+function findDownloadedContentCommand(downloadRoot: string, contentName: string) {
+  return `find ${shellQuote(downloadRoot)} -maxdepth 5 -type f -name ${shellQuote(contentName)} -print -quit`
+}
+
 describe("torrent actions", function () {
   configureSpec()
 
@@ -80,6 +88,45 @@ describe("torrent actions", function () {
     await torrent.resume({ waitForState: false })
     await torrent.waitForDownloading({ timeout: 20 * 1000 })
     await torrent.checkInState(["all", "downloading"])
+  })
+
+  it("remove and delete removes downloaded content from disk", async function () {
+    this.timeout(300 * 1000)
+    if (!backend || !client.downloadRoot) {
+      return this.skip()
+    }
+
+    const torrentName = createUniqueLabel("delete-files")
+    const torrentPath = await createTorrentFile(tracker, { fileSize: 1, torrentName })
+    const torrentInfo = parseTorrent(fs.readFileSync(torrentPath))
+    const contentName = String(torrentInfo.name || torrentName)
+    const findContentCommand = findDownloadedContentCommand(client.downloadRoot, contentName)
+    const contentExistsCommand = `${findContentCommand} | grep -q .`
+    const contentMissingCommand = `[ -z "$(${findContentCommand})" ]`
+    const torrentToDelete = await this.app.uploadTorrent({ filename: torrentPath })
+
+    try {
+      await torrentToDelete.waitForExist({ timeout: 20 * 1000 })
+      await torrentToDelete.waitForStates(["Seeding", "Finished"], { timeout: 120 * 1000 })
+      await backend.waitForExec(["sh", "-lc", contentExistsCommand], 20 * 1000)
+      await $("#page-torrents li[data-state=all]").click()
+      await torrentToDelete.waitForExist()
+
+      const modal = await torrentToDelete.openDeleteConfirmation()
+      const approveButton = modal.$("button.approve")
+      await approveButton.waitForDisplayed()
+      await approveButton.waitForClickable()
+      await approveButton.click()
+      await waitForModalClose(modal)
+      await torrentToDelete.waitForGone()
+
+      await backend.waitForExec(["sh", "-lc", contentMissingCommand], 60 * 1000)
+    } finally {
+      if (await torrentToDelete.isExisting()) {
+        await $("#page-torrents li[data-state=all]").click()
+        await torrentToDelete.delete()
+      }
+    }
   })
 
   it("moves downloaded content via Set Location", async function () {

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -149,15 +149,13 @@ describe("torrent actions", function () {
       },
     })
     const findContentCommand = findDownloadedDirectoryCommand(client.downloadRoot, torrentName)
-    const addUnlistedContentCommand = `content_path=$(${findContentCommand}); [ -n "$content_path" ] && mkdir -p "$content_path/unlisted/deeper" && touch "$content_path/unlisted/deeper/extra.bin" && chmod -R 777 "$content_path/unlisted"`
-    const contentExistsCommand = `content_path=$(${findContentCommand}); [ -n "$content_path" ] && [ -f "$content_path/first.bin" ] && [ -f "$content_path/nested/deeper/third.bin" ] && [ -f "$content_path/unlisted/deeper/extra.bin" ]`
+    const contentExistsCommand = `content_path=$(${findContentCommand}); [ -n "$content_path" ] && [ -f "$content_path/first.bin" ] && [ -f "$content_path/nested/deeper/third.bin" ]`
     const contentMissingCommand = `[ -z "$(${findContentCommand})" ]`
     const torrentToDelete = await this.app.uploadTorrent({ filename: torrentPath })
 
     try {
       await torrentToDelete.waitForExist({ timeout: 20 * 1000 })
       await torrentToDelete.waitForStates(["Seeding", "Finished"], { timeout: 120 * 1000 })
-      await backend.exec(["sh", "-lc", addUnlistedContentCommand])
       await backend.waitForExec(["sh", "-lc", contentExistsCommand], 20 * 1000)
       await $("#page-torrents li[data-state=all]").click()
       await torrentToDelete.waitForExist()

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -23,6 +23,10 @@ function findDownloadedContentCommand(downloadRoot: string, contentName: string)
   return `find ${shellQuote(downloadRoot)} -maxdepth 5 -type f -name ${shellQuote(contentName)} -print -quit`
 }
 
+function findDownloadedDirectoryCommand(downloadRoot: string, contentName: string) {
+  return `find ${shellQuote(downloadRoot)} -maxdepth 5 -type d -name ${shellQuote(contentName)} -print -quit`
+}
+
 describe("torrent actions", function () {
   configureSpec()
 
@@ -102,6 +106,50 @@ describe("torrent actions", function () {
     const contentName = String(torrentInfo.name || torrentName)
     const findContentCommand = findDownloadedContentCommand(client.downloadRoot, contentName)
     const contentExistsCommand = `${findContentCommand} | grep -q .`
+    const contentMissingCommand = `[ -z "$(${findContentCommand})" ]`
+    const torrentToDelete = await this.app.uploadTorrent({ filename: torrentPath })
+
+    try {
+      await torrentToDelete.waitForExist({ timeout: 20 * 1000 })
+      await torrentToDelete.waitForStates(["Seeding", "Finished"], { timeout: 120 * 1000 })
+      await backend.waitForExec(["sh", "-lc", contentExistsCommand], 20 * 1000)
+      await $("#page-torrents li[data-state=all]").click()
+      await torrentToDelete.waitForExist()
+
+      const modal = await torrentToDelete.openDeleteConfirmation()
+      const approveButton = modal.$("button.approve")
+      await approveButton.waitForDisplayed()
+      await approveButton.waitForClickable()
+      await approveButton.click()
+      await waitForModalClose(modal)
+      await torrentToDelete.waitForGone()
+
+      await backend.waitForExec(["sh", "-lc", contentMissingCommand], 60 * 1000)
+    } finally {
+      if (await torrentToDelete.isExisting()) {
+        await $("#page-torrents li[data-state=all]").click()
+        await torrentToDelete.delete()
+      }
+    }
+  })
+
+  it("remove and delete removes multi-file content from disk", async function () {
+    this.timeout(300 * 1000)
+    if (!backend || !client.downloadRoot) {
+      return this.skip()
+    }
+
+    const torrentName = createUniqueLabel("delete-multi-file")
+    const torrentPath = await createTorrentFile(tracker, {
+      torrentName,
+      files: {
+        "first.bin": 1,
+        "nested/second.bin": 1,
+        "nested/deeper/third.bin": 1,
+      },
+    })
+    const findContentCommand = findDownloadedDirectoryCommand(client.downloadRoot, torrentName)
+    const contentExistsCommand = `content_path=$(${findContentCommand}); [ -n "$content_path" ] && [ -f "$content_path/first.bin" ] && [ -f "$content_path/nested/deeper/third.bin" ]`
     const contentMissingCommand = `[ -z "$(${findContentCommand})" ]`
     const torrentToDelete = await this.app.uploadTorrent({ filename: torrentPath })
 

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -149,13 +149,15 @@ describe("torrent actions", function () {
       },
     })
     const findContentCommand = findDownloadedDirectoryCommand(client.downloadRoot, torrentName)
-    const contentExistsCommand = `content_path=$(${findContentCommand}); [ -n "$content_path" ] && [ -f "$content_path/first.bin" ] && [ -f "$content_path/nested/deeper/third.bin" ]`
+    const addUnlistedContentCommand = `content_path=$(${findContentCommand}); [ -n "$content_path" ] && mkdir -p "$content_path/unlisted/deeper" && touch "$content_path/unlisted/deeper/extra.bin" && chmod -R 777 "$content_path/unlisted"`
+    const contentExistsCommand = `content_path=$(${findContentCommand}); [ -n "$content_path" ] && [ -f "$content_path/first.bin" ] && [ -f "$content_path/nested/deeper/third.bin" ] && [ -f "$content_path/unlisted/deeper/extra.bin" ]`
     const contentMissingCommand = `[ -z "$(${findContentCommand})" ]`
     const torrentToDelete = await this.app.uploadTorrent({ filename: torrentPath })
 
     try {
       await torrentToDelete.waitForExist({ timeout: 20 * 1000 })
       await torrentToDelete.waitForStates(["Seeding", "Finished"], { timeout: 120 * 1000 })
+      await backend.exec(["sh", "-lc", addUnlistedContentCommand])
       await backend.waitForExec(["sh", "-lc", contentExistsCommand], 20 * 1000)
       await $("#page-torrents li[data-state=all]").click()
       await torrentToDelete.waitForExist()

--- a/test/torrent.ts
+++ b/test/torrent.ts
@@ -13,6 +13,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export async function createTorrentFile(tracker: DockerComposeService, options: {
     torrentName?: string;
     fileSize?: number;
+    files?: Record<string, number>;
     downloadSpeed?: number;
     uploadSpeed?: number;
     trackerUrl?: string;
@@ -23,8 +24,14 @@ export async function createTorrentFile(tracker: DockerComposeService, options: 
     const cmd = [
         "gen-torrent",
         "--torrent-name", torrentName,
-        "--file-size", fileSize.toString(),
     ]
+    if (options.files) {
+        for (const [filePath, size] of Object.entries(options.files)) {
+            cmd.push("--file", filePath, size.toString());
+        }
+    } else {
+        cmd.push("--file-size", fileSize.toString());
+    }
     if (options.downloadSpeed) {
         cmd.push("--download-speed", options.downloadSpeed.toString());
     }


### PR DESCRIPTION
## Summary
- replace rTorrent remove-and-delete custom5 signaling with direct XMLRPC metadata, erase, and filesystem calls
- delete exact payload files and clean multi-file directories with one depth-first `find` RPC
- preserve untracked content because cleanup uses `rmdir` for empty directories only
- extend torrent fixtures with arbitrary relative file paths and generated random data
- verify UI deletion removes both single-file and nested multi-file torrents from disk

## Validation
- npm run lint
- npm run build
- npm run test -- --client "rtorrent" --spec "test/specs/standard/torrent-actions.spec.ts"
- npm run test -- --client "rtorrent:latest" --spec "test/specs/standard/torrent-actions.spec.ts"
- npm run test -- --client "rtorrent:latest" --spec "test/specs/standard/torrent-actions.spec.ts" --mochaOpts.grep "remove and delete removes multi-file content from disk"