### PR TITLE
refactor: consolidate CLI argument handling

### DIFF
--- a/src/main/lib/command-line.ts
+++ b/src/main/lib/command-line.ts
@@ -1,0 +1,80 @@
+import { app } from 'electron'
+import yargs from 'yargs'
+
+export type SquirrelCommand =
+    | '--squirrel-install'
+    | '--squirrel-updated'
+    | '--squirrel-uninstall'
+    | '--squirrel-obsolete'
+
+export interface ParsedLaunchArguments {
+    magnetLinks: string[]
+    torrentFilePaths: string[]
+}
+
+export interface ParsedCommandLineOptions {
+    debug: boolean
+    verbose: boolean
+    forceTitleBarMenu: boolean
+    updateUrl?: string
+    headless: boolean
+    startedAtLogin: boolean
+    squirrelCommand?: SquirrelCommand
+    launch: ParsedLaunchArguments
+}
+
+interface YargsOptions {
+    debug?: boolean
+    verbose?: boolean
+    'force-title-bar-menu'?: boolean
+    'update-url'?: string | string[]
+}
+
+export const STARTED_AT_LOGIN_ARGUMENT = '--started-at-login'
+const SQUIRREL_COMMANDS: readonly SquirrelCommand[] = [
+    '--squirrel-install',
+    '--squirrel-updated',
+    '--squirrel-uninstall',
+    '--squirrel-obsolete',
+]
+
+export function parseLaunchArguments(args: readonly string[]): ParsedLaunchArguments {
+    const isMagnetLink = (argument: string) => /^magnet:\?/i.test(argument)
+    const magnetLinks = args.filter(isMagnetLink)
+    const torrentFilePaths = args.filter((argument) => (
+        !isMagnetLink(argument) && argument.toLowerCase().endsWith('.torrent')
+    ))
+
+    return { magnetLinks, torrentFilePaths }
+}
+
+function parseCommandLineOptions(args: readonly string[]): ParsedCommandLineOptions {
+    const parserArguments = args.slice(1)
+    const parser = yargs(parserArguments)
+    parser.version(app.getVersion())
+    parser.help('h').alias('h', 'help')
+    parser.usage(`Electorrent ${app.getVersion()}`)
+    parser.boolean('v').alias('v', 'verbose').describe('v', 'Enable verbose logging')
+    parser.boolean('d').alias('d', 'debug').describe('d', 'Start in debug mode')
+    parser.boolean('force-title-bar-menu')
+    parser.string('update-url')
+
+    const parsed = parser.parse(parserArguments) as YargsOptions
+    const updateUrl = Array.isArray(parsed['update-url'])
+        ? parsed['update-url'][parsed['update-url'].length - 1]
+        : parsed['update-url']
+    const squirrelCommand = SQUIRREL_COMMANDS.find((command) => command === args[1])
+
+    return {
+        debug: !!parsed.debug,
+        verbose: !!parsed.verbose,
+        forceTitleBarMenu: parsed['force-title-bar-menu'] === true,
+        updateUrl,
+        headless: app.commandLine.hasSwitch('headless'),
+        startedAtLogin: args.includes(STARTED_AT_LOGIN_ARGUMENT),
+        squirrelCommand,
+        launch: parseLaunchArguments(args),
+    }
+}
+
+export const commandLineOptions = parseCommandLineOptions(process.argv)

--- a/src/main/lib/logger.ts
+++ b/src/main/lib/logger.ts
@@ -1,9 +1,9 @@
 import { app } from 'electron'
 import path from 'path'
 import winston from 'winston'
-import yargs from 'yargs'
 
-const program = yargs(process.argv.slice(1)).parse(process.argv.slice(1)) as { debug?: boolean; verbose?: boolean }
+import { commandLineOptions } from './command-line'
+
 const loglevel = getLogLevel()
 const logfile = path.join(app.getPath('userData'), 'logfile.log')
 
@@ -15,9 +15,9 @@ const logger = new winston.Logger({
 })
 
 function getLogLevel() {
-    if (program.debug) {
+    if (commandLineOptions.debug) {
         return 'debug'
-    } else if (program.verbose) {
+    } else if (commandLineOptions.verbose) {
         return 'verbose'
     }
 

--- a/src/main/lib/startup.ts
+++ b/src/main/lib/startup.ts
@@ -5,9 +5,9 @@ import Q from 'q'
 import electronRegedit from 'electron-regedit'
 
 import type { SystemStartupOption } from '@shared/ipc-contract'
+import { commandLineOptions, STARTED_AT_LOGIN_ARGUMENT, type SquirrelCommand } from './command-line'
 
 const { ProgId, Regedit } = electronRegedit as any
-const STARTED_AT_LOGIN_ARG = '--started-at-login'
 
 new ProgId({
     description: 'Torrent File',
@@ -41,12 +41,11 @@ function removeShortcut() {
     return executeSquirrelCommand(['--removeShortcut', target])
 }
 
-function checkSquirrel() {
+function checkSquirrel(squirrelCommand?: SquirrelCommand) {
     if (process.platform !== 'win32') {
         return false
     }
 
-    const squirrelCommand = process.argv[1]
     switch (squirrelCommand) {
         case '--squirrel-install':
         case '--squirrel-updated':
@@ -69,7 +68,7 @@ function checkSquirrel() {
     }
 }
 
-const shouldQuitFromStartup = checkSquirrel()
+const shouldQuitFromStartup = checkSquirrel(commandLineOptions.squirrelCommand)
 
 export function configureSystemStartup(option: SystemStartupOption) {
     if (!app.isPackaged || !['darwin', 'win32'].includes(process.platform)) {
@@ -86,7 +85,7 @@ export function configureSystemStartup(option: SystemStartupOption) {
         app.setLoginItemSettings({
             openAtLogin,
             path: stubLauncher,
-            args: openAtLogin ? [STARTED_AT_LOGIN_ARG] : [],
+            args: openAtLogin ? [STARTED_AT_LOGIN_ARGUMENT] : [],
         })
         return
     }
@@ -94,13 +93,13 @@ export function configureSystemStartup(option: SystemStartupOption) {
     app.setLoginItemSettings({ openAtLogin })
 }
 
-export function shouldStartInBackground(option: SystemStartupOption) {
+export function shouldStartInBackground(option: SystemStartupOption, startedAtLogin: boolean) {
     if (option !== 'background') {
         return false
     }
 
     if (process.platform === 'win32') {
-        return process.argv.includes(STARTED_AT_LOGIN_ARG)
+        return startedAtLogin
     }
 
     return process.platform === 'darwin' && app.getLoginItemSettings().wasOpenedAtLogin

--- a/src/main/lib/torrent-file-watcher.ts
+++ b/src/main/lib/torrent-file-watcher.ts
@@ -1,7 +1,7 @@
 import fs, { type FSWatcher } from 'fs'
 import path from 'path'
 
-import { app, Notification, type BrowserWindow } from 'electron'
+import { Notification, type BrowserWindow } from 'electron'
 
 import { bittorrentManager } from '@main/lib/bittorrent'
 import { IPC_CHANNELS } from '@shared/ipc'
@@ -12,6 +12,7 @@ import { serializeTorrentFile } from './torrents'
 interface TorrentFileWatcherOptions {
     getSettings: () => Pick<AppSettings, 'watchDirectory' | 'alwaysPromptUploadOptions'>
     getWindow: () => BrowserWindow | null
+    isHeadless: boolean
     isRendererLoaded: () => boolean
     showOrCreateTorrentWindow: () => void
     showTorrentWindow: () => void
@@ -151,7 +152,7 @@ export class TorrentFileWatcher {
     }
 
     private showNativeNotification(title: string, body: string) {
-        if (app.commandLine.hasSwitch('headless') || !Notification.isSupported()) {
+        if (this.options.isHeadless || !Notification.isSupported()) {
             return
         }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13,35 +13,18 @@ import {
 } from 'electron'
 import is from 'electron-is'
 import path from 'path'
-import yargs from 'yargs'
 
+import { commandLineOptions, parseLaunchArguments, type ParsedLaunchArguments } from '@main/lib/command-line'
 import startup, { configureSystemStartup, shouldStartInBackground } from '@main/lib/startup'
 import type { PendingTorrentUploadLink } from '@shared/ipc-contract'
 
 declare const __non_webpack_require__: NodeRequire | undefined
-
-function isMagnetLink(arg: string) {
-    return /^magnet:\?/i.test(arg)
-}
-
-function isTorrentFilePath(arg: string) {
-    return !isMagnetLink(arg) && arg.toLowerCase().endsWith('.torrent')
-}
 
 if (!startup) {
     void bootstrap()
 }
 
 async function bootstrap() {
-    const parser = yargs(process.argv.slice(1))
-    parser.version(app.getVersion())
-    parser.help('h').alias('h', 'help')
-    parser.usage(`Electorrent ${app.getVersion()}`)
-    parser.boolean('v').alias('v', 'verbose').describe('v', 'Enable verbose logging')
-    parser.boolean('d').alias('d', 'debug').describe('d', 'Start in debug mode')
-    parser.boolean('force-title-bar-menu')
-    parser.string('update-url')
-
     const [
         { IPC_CHANNELS },
         { bittorrentManager },
@@ -77,8 +60,6 @@ async function bootstrap() {
     logger.debug('Starting Electorrent in debug mode')
     logger.verbose('Verbose logging enabled')
 
-    const program = parser.parse(process.argv.slice(1)) as { debug?: boolean; verbose?: boolean; forceTitleBarMenu?: boolean; updateUrl?: string }
-
     if (!app.isPackaged) {
         try {
             const runtimeRequire: NodeRequire = typeof __non_webpack_require__ === 'function'
@@ -103,13 +84,14 @@ async function bootstrap() {
     const torrentFileWatcher = new TorrentFileWatcher({
         getSettings: () => settings.getAllSettings(),
         getWindow: () => torrentWindow,
+        isHeadless: commandLineOptions.headless,
         isRendererLoaded: () => rendererLoaded,
         showOrCreateTorrentWindow,
         showTorrentWindow,
     })
 
     function shouldUseTray() {
-        return !app.commandLine.hasSwitch('headless')
+        return !commandLineOptions.headless
             && (startedInBackground || settings.get('closeToTray') !== false)
     }
 
@@ -368,28 +350,20 @@ async function bootstrap() {
         destroyTray()
     }
 
-    function getMagnetLinks(args: string[]): string[] {
-        return args.filter(isMagnetLink)
+    function queuePendingLaunchArgs(args: ParsedLaunchArguments) {
+        pendingLaunchPayload.magnets.push(...args.magnetLinks.map((uri) => torrents.serializeMagnetLink(uri)))
+        pendingLaunchPayload.torrentFilePaths.push(...args.torrentFilePaths)
     }
 
-    function getTorrentFilePaths(args: string[]): string[] {
-        return args.filter(isTorrentFilePath)
-    }
-
-    function queuePendingLaunchArgs(args: string[]) {
-        pendingLaunchPayload.magnets.push(...getMagnetLinks(args).map((uri) => torrents.serializeMagnetLink(uri)))
-        pendingLaunchPayload.torrentFilePaths.push(...getTorrentFilePaths(args))
-    }
-
-    async function sendMagnetLinks(args: string[]) {
-        const magnetLinks = getMagnetLinks(args).map((uri) => torrents.serializeMagnetLink(uri))
+    async function sendMagnetLinks(args: ParsedLaunchArguments) {
+        const magnetLinks = args.magnetLinks.map((uri) => torrents.serializeMagnetLink(uri))
         if (magnetLinks.length === 0 || !torrentWindow || torrentWindow.isDestroyed()) return
         torrentWindow.webContents.send(IPC_CHANNELS.launch.magnets, magnetLinks)
     }
 
-    async function sendTorrentFiles(args: string[]) {
-        logger.info('Main searching for files in', args)
-        const torrentFiles = getTorrentFilePaths(args)
+    async function sendTorrentFiles(args: ParsedLaunchArguments) {
+        logger.info('Main searching for files in', args.torrentFilePaths)
+        const torrentFiles = args.torrentFilePaths
         if (torrentFiles.length === 0 || !torrentWindow || torrentWindow.isDestroyed()) return
         logger.info('Main sending torrent files', torrentFiles)
         const files = await torrents.readFiles(torrentFiles, false)
@@ -412,8 +386,8 @@ async function bootstrap() {
     }
 
     ipcHandlers.registerHandlers({
-        isDebug: !!program.debug,
-        forceTitleBarMenu: !!program.forceTitleBarMenu,
+        isDebug: commandLineOptions.debug,
+        forceTitleBarMenu: commandLineOptions.forceTitleBarMenu,
         getWindow: () => torrentWindow,
         consumePendingLaunchPayload,
         onSettingsSaved: async (newSettings) => {
@@ -439,48 +413,51 @@ async function bootstrap() {
         app.quit()
     } else {
         app.on('second-instance', function(_event: ElectronEvent, args: string[]) {
+            const launchArguments = parseLaunchArguments(args)
             if (torrentWindow) {
-                sendMagnetLinks(args)
-                sendTorrentFiles(args)
+                sendMagnetLinks(launchArguments)
+                sendTorrentFiles(launchArguments)
                 showTorrentWindow()
             } else {
-                queuePendingLaunchArgs(args)
+                queuePendingLaunchArgs(launchArguments)
                 showOrCreateTorrentWindow()
             }
         })
     }
 
     app.on('open-url', function(_event: ElectronEvent, url: string) {
+        const launchArguments = parseLaunchArguments([url])
         if (torrentWindow) {
-            sendMagnetLinks([url])
+            sendMagnetLinks(launchArguments)
             showTorrentWindow()
         } else {
-            queuePendingLaunchArgs([url])
+            queuePendingLaunchArgs(launchArguments)
             showOrCreateTorrentWindow()
         }
     })
 
     app.on('open-file', function(_event: ElectronEvent, filePath: string) {
+        const launchArguments = parseLaunchArguments([filePath])
         if (torrentWindow) {
-            sendTorrentFiles([filePath])
+            sendTorrentFiles(launchArguments)
             showTorrentWindow()
         } else {
-            queuePendingLaunchArgs([filePath])
+            queuePendingLaunchArgs(launchArguments)
             showOrCreateTorrentWindow()
         }
     })
 
     app.on('ready', function() {
-        queuePendingLaunchArgs(process.argv)
+        queuePendingLaunchArgs(commandLineOptions.launch)
         configureSystemStartup(settings.getAllSettings().systemStartup)
-        startedInBackground = shouldStartInBackground(settings.getAllSettings().systemStartup)
+        startedInBackground = shouldStartInBackground(settings.getAllSettings().systemStartup, commandLineOptions.startedAtLogin)
         if (startedInBackground && is.macOS()) {
             app.dock.hide()
         }
         createTorrentWindow(startedInBackground)
         syncTray()
         torrentFileWatcher.start()
-        updater.initialise(torrentWindow, program.updateUrl)
+        updater.initialise(torrentWindow, commandLineOptions.updateUrl)
 
         session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
             const { requestHeaders } = details
@@ -510,7 +487,7 @@ async function bootstrap() {
     })
 
     app.on('window-all-closed', () => {
-        if (process.platform !== 'darwin' || app.commandLine.hasSwitch('headless')) {
+        if (process.platform !== 'darwin' || commandLineOptions.headless) {
             app.quit()
         }
     })


### PR DESCRIPTION
## Summary
- parse application CLI options once through a dedicated typed abstraction
- centralize launch argument, Squirrel, login startup, and headless handling
- pass parsed values to logger, startup, watcher, and window consumers
- normalize yargs dashed and repeated option values

## Testing
- npm run lint
- npm run build
- npm run test -- --client mock --spec test/specs/mock/software-update.spec.ts