### PR TITLE
test: cover manual software updates

### DIFF
--- a/src/main/lib/update.ts
+++ b/src/main/lib/update.ts
@@ -37,8 +37,9 @@ export function checkForUpdates(notifyVerbose: boolean) {
     }
 }
 
-export function initialise(initWindow: BrowserWindow) {
+export function initialise(initWindow: BrowserWindow, customUpdateUrl?: string) {
     mainWindow = initWindow
+    updateUrl = customUpdateUrl || updateUrl
     squirrelUpdater()
     manualDownloader()
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -40,6 +40,7 @@ async function bootstrap() {
     parser.boolean('v').alias('v', 'verbose').describe('v', 'Enable verbose logging')
     parser.boolean('d').alias('d', 'debug').describe('d', 'Start in debug mode')
     parser.boolean('force-title-bar-menu')
+    parser.string('update-url')
 
     const [
         { IPC_CHANNELS },
@@ -76,7 +77,7 @@ async function bootstrap() {
     logger.debug('Starting Electorrent in debug mode')
     logger.verbose('Verbose logging enabled')
 
-    const program = parser.parse(process.argv.slice(1)) as { debug?: boolean; verbose?: boolean; forceTitleBarMenu?: boolean }
+    const program = parser.parse(process.argv.slice(1)) as { debug?: boolean; verbose?: boolean; forceTitleBarMenu?: boolean; updateUrl?: string }
 
     if (!app.isPackaged) {
         try {
@@ -479,7 +480,7 @@ async function bootstrap() {
         createTorrentWindow(startedInBackground)
         syncTray()
         torrentFileWatcher.start()
-        updater.initialise(torrentWindow)
+        updater.initialise(torrentWindow, program.updateUrl)
 
         session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
             const { requestHeaders } = details

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
@@ -198,7 +198,7 @@ export class TitleBarMenuController {
             },
         ];
 
-        const helpMenuItems = (): TitleBarMenuItem[] => [
+        const helpMenuItems: TitleBarMenuItem[] = [
             {
                 label: "Learn More",
                 action: { type: "open-external", url: "https://github.com/tympanix/Electorrent" },
@@ -233,7 +233,7 @@ export class TitleBarMenuController {
             { label: "View", items: viewMenuItems },
             { label: "Servers", items: serverMenuItems },
             { label: "Window", items: windowMenuItems },
-            { label: "Help", items: helpMenuItems },
+            { label: "Help", items: () => helpMenuItems },
         ];
         $scope.visibleTitleBarMenuItems = (menu: TitleBarMenu) => {
             return menu.items().filter((item) => item.visible ? item.visible() : true);

--- a/test/clients/mock/index.ts
+++ b/test/clients/mock/index.ts
@@ -32,5 +32,6 @@ export default {
     host: "localhost",
     port: 1,
     specs: ["test/specs/mock/**/*.spec.ts"],
+    appArgs: ["-d", "--force-title-bar-menu", "--update-url=http://127.0.0.1:43871/update"],
   }),
 }

--- a/test/clients/types.ts
+++ b/test/clients/types.ts
@@ -20,6 +20,7 @@ export interface TestClient {
   downloadLabel: string
   saveLocation?: string
   specs?: string[]
+  appArgs?: string[]
 }
 
 export type TestClientInput = Omit<TestClient, "host" | "acceptHttpStatus" | "stopLabel" | "downloadLabel">

--- a/test/specs/mock/software-update.spec.ts
+++ b/test/specs/mock/software-update.spec.ts
@@ -1,0 +1,83 @@
+import chai from "chai"
+import fs from "node:fs"
+import http from "node:http"
+import path from "node:path"
+import { $, browser } from "@wdio/globals"
+import { waitForModalClose, waitForModalOpen } from "../../e2e/modal"
+import { configureSpec } from "../../framework/fixture"
+
+const assert: Chai.AssertStatic = chai.assert
+const updatePort = 43871
+const updateFilename = "electorrent-test-update.dmg"
+const updateContents = Buffer.from("Electorrent test update")
+let updatePath: string | undefined
+
+describe("software updates", function () {
+  configureSpec()
+
+  const server = http.createServer((request, response) => {
+    if (request.url === "/update") {
+      response.writeHead(200, { "Content-Type": "application/json" })
+      response.end(JSON.stringify({
+        name: "99.0.0",
+        url: `http://127.0.0.1:${updatePort}/download`,
+        notes: "Local update server release notes",
+        pub_date: "2026-07-13T00:00:00.000Z",
+      }))
+      return
+    }
+
+    if (request.url === "/download") {
+      response.writeHead(200, {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Disposition": `attachment; filename="${updateFilename}"`,
+        "Content-Length": updateContents.length,
+        "Content-Type": "application/octet-stream",
+      })
+      response.end(updateContents)
+      return
+    }
+
+    response.writeHead(404)
+    response.end()
+  })
+
+  before(async function () {
+    const downloadsPath = await browser.electron.execute((electron) => electron.app.getPath("downloads"))
+    updatePath = path.join(downloadsPath, updateFilename)
+    fs.rmSync(updatePath, { force: true })
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(updatePort, "127.0.0.1", resolve)
+    })
+  })
+
+  after(async function () {
+    if (updatePath) {
+      fs.rmSync(updatePath, { force: true })
+    }
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  })
+
+  it("downloads a newer version and shows the update modal", async function () {
+    const helpMenu = $("//button[contains(@class, 'title-bar-menu-trigger') and normalize-space(.)='Help']")
+    await helpMenu.waitForClickable()
+    await helpMenu.click()
+
+    const checkForUpdates = $("//button[contains(@class, 'title-bar-menu-item')]//*[normalize-space(.)='Check For Updates']/parent::button")
+    await checkForUpdates.waitForClickable()
+    await checkForUpdates.click()
+
+    const modal = $("#updateModal")
+    await waitForModalOpen(modal, 20_000)
+
+    assert.equal(await modal.$(".header").getText(), "Update Available")
+    assert.include(await modal.$(".content").getText(), "99.0.0")
+    assert.isDefined(updatePath)
+    assert.deepEqual(fs.readFileSync(updatePath!), updateContents)
+
+    await modal.$("button.deny").click()
+    await waitForModalClose(modal)
+  })
+})

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -40,7 +40,7 @@ function electronCapability(client: (typeof selectedClients)[number]): Webdriver
         'electorrent:client': client,
         'wdio:electronServiceOptions': {
             appEntryPoint: 'app/main.js',
-            appArgs: [],
+            appArgs: client.appArgs ?? [],
         },
         'goog:chromeOptions': {
             args: [


### PR DESCRIPTION
## Summary
- add an update URL CLI override for local update-server testing
- add a mock-client spec that serves and downloads a newer release, then verifies the update modal
- keep Help menu items stable so the manual menu interaction does not trigger an Angular digest loop

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "mock" --spec "test/specs/mock/software-update.spec.ts"`