### PR TITLE
fix: consume launch torrents once

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -402,6 +402,12 @@ async function bootstrap() {
     }
 
     async function consumePendingLaunchPayload() {
+        for (let index = process.argv.length - 1; index >= 0; index -= 1) {
+            if (isMagnetLink(process.argv[index]) || isTorrentFilePath(process.argv[index])) {
+                process.argv.splice(index, 1)
+            }
+        }
+
         return {
             magnets: pendingLaunchPayload.magnets.splice(0),
             torrentFiles: [

--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -45,6 +45,7 @@ export class AppShellController {
         let loadingTimer: angular.IPromise<void> | undefined;
         let page: string | null = null;
         let activeConnectionId = 0;
+        let initialLaunchPayloadConsumed = false;
         let pendingMagnets: Array<PendingTorrentUploadLink & { askUploadOptions?: boolean }> = [];
         let pendingTorrentFiles: Array<PendingTorrentUploadFile & { askUploadOptions?: boolean }> = [];
 
@@ -228,6 +229,10 @@ export class AppShellController {
                 $scope.statusText = "Loading Torrents";
                 settingsService.updateServer(server);
                 pageTorrents(true);
+                if (initialLaunchPayloadConsumed) {
+                    return;
+                }
+                initialLaunchPayloadConsumed = true;
                 return electorrent.launch.getPending().then((payload: LaunchPayload) => {
                     if (!isCurrentConnection()) {
                         return;

--- a/test/specs/mock/multiple-servers.spec.ts
+++ b/test/specs/mock/multiple-servers.spec.ts
@@ -1,5 +1,5 @@
 import chai from "chai"
-import { $$, browser } from "@wdio/globals"
+import { $, $$, browser } from "@wdio/globals"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec } from "../../framework/fixture"
 import { restartApplication } from "../../shared"
@@ -27,6 +27,27 @@ describe("mock multiple servers", function () {
     await saveMockServers()
     await restartApplication(this)
     await this.app.serverSelectionPageIsVisible()
+  })
+
+  it("adds a launch magnet only to the first server", async function () {
+    const launchTorrentName = "Mock Magnet 0000000000000000000000000000000000000356"
+    const launchMagnet = "magnet:?xt=urn:btih:0000000000000000000000000000000000000356"
+
+    await browser.electron.execute((electron, uri) => {
+      electron.app.emit("open-url", {} as Electron.Event, uri)
+    }, launchMagnet)
+
+    await this.app.connectServerSelection(0)
+    await this.app.torrentsPageIsVisible()
+    await expectOnlyTorrent(launchTorrentName)
+
+    await openServerSelection()
+    await this.app.connectServerSelection(1)
+    await this.app.torrentsPageIsVisible()
+    await eventually(getTorrentNames).satisfies(
+      "not include the launch magnet on the second server",
+      (names) => !names.includes(launchTorrentName),
+    )
   })
 
   it("shows each server's torrent after changing servers", async function () {
@@ -88,6 +109,15 @@ async function invokeMockAction(action: string, ...args: any[]) {
   await browser.execute(async (request) => {
     await (window as any).electorrent.bittorrent.invokeAction(request)
   }, { action, args })
+}
+
+async function openServerSelection() {
+  await browser.execute(() => {
+    const rootScope = angular.element(document.documentElement).injector().get("$rootScope")
+    rootScope.$broadcast("show:servers")
+    rootScope.$applyAsync()
+  })
+  await $("#page-server-selection").waitForDisplayed()
 }
 
 async function addMockedTorrent(torrent: MockTorrent) {


### PR DESCRIPTION
## Summary
- remove consumed magnet and torrent-file entries from the initial process arguments
- consume the initial launch payload only on the first successful server connection
- cover switching servers after receiving a launch magnet

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "mock" --spec "test/specs/mock/multiple-servers.spec.ts"`

Closes #356