### PR TITLE
feat: improve client connection errors

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -210,7 +210,10 @@ export class DelugeRuntime implements BittorrentRuntime {
             jar: request.jar(),
         }
 
-        await defer((done) => this.rpc("auth.login", [server.password], done, HTTP_LOGIN_TIMEOUT))
+        const authenticated = await defer<boolean>((done) => this.rpc("auth.login", [server.password], done, HTTP_LOGIN_TIMEOUT))
+        if (!authenticated) {
+            throw new Error("Invalid credentials")
+        }
 
         const hosts = await this.getHosts()
         const hostId = hosts[0]?.[0]

--- a/src/main/lib/bittorrent/connection-error.ts
+++ b/src/main/lib/bittorrent/connection-error.ts
@@ -1,0 +1,106 @@
+import type { BittorrentConnectionError, BittorrentConnectionErrorKind } from "@shared/ipc-contract"
+
+const TLS_CODES = new Set([
+    "DEPTH_ZERO_SELF_SIGNED_CERT",
+    "SELF_SIGNED_CERT_IN_CHAIN",
+    "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+    "CERT_HAS_EXPIRED",
+    "ERR_TLS_CERT_ALTNAME_INVALID",
+])
+
+const TIMEOUT_CODES = new Set(["ECONNABORTED", "ESOCKETTIMEDOUT", "ETIMEDOUT"])
+const ADDRESS_CODES = new Set(["EAI_AGAIN", "ENOTFOUND"])
+const UNREACHABLE_CODES = new Set(["ECONNREFUSED", "ECONNRESET", "EHOSTUNREACH", "ENETUNREACH"])
+
+const MESSAGES: Record<BittorrentConnectionErrorKind, string> = {
+    authentication: "Incorrect username or password.",
+    timeout: "Connection timed out.",
+    unreachable: "Client is unreachable.",
+    address: "Check the client address and path.",
+    tls: "Secure connection failed.",
+    server: "Client is unavailable.",
+    response: "Client returned an invalid response.",
+    cancelled: "Connection cancelled.",
+    unknown: "Could not connect to client.",
+}
+
+type ErrorDetails = {
+    codes: Set<string>
+    statuses: Set<number>
+    messages: string[]
+}
+
+function collectErrorDetails(error: unknown, details: ErrorDetails, seen: Set<unknown>) {
+    if (error === null || error === undefined || seen.has(error)) {
+        return
+    }
+    if (typeof error !== "object") {
+        details.messages.push(String(error))
+        return
+    }
+
+    seen.add(error)
+    const value = error as Record<string, any>
+    if (typeof value.code === "string") {
+        details.codes.add(value.code.toUpperCase())
+    }
+    for (const status of [value.status, value.statusCode, value.response?.status]) {
+        const numericStatus = Number(status)
+        if (Number.isInteger(numericStatus)) {
+            details.statuses.add(numericStatus)
+        }
+    }
+    if (value.message) {
+        details.messages.push(String(value.message))
+    }
+    if (Array.isArray(value.errors)) {
+        value.errors.forEach((nestedError) => collectErrorDetails(nestedError, details, seen))
+    }
+    collectErrorDetails(value.cause, details, seen)
+}
+
+function connectionError(kind: BittorrentConnectionErrorKind, details: ErrorDetails): BittorrentConnectionError {
+    return {
+        kind,
+        message: MESSAGES[kind],
+        code: [...details.codes][0],
+    }
+}
+
+export function normalizeConnectionError(error: unknown): BittorrentConnectionError {
+    const details: ErrorDetails = { codes: new Set(), statuses: new Set(), messages: [] }
+    collectErrorDetails(error, details, new Set())
+    const message = details.messages.join(" ").toLowerCase()
+
+    if (message.includes("stale bittorrent connection")) {
+        return connectionError("cancelled", details)
+    }
+    if ([...details.codes].some((code) => TLS_CODES.has(code))
+        || /self[- ]signed certificate|certificate (has expired|is not yet valid)|unable to verify.*certificate|hostname.*certificate/.test(message)) {
+        return connectionError("tls", details)
+    }
+    if ([...details.statuses].some((status) => status === 401 || status === 403)
+        || /\b(401|403)\b|invalid (login|credentials)|failed to authenticate|incorrect password|no such account|account disabled|permission denied/.test(message)) {
+        return connectionError("authentication", details)
+    }
+    if ([...details.codes].some((code) => TIMEOUT_CODES.has(code)) || /timed? ?out|timeout/.test(message)) {
+        return connectionError("timeout", details)
+    }
+    if ([...details.codes].some((code) => ADDRESS_CODES.has(code))) {
+        return connectionError("address", details)
+    }
+    if ([...details.codes].some((code) => UNREACHABLE_CODES.has(code))) {
+        return connectionError("unreachable", details)
+    }
+    if (details.statuses.has(404) || /\b404\b/.test(message)) {
+        return connectionError("address", details)
+    }
+    if ([...details.statuses].some((status) => status >= 500)) {
+        return connectionError("server", details)
+    }
+    if (/did not return|invalid response|unexpected token|parse error/.test(message)) {
+        return connectionError("response", details)
+    }
+
+    return connectionError("unknown", details)
+}

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -5,6 +5,7 @@ import { IPC_CHANNELS } from '@shared/ipc'
 import type { AppSettings, EditCommand, PendingTorrentUploadLink, WindowCommand } from '@shared/ipc-contract'
 import { getAppVersion } from './app-meta'
 import { bittorrentManager } from './bittorrent'
+import { normalizeConnectionError } from './bittorrent/connection-error'
 import * as certificates from './certificates'
 import * as menu from './menu'
 import * as settings from './settings'
@@ -215,10 +216,14 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }) {
         menu.setActiveServer(server, false)
-        const connection = await bittorrentManager.connect(event.sender, server)
-        menu.setActiveServer(server, true)
-        await onBittorrentConnected?.()
-        return connection
+        try {
+            const connection = await bittorrentManager.connect(event.sender, server)
+            menu.setActiveServer(server, true)
+            await onBittorrentConnected?.()
+            return { ok: true, connection }
+        } catch (error) {
+            return { ok: false, error: normalizeConnectionError(error) }
+        }
     })
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.disconnect, async function(event: IpcMainInvokeEvent) {

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -25,8 +25,13 @@ export function serializeServer(server: any): BittorrentServerConfig {
     }
 }
 
-export function connect(server: any): Promise<TorrentClientConnection> {
-    return bridge().connect(serializeServer(server))
+export async function connect(server: any): Promise<TorrentClientConnection> {
+    const result = await bridge().connect(serializeServer(server))
+    if (result.ok === false) {
+        throw Object.assign(new Error(result.error.message), result.error)
+    }
+
+    return result.connection
 }
 
 export function disconnect() {

--- a/src/renderer/app/services/notification.ts
+++ b/src/renderer/app/services/notification.ts
@@ -66,15 +66,17 @@ export let notificationService = ["$rootScope", function ($rootScope) {
         if (typeof err === 'string') {
             this.alert('Connection problem', err)
         } else if (typeof err !== 'object') {
-            this.alert("Connection problem", "The connection could not be established")
+            this.alert("Connection problem", "Could not connect to client.")
+        } else if (typeof err.message === 'string' && err.kind) {
+            this.alert("Connection problem", err.message)
         } else if (err.status === -1) {
-            this.alert("Connection problem", "The connection to the server timed out!")
+            this.alert("Connection problem", "Connection timed out.")
         } else if (err.status === 401) {
-            this.alert("Connection problem", "You entered an incorrent username/password")
+            this.alert("Connection problem", "Incorrect username or password.")
         } else if (err.code && ERR_CODES.hasOwnProperty(err.code)) {
             this.alert(ERR_CODES[err.code].title, ERR_CODES[err.code].msg)
         } else {
-            this.alert("Connection problem", "The connection could not be established")
+            this.alert("Connection problem", "Could not connect to client.")
         }
     }
 

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -42,13 +42,8 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                 || message.includes("certificate")
         }
 
-        function isAggregateConnectionError(err: any) {
-            const message = String(err?.message || err).toLowerCase()
-            return err?.name === "AggregateError" || message.includes("aggregateerror")
-        }
-
         function isStaleConnectionError(err: any) {
-            return String(err?.message || err).toLowerCase().includes("stale bittorrent connection")
+            return err?.kind === "cancelled" || String(err?.message || err).toLowerCase().includes("stale bittorrent connection")
         }
 
         /**
@@ -208,7 +203,7 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
 
             return service.connect(this).catch(function(err) {
                 self.isConnected = false
-                if (self.isHTTPS() && (isTlsCertificateError(err) || isAggregateConnectionError(err))) {
+                if (self.isHTTPS() && (err?.kind === "tls" || isTlsCertificateError(err))) {
                     return self.askForCertificate().then(function() {
                         return self.connect()
                     })

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -205,6 +205,27 @@ export interface TorrentClientConnection {
     readonly features: TorrentClientFeatures
 }
 
+export type BittorrentConnectionErrorKind =
+    | "authentication"
+    | "timeout"
+    | "unreachable"
+    | "address"
+    | "tls"
+    | "server"
+    | "response"
+    | "cancelled"
+    | "unknown"
+
+export interface BittorrentConnectionError {
+    readonly kind: BittorrentConnectionErrorKind
+    readonly message: string
+    readonly code?: string
+}
+
+export type BittorrentConnectResult =
+    | { readonly ok: true; readonly connection: TorrentClientConnection }
+    | { readonly ok: false; readonly error: BittorrentConnectionError }
+
 export interface ResolvedTorrentClientFeatures {
     readonly magnetLinks: boolean
     readonly labels: boolean
@@ -349,7 +370,7 @@ export interface ElectorrentBridge {
         getPathForFile(file: unknown): string
     }
     bittorrent: {
-        connect(server: BittorrentServerConfig): Promise<TorrentClientConnection>
+        connect(server: BittorrentServerConfig): Promise<BittorrentConnectResult>
         disconnect(): Promise<void>
         getSnapshot(request?: BittorrentSnapshotRequest): Promise<any>
         addTorrentUrl(request: BittorrentAddTorrentUrlRequest): Promise<void>

--- a/test/specs/standard/connection-auth.spec.ts
+++ b/test/specs/standard/connection-auth.spec.ts
@@ -23,6 +23,7 @@ describe("connection authentication", function () {
       throw new Error("Expected a connection problem notification")
     }
     assert.equal(error.title, "Connection problem")
+    assert.equal(error.message, "Incorrect username or password.")
     await this.app.welcomePageIsVisible()
   })
 })


### PR DESCRIPTION
## Summary
- normalize connection failures into concise, transport-safe messages
- classify authentication, timeout, address, network, TLS, server, and response failures across all clients
- validate Deluge login responses and assert authentication message text

## Testing
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/connection-auth.spec.ts"
- npm run test -- --client "transmission" --spec "test/specs/standard/connection-auth.spec.ts"
- npm run test -- --client "rtorrent:latest" --spec "test/specs/standard/connection-auth.spec.ts"
- npm run test -- --client "deluge:2" --spec "test/specs/standard/connection-auth.spec.ts"
- npm run test -- --client "utorrent" --spec "test/specs/standard/connection-auth.spec.ts"