### PR TITLE
feat: add label colors

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -85,6 +85,8 @@ import { notificationService } from "@renderer/app/services/notification"
 torrentApp.service("notificationService", notificationService)
 import { CertificateResponseService } from "@renderer/app/services/certificate-response"
 torrentApp.service("certificateResponseService", CertificateResponseService)
+import { labelColorService } from "@renderer/app/services/label-colors"
+torrentApp.service("labelColorService", labelColorService)
 import { serverService} from "@renderer/app/services/server"
 torrentApp.factory("Server", serverService)
 
@@ -168,6 +170,8 @@ import { LabelsDropdownDirective } from "@renderer/app/directives/labels-dropdow
 torrentApp.directive("labelsDropdown", LabelsDropdownDirective.getInstance())
 import { LabelsMenuDirective } from "@renderer/app/directives/labels-menu/labels-menu.directive"
 torrentApp.directive("labelsMenu", LabelsMenuDirective.getInstance())
+import { LabelChipDirective } from "@renderer/app/directives/label-chip/label-chip.directive"
+torrentApp.directive("labelChip", LabelChipDirective.getInstance())
 import { NewLabelModalDirective } from "@renderer/app/directives/new-label-modal/new-label-modal.directive"
 torrentApp.directive("newLabelModal", NewLabelModalDirective.getInstance())
 import { DragAndDropDirective } from "@renderer/app/directives/drag-and-drop/drag-and-drop.directive"
@@ -216,3 +220,5 @@ import { TorrentSetRatioModalDirective } from "@renderer/app/directives/torrent-
 torrentApp.directive('torrentSetRatioModal', TorrentSetRatioModalDirective.getInstance())
 import { SavedLocationModalDirective } from "@renderer/app/directives/saved-location-modal/saved-location-modal.directive";
 torrentApp.directive('savedLocationModal', SavedLocationModalDirective.getInstance())
+import { LabelColorModalDirective } from "@renderer/app/directives/label-color-modal/label-color-modal.directive";
+torrentApp.directive('labelColorModal', LabelColorModalDirective.getInstance())

--- a/src/renderer/app/bittorrent/abstracttorrent.ts
+++ b/src/renderer/app/bittorrent/abstracttorrent.ts
@@ -276,7 +276,7 @@ export abstract class Torrent implements TorrentProps {
     static COL_LABEL = new Column({
       name: 'Label',
       enabled: true,
-      template: '{{torrent.label}}',
+      template: '<span class="torrent-table-label-chip" ng-if="torrent.label" label-chip="torrent.label"><span class="label-chip-text">{{torrent.label}}</span></span>',
       attribute: 'label',
       sort: Column.ALPHABETICAL
     })

--- a/src/renderer/app/directives/dropdown/dropdown.directive.ts
+++ b/src/renderer/app/directives/dropdown/dropdown.directive.ts
@@ -41,6 +41,10 @@ export class SemanticDropdownDirective implements IDirective {
             action: "hide",
         });
 
+        if ("dropdownNoBlur" in attr) {
+            dropdown.off("blur.dropdown");
+        }
+
         if ("ref" in attr) {
             scope.ref = {
                 clear: doAction("clear"),

--- a/src/renderer/app/directives/label-chip/label-chip.directive.ts
+++ b/src/renderer/app/directives/label-chip/label-chip.directive.ts
@@ -1,0 +1,45 @@
+import { IAugmentedJQuery, IAttributes, IDirective, IDirectiveFactory, IScope } from "angular";
+import type { LabelColorHue, LabelColorOverrides } from "@shared/ipc-contract";
+
+interface LabelChipAttributes extends IAttributes {
+    labelChip?: string
+    labelColor?: string
+    labelColorOverrides?: string
+}
+
+interface LabelColorService {
+    getHue(label?: string, overrides?: LabelColorOverrides): LabelColorHue
+}
+
+export class LabelChipDirective implements IDirective {
+    restrict = "A";
+
+    constructor(private readonly labelColorService: LabelColorService) {}
+
+    static getInstance(): IDirectiveFactory {
+        return ["labelColorService", (labelColorService: LabelColorService) => new LabelChipDirective(labelColorService)] as unknown as IDirectiveFactory;
+    }
+
+    link(scope: IScope, element: IAugmentedJQuery, attrs: LabelChipAttributes) {
+        const getLabel = () => {
+            const expression = attrs.labelChip || attrs.labelColor;
+            const value = expression ? scope.$eval(expression) : undefined;
+            return value || attrs.labelColor || "";
+        };
+
+        const getOverrides = () => attrs.labelColorOverrides ? scope.$eval(attrs.labelColorOverrides) : undefined;
+
+        const render = () => {
+            const label = getLabel();
+            const overrides = getOverrides();
+            const hue = this.labelColorService.getHue(label, overrides);
+
+            element.addClass("ui circular label label-chip");
+            element.css("--label-hue", String(hue));
+            element.attr("data-label-hue", String(hue));
+        };
+
+        scope.$watch(getLabel, render);
+        scope.$watch(getOverrides, render, true);
+    }
+}

--- a/src/renderer/app/directives/label-color-modal/label-color-modal.controller.ts
+++ b/src/renderer/app/directives/label-color-modal/label-color-modal.controller.ts
@@ -1,0 +1,64 @@
+import { IScope } from "angular";
+import { ModalController } from "@renderer/app/directives/modal/modal.controller";
+import type { LabelColorHue } from "@shared/ipc-contract";
+import { LABEL_COLOR_HUES } from "@renderer/app/services/label-colors";
+
+interface LabelColorModalOpenOptions {
+    currentHue?: LabelColorHue
+    label: string
+    onSelect?: (hue: LabelColorHue) => void
+}
+
+interface LabelColorModalScope extends IScope {
+    modalId?: string
+}
+
+export class LabelColorModalController {
+    static $inject = ["$scope"];
+
+    modalref: ModalController;
+    readonly hues = LABEL_COLOR_HUES;
+    readonly modalId: string;
+    label = "";
+    selectedHue: LabelColorHue = 220;
+    private onSelect?: (hue: LabelColorHue) => void;
+
+    constructor(private readonly scope: LabelColorModalScope) {
+        this.modalId = scope.modalId || "labelColorModal";
+    }
+
+    open(options: LabelColorModalOpenOptions) {
+        this.label = options.label;
+        this.selectedHue = options.currentHue ?? 220;
+        this.onSelect = options.onSelect;
+        this.modalref?.showModal();
+    }
+
+    close() {
+        this.modalref?.hideModal();
+    }
+
+    onHidden() {
+        this.label = "";
+        this.selectedHue = 220;
+        this.onSelect = undefined;
+    }
+
+    selectHue(hue: LabelColorHue) {
+        this.selectedHue = hue;
+    }
+
+    isSelected(hue: LabelColorHue) {
+        return this.selectedHue === hue;
+    }
+
+    getHueStyle(hue: LabelColorHue) {
+        return { "--label-hue": hue };
+    }
+
+    save() {
+        this.onSelect?.(this.selectedHue);
+        this.close();
+        this.scope.$applyAsync();
+    }
+}

--- a/src/renderer/app/directives/label-color-modal/label-color-modal.directive.ts
+++ b/src/renderer/app/directives/label-color-modal/label-color-modal.directive.ts
@@ -1,0 +1,17 @@
+import { IDirective, IDirectiveFactory } from "angular";
+import { LabelColorModalController } from "./label-color-modal.controller";
+import html from "./label-color-modal.template.html";
+
+export class LabelColorModalDirective implements IDirective {
+    restrict = "E";
+    scope = {
+        modalId: "@?",
+    };
+    template = html;
+    controller = LabelColorModalController;
+    controllerAs = "ctl";
+
+    static getInstance(): IDirectiveFactory {
+        return () => new LabelColorModalDirective();
+    }
+}

--- a/src/renderer/app/directives/label-color-modal/label-color-modal.template.html
+++ b/src/renderer/app/directives/label-color-modal/label-color-modal.template.html
@@ -1,0 +1,36 @@
+<modal
+    size="small"
+    id="{{ ctl.modalId }}"
+    on-hidden="ctl.onHidden()"
+    ng-ref="ctl.modalref">
+    <i class="close icon"></i>
+    <div class="header">
+        Label color
+    </div>
+    <div class="content">
+        <p>Choose a theme-aware hue for <strong>{{ ctl.label }}</strong>.</p>
+        <div class="label-color-picker-grid">
+            <button
+                type="button"
+                class="label-color-picker-option"
+                data-role="label-color-option"
+                data-hue="{{ hue }}"
+                title="Hue {{ hue }}"
+                ng-repeat="hue in ctl.hues track by hue"
+                ng-class="{'is-selected': ctl.isSelected(hue)}"
+                ng-attr-style="--label-hue: {{ hue }}"
+                ng-click="ctl.selectHue(hue)">
+                <span class="label-color-picker-dot"></span>
+            </button>
+        </div>
+    </div>
+    <div class="actions">
+        <button type="button" class="ui black button" ng-click="ctl.close()">
+            Cancel
+        </button>
+        <button type="button" class="ui green right labeled icon button" data-role="label-color-save" ng-click="ctl.save()">
+            Save color
+            <i class="checkmark icon"></i>
+        </button>
+    </div>
+</modal>

--- a/src/renderer/app/directives/labels-menu/labels-menu.template.html
+++ b/src/renderer/app/directives/labels-menu/labels-menu.template.html
@@ -1,21 +1,22 @@
-<div data-role="labels" dropdown class="ui icon top left pointing dropdown button" ng-class="{disabled: enabled}">
+<div data-role="labels" dropdown dropdown-no-blur class="ui icon top left pointing dropdown button" ng-class="{disabled: enabled}">
     <i class="tag icon"></i>
     <div class="menu">
-        <div class="ui icon search input">
+        <div class="ui icon input">
             <i class="search icon"></i>
-            <input type="text" placeholder="Search labels...">
+            <input type="text" placeholder="Search labels..." ng-model="labelSearch">
         </div>
         <div data-role="remove-label" class="item" ng-click="action('')"><i class="remove icon"></i> Remove Label</div>
         <div data-role="new-label" class="item" ng-click="openNewLabelModal()"><i class="edit icon"></i> New Label</div>
         <div class="divider"></div>
         <div class="scrolling menu">
-            <div class="item label-dropdown-option" data-role="label-option" data-label="{{label}}" ng-repeat="label in labels" ng-click="action(label)">
+            <div class="item label-dropdown-option" data-role="label-option" data-label="{{label}}" ng-repeat="label in labels | filter:labelSearch" ng-click="action(label)">
                 <span class="label-dropdown-chip" label-chip="label">
                     <span class="label-chip-text">{{label}}</span>
                 </span>
             </div>
             <div></div>
         </div>
+        <div class="message" ng-if="labelSearch && (labels | filter:labelSearch).length === 0">No results found</div>
     </div>
 </div>
 

--- a/src/renderer/app/directives/labels-menu/labels-menu.template.html
+++ b/src/renderer/app/directives/labels-menu/labels-menu.template.html
@@ -9,7 +9,11 @@
         <div data-role="new-label" class="item" ng-click="openNewLabelModal()"><i class="edit icon"></i> New Label</div>
         <div class="divider"></div>
         <div class="scrolling menu">
-            <div class="item" data-role="label-option" data-label="{{label}}" ng-repeat="label in labels" ng-click="action(label)">{{label}}</div>
+            <div class="item label-dropdown-option" data-role="label-option" data-label="{{label}}" ng-repeat="label in labels" ng-click="action(label)">
+                <span class="label-dropdown-chip" label-chip="label">
+                    <span class="label-chip-text">{{label}}</span>
+                </span>
+            </div>
             <div></div>
         </div>
     </div>

--- a/src/renderer/app/directives/settings-advanced/settings-advanced.controller.ts
+++ b/src/renderer/app/directives/settings-advanced/settings-advanced.controller.ts
@@ -1,6 +1,7 @@
-import { IScope } from "angular";
-import type { SavedLocationConfig, TorrentUploadOptions } from "@shared/ipc-contract";
+import { IRootScopeService, IScope } from "angular";
+import type { LabelColorHue, LabelColorOverrides, SavedLocationConfig, TorrentUploadOptions } from "@shared/ipc-contract";
 import { SavedLocationModalController } from "@renderer/app/directives/saved-location-modal/saved-location-modal.controller";
+import { LabelColorModalController } from "@renderer/app/directives/label-color-modal/label-color-modal.controller";
 
 interface SettingsAdvancedScope extends IScope {
     server?: {
@@ -8,16 +9,26 @@ interface SettingsAdvancedScope extends IScope {
         savedLocations?: SavedLocationConfig[]
         defaultUploadOptionsEnabled?: boolean
         defaultUploadOptions?: TorrentUploadOptions
+        labelColors?: LabelColorOverrides
         getDisplayName?: () => string
     }
 }
 
+interface LabelColorService {
+    getHue(label?: string, overrides?: LabelColorOverrides): LabelColorHue
+}
+
 export class SettingsAdvancedController {
-    static $inject = ["$scope"];
+    static $inject = ["$scope", "$rootScope", "labelColorService"];
 
     savedLocationModalRef: SavedLocationModalController;
+    labelColorModalRef: LabelColorModalController;
 
-    constructor(private readonly scope: SettingsAdvancedScope) {}
+    constructor(
+        private readonly scope: SettingsAdvancedScope,
+        private readonly rootScope: IRootScopeService & { currentLabelsByServer?: Record<string, string[]> },
+        private readonly labelColorService: LabelColorService,
+    ) {}
 
     hasServer() {
         return !!this.scope.server?.id;
@@ -25,6 +36,61 @@ export class SettingsAdvancedController {
 
     getServerName() {
         return this.scope.server?.getDisplayName?.() || "current server";
+    }
+
+    getLabels() {
+        const labels = new Set<string>();
+
+        const serverId = this.scope.server?.id;
+        const serverLabels = serverId ? this.rootScope.currentLabelsByServer?.[serverId] || [] : [];
+
+        serverLabels.forEach((label) => {
+            if (label) {
+                labels.add(label);
+            }
+        });
+
+        Object.keys(this.getLabelColors()).forEach((label) => labels.add(label));
+
+        return Array.from(labels).sort((left, right) => left.localeCompare(right));
+    }
+
+    getLabelColors() {
+        if (!this.scope.server) {
+            return {};
+        }
+
+        if (!this.scope.server.labelColors || typeof this.scope.server.labelColors !== "object") {
+            this.scope.server.labelColors = {};
+        }
+
+        return this.scope.server.labelColors;
+    }
+
+    getLabelHue(label: string) {
+        return this.labelColorService.getHue(label, this.getLabelColors());
+    }
+
+    hasCustomLabelColor(label: string) {
+        return !!this.getLabelColors()[label];
+    }
+
+    openLabelColorModal(label: string) {
+        if (!this.hasServer()) {
+            return;
+        }
+
+        this.labelColorModalRef?.open({
+            label,
+            currentHue: this.getLabelHue(label),
+            onSelect: (hue) => {
+                this.getLabelColors()[label] = hue;
+            },
+        });
+    }
+
+    resetLabelColor(label: string) {
+        delete this.getLabelColors()[label];
     }
 
     getSavedLocations() {

--- a/src/renderer/app/directives/settings-advanced/settings-advanced.controller.ts
+++ b/src/renderer/app/directives/settings-advanced/settings-advanced.controller.ts
@@ -50,8 +50,6 @@ export class SettingsAdvancedController {
             }
         });
 
-        Object.keys(this.getLabelColors()).forEach((label) => labels.add(label));
-
         return Array.from(labels).sort((left, right) => left.localeCompare(right));
     }
 

--- a/src/renderer/app/directives/settings-advanced/settings-advanced.template.html
+++ b/src/renderer/app/directives/settings-advanced/settings-advanced.template.html
@@ -57,6 +57,55 @@
 
     <div class="ui divider"></div>
 
+    <div data-role="advanced-label-colors-row">
+        <div class="ui small header">Label colors</div>
+        <p>Override theme-aware label hues for <strong>{{ ctl.getServerName() }}</strong>. The saved value is the hue, while lightness and chroma stay theme-controlled.</p>
+        <div style="margin-left: 2rem;">
+            <div class="ui divided list settings-label-color-list" ng-if="ctl.hasServer() && ctl.getLabels().length">
+                <div
+                    class="item settings-label-color-item"
+                    ng-repeat="label in ctl.getLabels() track by label"
+                    data-role="settings-label-color-item"
+                    data-label="{{ label }}">
+                    <div class="settings-label-color-row">
+                        <span class="settings-label-color-chip" label-chip="label" label-color-overrides="server.labelColors">
+                            <span class="label-chip-text">{{ label }}</span>
+                        </span>
+                        <span class="settings-label-color-hue" title="Hue {{ ctl.getLabelHue(label) }}" ng-attr-style="--label-hue: {{ ctl.getLabelHue(label) }}">
+                            <span class="label-color-preview-dot"></span>
+                        </span>
+                        <button
+                            type="button"
+                            class="ui tiny button"
+                            data-role="settings-label-color-change"
+                            ng-click="ctl.openLabelColorModal(label)">
+                            Change
+                        </button>
+                        <button
+                            type="button"
+                            class="ui tiny icon button"
+                            title="Use deterministic color"
+                            data-role="settings-label-color-reset"
+                            ng-click="ctl.resetLabelColor(label)"
+                            ng-disabled="!ctl.hasCustomLabelColor(label)">
+                            <i class="undo icon"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="ui info message" ng-if="ctl.hasServer() && !ctl.getLabels().length">
+                <p>No labels found for this server yet. Labels will appear here after they are reported by the connected client.</p>
+            </div>
+
+            <div class="ui warning message" ng-if="!ctl.hasServer()">
+                <p>Connect to a server to manage label colors.</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="ui divider"></div>
+
     <div data-role="advanced-saved-locations-row">
         <div class="ui small header">Saved locations</div>
         <p>Save reusable upload locations. These locations appear in the upload modal for this server.</p>
@@ -102,3 +151,4 @@
 </div>
 
 <saved-location-modal modal-id="settingsSavedLocationModal" ng-ref="ctl.savedLocationModalRef"></saved-location-modal>
+<label-color-modal modal-id="settingsLabelColorModal" ng-ref="ctl.labelColorModalRef"></label-color-modal>

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.template.html
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.template.html
@@ -5,12 +5,29 @@
 <ul class="filter label">
     <span ng-if="ctl.displayEmpty()" class="meta text">{{ctl.emptyText}}</span>
     <li ng-if="ctl.hasSpecialItem()" ng-attr-data-label="{{ctl.itemAttribute == 'label' ? ctl.specialItemValue : undefined}}" ng-attr-data-tracker="{{ctl.itemAttribute == 'tracker' ? ctl.specialItemValue : undefined}}">
-        <div class="ui fluid torrent tag label" ng-click="ctl.select(ctl.specialItemValue)" ng-class="{blue: ctl.isActive(ctl.specialItemValue)}">
+        <div
+            class="ui circular label label-chip torrent-sidebar-label-chip torrent-sidebar-label-chip--empty"
+            ng-if="ctl.itemAttribute == 'label'"
+            ng-click="ctl.select(ctl.specialItemValue)"
+            ng-class="{'is-active': ctl.isActive(ctl.specialItemValue)}">
+            <span class="label-chip-text">{{ctl.itemText(ctl.specialItemValue)}}</span>
+            <span class="label-chip-active-dot" ng-if="ctl.isActive(ctl.specialItemValue)"></span>
+        </div>
+        <div class="ui fluid torrent tag label" ng-if="ctl.itemAttribute != 'label'" ng-click="ctl.select(ctl.specialItemValue)" ng-class="{blue: ctl.isActive(ctl.specialItemValue)}">
             {{ctl.itemText(ctl.specialItemValue)}}
         </div>
     </li>
     <li ng-attr-data-label="{{ctl.itemAttribute == 'label' ? item : undefined}}" ng-attr-data-tracker="{{ctl.itemAttribute == 'tracker' ? item : undefined}}" ng-repeat="item in ctl.items track by item">
-        <div class="ui fluid torrent tag label" ng-click="ctl.select(item)" ng-class="{blue: ctl.isActive(item)}">
+        <div
+            class="torrent-sidebar-label-chip"
+            ng-if="ctl.itemAttribute == 'label'"
+            label-chip="item"
+            ng-click="ctl.select(item)"
+            ng-class="{'is-active': ctl.isActive(item)}">
+            <span class="label-chip-text">{{ctl.itemText(item)}}</span>
+            <span class="label-chip-active-dot" ng-if="ctl.isActive(item)"></span>
+        </div>
+        <div class="ui fluid torrent tag label" ng-if="ctl.itemAttribute != 'label'" ng-click="ctl.select(item)" ng-class="{blue: ctl.isActive(item)}">
             {{ctl.itemText(item)}}
         </div>
     </li>

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -405,6 +405,10 @@ export class TorrentsPageController {
             $scope.torrents = {};
             $scope.arrayTorrents = [];
             setLabels([]);
+            if ($rootScope.$server?.id) {
+                $rootScope.currentLabelsByServer = $rootScope.currentLabelsByServer || {};
+                $rootScope.currentLabelsByServer[$rootScope.$server.id] = $scope.labels;
+            }
             $scope.trackers = [];
         }
 
@@ -965,6 +969,11 @@ export class TorrentsPageController {
                         $scope.labels.push(label);
                     }
                 });
+            }
+
+            if ($rootScope.$server?.id) {
+                $rootScope.currentLabelsByServer = $rootScope.currentLabelsByServer || {};
+                $rootScope.currentLabelsByServer[$rootScope.$server.id] = $scope.labels;
             }
         }
 

--- a/src/renderer/app/services/label-colors.ts
+++ b/src/renderer/app/services/label-colors.ts
@@ -1,0 +1,40 @@
+import type { LabelColorHue, LabelColorOverrides } from "@shared/ipc-contract";
+
+export const LABEL_COLOR_HUE_STEP = 20;
+export const LABEL_COLOR_HUES: LabelColorHue[] = Array.from(
+    { length: 360 / LABEL_COLOR_HUE_STEP },
+    (_unused, index) => index * LABEL_COLOR_HUE_STEP,
+);
+
+export function normalizeLabelColorHue(value: unknown): LabelColorHue | undefined {
+    const hue = Number(value);
+
+    if (!Number.isFinite(hue)) {
+        return undefined;
+    }
+
+    return (((Math.round(hue) % 360) + 360) % 360) as LabelColorHue;
+}
+
+export function getDeterministicLabelColorHue(label?: string): LabelColorHue {
+    const normalizedLabel = (label || "").trim().toLowerCase();
+    let hash = 0;
+
+    for (let index = 0; index < normalizedLabel.length; index += 1) {
+        hash = ((hash << 5) - hash + normalizedLabel.charCodeAt(index)) | 0;
+    }
+
+    return LABEL_COLOR_HUES[Math.abs(hash) % LABEL_COLOR_HUES.length];
+}
+
+export function getLabelColorHue(label?: string, overrides?: LabelColorOverrides): LabelColorHue {
+    const override = label ? normalizeLabelColorHue(overrides?.[label]) : undefined;
+
+    return override ?? getDeterministicLabelColorHue(label);
+}
+
+export const labelColorService = ["$rootScope", function($rootScope: angular.IRootScopeService & { $server?: { labelColors?: LabelColorOverrides } }) {
+    this.hues = LABEL_COLOR_HUES;
+    this.getHue = (label?: string, overrides?: LabelColorOverrides) => getLabelColorHue(label, overrides || $rootScope.$server?.labelColors);
+    this.normalizeHue = normalizeLabelColorHue;
+}];

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -2,7 +2,8 @@ import _ from "underscore"
 import { Torrent } from "@renderer/app/bittorrent"
 import { parseServerAddressInput, sanitizeServerAddress } from "@shared/server-address"
 import type { CertificateResponseService } from "@renderer/app/services/certificate-response"
-import type { SavedLocationConfig, StoredServerConfig, TorrentUploadOptions } from "@shared/ipc-contract"
+import type { LabelColorHue, LabelColorOverrides, SavedLocationConfig, StoredServerConfig, TorrentUploadOptions } from "@shared/ipc-contract"
+import { normalizeLabelColorHue } from "@renderer/app/services/label-colors"
 
 export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclients', 'certificateResponseService',
     function($q, $notify, $bittorrent, $btclients, certificateResponseService: CertificateResponseService) {
@@ -70,6 +71,7 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                 this.lastused = -1
                 this.columns = this.defaultColumns()
                 this.savedLocations = []
+                this.labelColors = {}
                 this.defaultUploadOptionsEnabled = false
                 this.defaultUploadOptions = normalizeDefaultUploadOptions()
             }
@@ -93,6 +95,20 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
             return Object.assign({ startTorrent: true }, options || {})
         }
 
+        function normalizeLabelColors(labelColors?: LabelColorOverrides) {
+            if (!labelColors || typeof labelColors !== "object") {
+                return {}
+            }
+
+            return Object.keys(labelColors).reduce((normalized: Record<string, LabelColorHue>, label) => {
+                const hue = normalizeLabelColorHue(labelColors[label])
+                if (label && hue !== undefined) {
+                    normalized[label] = hue
+                }
+                return normalized
+            }, {})
+        }
+
         Server.prototype.fromJson = function(data) {
             this.name = data.name
             this.id = data.id
@@ -112,6 +128,7 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
             this.savedLocations = normalizeSavedLocations(data.savedLocations)
             this.defaultUploadOptionsEnabled = data.defaultUploadOptionsEnabled === true
             this.defaultUploadOptions = normalizeDefaultUploadOptions(data.defaultUploadOptions)
+            this.labelColors = normalizeLabelColors(data.labelColors)
         };
 
         Server.prototype.json = function() {
@@ -133,6 +150,7 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
                 savedLocations: normalizeSavedLocations(this.savedLocations),
                 defaultUploadOptionsEnabled: this.defaultUploadOptionsEnabled === true,
                 defaultUploadOptions: normalizeDefaultUploadOptions(this.defaultUploadOptions),
+                labelColors: normalizeLabelColors(this.labelColors),
             }
         };
 

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -509,10 +509,16 @@ torrent-sidebar + .main-panel {
     padding: 0.35em 0.65em;
 }
 .torrent-table-label-chip {
-    line-height: 1;
+    line-height: 1 !important;
 }
-.label-dropdown-option.item {
+.ui.dropdown .menu > .label-dropdown-option.item {
     display: flex !important;
+    padding-top: 0.35rem !important;
+    padding-bottom: 0.35rem !important;
+
+    &:first-child {
+        margin-top: .5rem;
+    }
 }
 .torrent.tag {
     background-color: @highlightBackground;

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -452,6 +452,65 @@ torrent-sidebar + .main-panel {
 .sidebar-flyout .filter.label {
     padding-right: 24px;
 }
+.ui.circular.label.label-chip {
+    align-items: center;
+    background: oklch(@labelChipBackgroundLightness @labelChipBackgroundChroma var(--label-hue, 225));
+    border: 1px solid oklch(@labelChipBorderLightness @labelChipBorderChroma var(--label-hue, 225));
+    color: @textColor;
+    display: inline-flex;
+    gap: 0.45em;
+    line-height: 1.15;
+    max-width: 100%;
+    padding-left: .75em !important;
+    padding-right: .75em !important;
+}
+.label-chip-active-dot {
+    background: @textColor;
+    border-radius: 999px;
+    display: inline-block;
+    flex: 0 0 auto;
+    height: 0.55em;
+    margin-left: auto;
+    width: 0.55em;
+}
+.label-chip-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.torrent-sidebar-label-chip {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    font-size: 1rem;
+    font-weight: 400;
+    min-height: 0;
+    padding: 0.35em 0.55em;
+    width: 100%;
+}
+.torrent-sidebar-label-chip:hover,
+.torrent-sidebar-label-chip.is-active {
+    // box-shadow: inset 0 0 0 1px oklch(@labelChipDotLightness @labelChipDotChroma var(--label-hue, 225));
+    border: 2px solid oklch(@labelChipDotLightness @labelChipDotChroma var(--label-hue, 225));
+}
+.ui.circular.label.torrent-sidebar-label-chip--empty {
+    background: @highlightBackground;
+    border: 1px solid @borderColor;
+    color: @textColor;
+    line-height: 1.15;
+    justify-content: flex-start;
+}
+.torrent-sidebar-label-chip--empty .label-chip-active-dot {
+    background: @textColor;
+}
+.torrent-table-label-chip,
+.label-dropdown-chip {
+    padding: 0.35em 0.65em;
+}
+.label-dropdown-option.item {
+    display: flex !important;
+}
 .torrent.tag {
     background-color: @highlightBackground;
 }

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -508,6 +508,9 @@ torrent-sidebar + .main-panel {
 .label-dropdown-chip {
     padding: 0.35em 0.65em;
 }
+.torrent-table-label-chip {
+    line-height: 1;
+}
 .label-dropdown-option.item {
     display: flex !important;
 }

--- a/src/renderer/styles/app/partials/settings.less
+++ b/src/renderer/styles/app/partials/settings.less
@@ -54,3 +54,78 @@
     font-size: 1.1em;
     margin: 0 !important;
 }
+
+.settings-label-color-list .settings-label-color-item {
+    display: block !important;
+}
+
+.settings-label-color-row {
+    align-items: center;
+    display: flex;
+    gap: .75rem;
+    width: 100%;
+}
+
+.settings-label-color-chip {
+    flex: 0 1 auto;
+    min-width: 0;
+    padding: 0.45em 0.75em;
+}
+
+.settings-label-color-row > button:first-of-type {
+    margin-left: auto;
+}
+
+.settings-label-color-hue {
+    align-items: center;
+    display: inline-flex;
+    flex: 0 0 auto;
+    justify-content: center;
+    width: 2rem;
+}
+
+.label-color-preview-dot,
+.label-color-picker-dot {
+    background: oklch(@labelChipDotLightness @labelChipDotChroma var(--label-hue, 225));
+    border-radius: 999px;
+    display: inline-block;
+}
+
+.label-color-preview-dot {
+    height: 0.9rem;
+    width: 0.9rem;
+}
+
+.label-color-picker-grid {
+    display: grid;
+    gap: .45rem;
+    grid-template-columns: repeat(auto-fill, minmax(2.4rem, 1fr));
+}
+
+.label-color-picker-option {
+    align-items: center;
+    background: transparent;
+    border: 1px solid @borderColor;
+    border-radius: 999px;
+    cursor: pointer;
+    display: inline-flex;
+    height: 2.4rem;
+    justify-content: center;
+    padding: 0;
+}
+
+.label-color-picker-option:hover,
+.label-color-picker-option.is-selected {
+    background: @highlightBackground;
+    border-color: @selectedBorderColor;
+}
+
+.label-color-picker-option.is-selected {
+    box-shadow: 0 0 0 2px oklch(@labelChipDotLightness @labelChipDotChroma var(--label-hue, 225));
+}
+
+.label-color-picker-dot {
+    height: 1.05rem;
+    width: 1.05rem;
+}
+

--- a/src/renderer/styles/app/partials/settings.less
+++ b/src/renderer/styles/app/partials/settings.less
@@ -128,4 +128,3 @@
     height: 1.05rem;
     width: 1.05rem;
 }
-

--- a/src/renderer/styles/themes/dark/globals/site.variables
+++ b/src/renderer/styles/themes/dark/globals/site.variables
@@ -57,6 +57,14 @@
 @negativeTextColor: #fff;
 @negativeBackgroundColor: #ee5f5b;
 @negativeBorderColor: darken(spin(@negativeBackgroundColor, -10), 3%);
+@labelChipBackgroundLightness : 32%;
+@labelChipBackgroundChroma    : 0.035;
+@labelChipBorderLightness     : 50%;
+@labelChipBorderChroma        : 0.070;
+@labelChipTextLightness       : 78%;
+@labelChipTextChroma          : 0.080;
+@labelChipDotLightness        : 68%;
+@labelChipDotChroma           : 0.110;
 
 
 @darkTextColor               : rgba(255, 255, 255, 0.85);

--- a/src/renderer/styles/themes/light/globals/site.variables
+++ b/src/renderer/styles/themes/light/globals/site.variables
@@ -7,3 +7,11 @@
 @highlightBackground : #F5F5F5;
 @overlayBackground   : @pageBackground;
 @popupBackground     : rgba(255, 255, 255, 0.5);
+@labelChipBackgroundLightness : 94%;
+@labelChipBackgroundChroma    : 0.025;
+@labelChipBorderLightness     : 78%;
+@labelChipBorderChroma        : 0.060;
+@labelChipTextLightness       : 38%;
+@labelChipTextChroma          : 0.100;
+@labelChipDotLightness        : 58%;
+@labelChipDotChroma           : 0.120;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -141,6 +141,10 @@ export interface LaunchPayload {
     torrentFiles: PendingTorrentUploadFile[]
 }
 
+export type LabelColorHue = number
+
+export type LabelColorOverrides = Partial<Record<string, LabelColorHue>>
+
 export interface StoredServerConfig {
     name?: string
     id: string
@@ -159,6 +163,7 @@ export interface StoredServerConfig {
     savedLocations?: SavedLocationConfig[]
     defaultUploadOptionsEnabled?: boolean
     defaultUploadOptions?: TorrentUploadOptions
+    labelColors?: LabelColorOverrides
 }
 
 export interface SavedLocationConfig {

--- a/test/specs/mock/action-header-label-search.spec.ts
+++ b/test/specs/mock/action-header-label-search.spec.ts
@@ -1,0 +1,71 @@
+import chai from "chai"
+import { $, $$, browser } from "@wdio/globals"
+import { eventually } from "../../e2e/eventually"
+import { configureSpec } from "../../framework/fixture"
+
+const assert: Chai.AssertStatic = chai.assert
+
+const torrents = [
+  { hash: "1".padStart(40, "0"), name: "Alpha torrent", category: "alpha-label" },
+  { hash: "2".padStart(40, "0"), name: "Beta torrent", category: "beta-label" },
+  { hash: "3".padStart(40, "0"), name: "Gamma torrent", category: "gamma-label" },
+]
+
+describe("mock action header label search", function () {
+  configureSpec({ clearTorrents: false })
+
+  before(async function () {
+    await invokeMockAction("clearMockedTorrents")
+    for (const torrent of torrents) {
+      await invokeMockAction("addMockedTorrent", torrent)
+    }
+
+    await eventually(async () => (await $$("#torrentTable tbody tr[data-hash]")).length)
+      .equals(torrents.length)
+  })
+
+  it("filters the labels in the action header dropdown", async function () {
+    const torrentRow = $(`#torrentTable tbody tr[data-hash='${torrents[0].hash}']`)
+    await torrentRow.waitForClickable()
+    await torrentRow.click()
+
+    const labelsDropdown = $("#torrent-action-header div[data-role='labels']")
+    await labelsDropdown.waitForClickable()
+    await labelsDropdown.click()
+
+    const searchInput = labelsDropdown.$("input[placeholder='Search labels...']")
+    await searchInput.waitForDisplayed()
+    assert.notInclude(await searchInput.parentElement().getAttribute("class"), "search")
+    await searchInput.setValue("beta")
+
+    await eventually(getDisplayedLabels).satisfies(
+      "only include beta-label",
+      (labels) => labels.length === 1 && labels[0] === "beta-label",
+    )
+    assert.deepEqual(await getDisplayedLabels(), ["beta-label"])
+
+    await searchInput.setValue("missing")
+    await eventually(getDisplayedLabels).satisfies("be empty", (labels) => labels.length === 0)
+
+    const noResults = labelsDropdown.$(".message")
+    await noResults.waitForDisplayed()
+    assert.equal(await noResults.getText(), "No results found")
+  })
+})
+
+async function invokeMockAction(action: string, ...args: any[]) {
+  await browser.execute(async (request) => {
+    await (window as any).electorrent.bittorrent.invokeAction(request)
+  }, { action, args })
+}
+
+async function getDisplayedLabels() {
+  const options = await $$("#torrent-action-header [data-role='label-option']")
+  const labels: string[] = []
+  for (const option of options) {
+    if (await option.isDisplayed()) {
+      labels.push((await option.getAttribute("data-label")) || "")
+    }
+  }
+  return labels
+}


### PR DESCRIPTION
## Summary
- add deterministic, theme-aware label colors with per-server hue overrides
- keep torrent table row heights consistent for labeled torrents
- show color overrides only for labels currently reported by the client

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-labels.spec.ts"`