### PR TITLE
feat(qbittorrent): show moving status

### DIFF
--- a/src/renderer/app/bittorrent/qbittorrent/torrentq.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/torrentq.ts
@@ -136,7 +136,9 @@ export class QBittorrentTorrent extends Torrent {
     }
 
     manualStatusText() {
-        if (this.isStatusChecking()) {
+        if (this.getStatus('moving')) {
+            return 'Moving';
+        } else if (this.isStatusChecking()) {
             return 'Checking';
         } else {
             return super.manualStatusText();


### PR DESCRIPTION
## Summary
- display qBittorrent torrents in the `moving` state as `Moving`
- retain existing completed-state behavior while files move

## Testing
- `npm run lint`
- `npm run build`
- `npm run smoketest`

Closes #647