### PR TITLE
build: add macOS entitlements

### DIFF
--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -5,6 +5,8 @@ productName: Electorrent
 appId: com.github.tympanix.electorrent
 mac:
   category: public.app-category.utilities
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.inherit.plist
   target:
     - target: dmg
       arch:


### PR DESCRIPTION
### Motivation
- Ensure the macOS build produced by `electron-builder` includes explicit entitlements for local file access and network requests and that helper processes inherit required runtime permissions.

### Description
- Add macOS entitlement plist files `build/entitlements.mac.plist` and `build/entitlements.mac.inherit.plist` with sandboxing, JIT/unsigned-executable-memory allowances, user-selected read/write, and network client permissions as appropriate.
- Wire the entitlements into the build configuration by updating `electron-builder.yml` to set `mac.entitlements` and `mac.entitlementsInherit` to the new files.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran `npm run build` (webpack) which completed successfully.
- Parsed and inspected the generated plists with `python3`/`plistlib` and confirmed the expected entitlement keys are present in `build/entitlements.mac.plist` and `build/entitlements.mac.inherit.plist`.
- Attempted `npm run smoketest` but it failed due to environment limits (`spawn docker ENOENT` and Puppeteer download HTTP 403), so end-to-end tests did not run.
- Attempted `npm run dist -- --mac dir --x64` but the build could not complete in this environment because downloading the macOS Electron binary returned HTTP 403, so the generated app bundle / `Info.plist` inspection could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5384be07848327b1685bcccd6a2b5d)