### PR TITLE
ci: remove test retry action

### DIFF
--- a/.github/workflows/electorrent-workflow.yml
+++ b/.github/workflows/electorrent-workflow.yml
@@ -63,13 +63,7 @@ jobs:
     - name: Build web application
       run: npm run build
     - name: Run tests
-      uses: nick-fields/retry@v3
-      timeout-minutes: 15
-      with:
-        max_attempts: 3
-        timeout_minutes: 10
-        retry_on: error
-        command: xvfb-run -a -- npm test -- --client "${{ matrix.client }}"
+      run: xvfb-run -a -- npm test -- --client "${{ matrix.client }}"
 
   build:
     strategy:


### PR DESCRIPTION
## Summary
- remove the nick-fields/retry action from the test job
- run the existing test command directly

## Validation
- npm run lint
- npm run build
- npm run smoketest