### PR TITLE
fix: submit modal forms on Enter

### DIFF
--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
@@ -1,4 +1,4 @@
-<form modal size="small" id="uploadTorrentModal" on-show="ctl.onShow()" on-hidden="ctl.onHidden()" ng-submit="ctl.uploadCurrentTorrent()" ng-ref="ctl.modalref">
+<modal size="small" id="uploadTorrentModal" on-show="ctl.onShow()" on-hidden="ctl.onHidden()" ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
         Add Torrent
@@ -7,27 +7,29 @@
         </div>
     </div>
     <div class="content">
-        <h4 class="ui header">
-            <div class="content">
-                Add a New Torrent
-                <div class="sub header">{{ ctl.getCurrentTorrentUploadLabel() }}</div>
-            </div>
-        </h4>
-        <torrent-upload-form
-            loading="ctl.isLoading"
-            options="ctl.uploadOptions"
-            labels="labels"
-            can-add-saved-location="!!ctl.rootScope.$server"
-            on-add-saved-location="ctl.openSavedLocationModal()"></torrent-upload-form>
+        <form id="upload-torrent-form" ng-submit="ctl.uploadCurrentTorrent()">
+            <h4 class="ui header">
+                <div class="content">
+                    Add a New Torrent
+                    <div class="sub header">{{ ctl.getCurrentTorrentUploadLabel() }}</div>
+                </div>
+            </h4>
+            <torrent-upload-form
+                loading="ctl.isLoading"
+                options="ctl.uploadOptions"
+                labels="labels"
+                can-add-saved-location="!!ctl.rootScope.$server"
+                on-add-saved-location="ctl.openSavedLocationModal()"></torrent-upload-form>
+        </form>
     </div>
     <div class="actions">
         <button type="button" class="ui black button" ng-class="{disabled: ctl.isLoading}" ng-click="ctl.discardCurrentTorrent()">
             Cancel
         </button>
-        <button type="submit" class="ui green right labeled icon button" ng-class="{disabled: ctl.isLoading}">
+        <button type="submit" form="upload-torrent-form" class="ui green right labeled icon button" ng-class="{disabled: ctl.isLoading}">
             Add Torrent
             <i class="plus icon"></i>
         </button>
     </div>
-</form>
+</modal>
 <saved-location-modal modal-id="uploadSavedLocationModal" ng-ref="ctl.savedLocationModalRef"></saved-location-modal>

--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
@@ -1,4 +1,4 @@
-<modal size="small" id="uploadTorrentModal" on-show="ctl.onShow()" on-hidden="ctl.onHidden()" ng-ref="ctl.modalref">
+<form modal size="small" id="uploadTorrentModal" on-show="ctl.onShow()" on-hidden="ctl.onHidden()" ng-submit="ctl.uploadCurrentTorrent()" ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
         Add Torrent
@@ -21,13 +21,13 @@
             on-add-saved-location="ctl.openSavedLocationModal()"></torrent-upload-form>
     </div>
     <div class="actions">
-        <button class="ui black button" ng-class="{disabled: ctl.isLoading}" ng-click="ctl.discardCurrentTorrent()">
+        <button type="button" class="ui black button" ng-class="{disabled: ctl.isLoading}" ng-click="ctl.discardCurrentTorrent()">
             Cancel
         </button>
-        <button type="submit" class="ui green right labeled icon button" ng-class="{disabled: ctl.isLoading}" ng-click="ctl.uploadCurrentTorrent()">
+        <button type="submit" class="ui green right labeled icon button" ng-class="{disabled: ctl.isLoading}">
             Add Torrent
             <i class="plus icon"></i>
         </button>
     </div>
-</modal>
+</form>
 <saved-location-modal modal-id="uploadSavedLocationModal" ng-ref="ctl.savedLocationModalRef"></saved-location-modal>

--- a/src/renderer/app/directives/modal/modal.directive.ts
+++ b/src/renderer/app/directives/modal/modal.directive.ts
@@ -70,7 +70,7 @@ export class ModalDirective implements IDirective {
         });
 
         scope.applyAndClose = function() {
-            if (!attr.approve || this.invokeExpression(scope, attr.approve)) {
+            if (!attr.approve || this.invokeExpression(scope, attr.approve) !== false) {
                 modal.modal('hide')
             }
         }.bind(this)

--- a/src/renderer/app/directives/new-label-modal/new-label-modal.template.html
+++ b/src/renderer/app/directives/new-label-modal/new-label-modal.template.html
@@ -1,32 +1,33 @@
-<modal
+<form modal
     size="tiny"
     approve="approve()"
+    ng-submit="applyAndClose()"
     id="newLabelModal">
     <i class="close icon"></i>
     <div class="header">
         New Label
     </div>
     <div class="content">
-        <form class="ui form" ng-submit="applyAndClose()">
+        <div class="ui form">
             <div class="field">
                 <div class="ui fluid left icon input">
                     <i class="tag icon"></i>
                     <input type="text" name="label" maxlength="36" ng-model="data.label" placeholder="Label Name">
                 </div>
             </div>
-        </form>
+        </div>
     </div>
     <div class="actions">
         <button type="button" class="ui black deny button">
             Cancel
         </button>
         <button
-            type="button"
-            class="ui green right labeled icon approve button"
+            type="submit"
+            class="ui green right labeled icon button"
             ng-class="{ disabled: !data.label }"
             ng-disabled="!data.label">
             Apply Label
             <i class="tag icon"></i>
         </button>
     </div>
-</modal>
+</form>

--- a/src/renderer/app/directives/new-label-modal/new-label-modal.template.html
+++ b/src/renderer/app/directives/new-label-modal/new-label-modal.template.html
@@ -1,21 +1,20 @@
-<form modal
+<modal
     size="tiny"
     approve="approve()"
-    ng-submit="applyAndClose()"
     id="newLabelModal">
     <i class="close icon"></i>
     <div class="header">
         New Label
     </div>
     <div class="content">
-        <div class="ui form">
+        <form id="new-label-form" class="ui form" ng-submit="applyAndClose()">
             <div class="field">
                 <div class="ui fluid left icon input">
                     <i class="tag icon"></i>
                     <input type="text" name="label" maxlength="36" ng-model="data.label" placeholder="Label Name">
                 </div>
             </div>
-        </div>
+        </form>
     </div>
     <div class="actions">
         <button type="button" class="ui black deny button">
@@ -23,6 +22,7 @@
         </button>
         <button
             type="submit"
+            form="new-label-form"
             class="ui green right labeled icon button"
             ng-class="{ disabled: !data.label }"
             ng-disabled="!data.label">
@@ -30,4 +30,4 @@
             <i class="tag icon"></i>
         </button>
     </div>
-</form>
+</modal>

--- a/src/renderer/app/directives/rename-server-modal/rename-server-modal.template.html
+++ b/src/renderer/app/directives/rename-server-modal/rename-server-modal.template.html
@@ -1,13 +1,14 @@
-<modal
+<form modal
     size="small"
     approve="approve()"
+    ng-submit="applyAndClose()"
     id="renameModal">
     <i class="close icon"></i>
     <div class="header">
         Rename Server
     </div>
     <div class="content">
-        <form class="ui form" ng-submit="applyAndClose()">
+        <div class="ui form">
             <div class="field">
                 <div class="ui fluid left icon action input">
                     <i class="user icon"></i>
@@ -17,19 +18,19 @@
                     </button>
                 </div>
             </div>
-        </form>
+        </div>
     </div>
     <div class="actions">
         <button type="button" class="ui black deny button">
             Cancel
         </button>
         <button
-            type="button"
-            class="ui green right labeled icon approve button"
+            type="submit"
+            class="ui green right labeled icon button"
             ng-class="{ disabled: !data.name }"
             ng-disabled="!data.name">
             Rename
             <i class="tag icon"></i>
         </button>
     </div>
-</modal>
+</form>

--- a/src/renderer/app/directives/rename-server-modal/rename-server-modal.template.html
+++ b/src/renderer/app/directives/rename-server-modal/rename-server-modal.template.html
@@ -1,14 +1,13 @@
-<form modal
+<modal
     size="small"
     approve="approve()"
-    ng-submit="applyAndClose()"
     id="renameModal">
     <i class="close icon"></i>
     <div class="header">
         Rename Server
     </div>
     <div class="content">
-        <div class="ui form">
+        <form id="rename-server-form" class="ui form" ng-submit="applyAndClose()">
             <div class="field">
                 <div class="ui fluid left icon action input">
                     <i class="user icon"></i>
@@ -18,7 +17,7 @@
                     </button>
                 </div>
             </div>
-        </div>
+        </form>
     </div>
     <div class="actions">
         <button type="button" class="ui black deny button">
@@ -26,6 +25,7 @@
         </button>
         <button
             type="submit"
+            form="rename-server-form"
             class="ui green right labeled icon button"
             ng-class="{ disabled: !data.name }"
             ng-disabled="!data.name">
@@ -33,4 +33,4 @@
             <i class="tag icon"></i>
         </button>
     </div>
-</form>
+</modal>

--- a/src/renderer/app/directives/saved-location-modal/saved-location-modal.template.html
+++ b/src/renderer/app/directives/saved-location-modal/saved-location-modal.template.html
@@ -1,15 +1,14 @@
-<form modal
+<modal
     size="small"
     id="{{ ctl.modalId }}"
     on-hidden="ctl.onHidden()"
-    ng-submit="ctl.addSavedLocation()"
     ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
         {{ ctl.title }}
     </div>
     <div class="content">
-        <div class="ui form">
+        <form id="{{ ctl.modalId }}-form" class="ui form" ng-submit="ctl.addSavedLocation()">
             <div class="field">
                 <label for="{{ ctl.modalId }}-path">Path</label>
                 <div class="ui left icon input">
@@ -46,7 +45,7 @@
             <div class="ui negative message" ng-if="ctl.error">
                 <p>{{ ctl.error }}</p>
             </div>
-        </div>
+        </form>
     </div>
     <div class="actions">
         <button type="button" class="ui black button" ng-click="ctl.close()">
@@ -54,6 +53,7 @@
         </button>
         <button
             type="submit"
+            form="{{ ctl.modalId }}-form"
             class="ui green right labeled icon button"
             data-role="saved-location-save"
             ng-disabled="!ctl.path || !ctl.selectedIcon">
@@ -61,4 +61,4 @@
             <i class="checkmark icon"></i>
         </button>
     </div>
-</form>
+</modal>

--- a/src/renderer/app/directives/saved-location-modal/saved-location-modal.template.html
+++ b/src/renderer/app/directives/saved-location-modal/saved-location-modal.template.html
@@ -1,14 +1,15 @@
-<modal
+<form modal
     size="small"
     id="{{ ctl.modalId }}"
     on-hidden="ctl.onHidden()"
+    ng-submit="ctl.addSavedLocation()"
     ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
         {{ ctl.title }}
     </div>
     <div class="content">
-        <form class="ui form" ng-submit="ctl.addSavedLocation()">
+        <div class="ui form">
             <div class="field">
                 <label for="{{ ctl.modalId }}-path">Path</label>
                 <div class="ui left icon input">
@@ -45,20 +46,19 @@
             <div class="ui negative message" ng-if="ctl.error">
                 <p>{{ ctl.error }}</p>
             </div>
-        </form>
+        </div>
     </div>
     <div class="actions">
         <button type="button" class="ui black button" ng-click="ctl.close()">
             Cancel
         </button>
         <button
-            type="button"
+            type="submit"
             class="ui green right labeled icon button"
             data-role="saved-location-save"
-            ng-click="ctl.addSavedLocation()"
             ng-disabled="!ctl.path || !ctl.selectedIcon">
             {{ ctl.submitLabel }}
             <i class="checkmark icon"></i>
         </button>
     </div>
-</modal>
+</form>

--- a/src/renderer/app/directives/set-location-modal/set-location-modal.template.html
+++ b/src/renderer/app/directives/set-location-modal/set-location-modal.template.html
@@ -1,14 +1,15 @@
-<modal
+<form modal
     size="tiny"
     id="setLocationModal"
     on-hidden="ctl.onHidden()"
+    ng-submit="ctl.apply()"
     ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
         Set Location
     </div>
     <div class="content">
-        <form class="ui form" ng-submit="ctl.apply()">
+        <div class="ui form">
             <p>Choose a new location for {{ ctl.getTargetLabel() }}.</p>
             <div class="field">
                 <label for="set-location-input">Location</label>
@@ -25,21 +26,20 @@
             <div class="ui negative message" ng-if="ctl.scope.error">
                 <p>{{ ctl.scope.error }}</p>
             </div>
-        </form>
+        </div>
     </div>
     <div class="actions">
         <button type="button" class="ui black button" ng-class="{ disabled: ctl.scope.loading }" ng-click="ctl.close()">
             Cancel
         </button>
         <button
-            type="button"
+            type="submit"
             class="ui green right labeled icon button"
             data-role="set-location-apply"
             ng-class="{ disabled: ctl.scope.loading || !ctl.scope.location }"
-            ng-disabled="ctl.scope.loading || !ctl.scope.location"
-            ng-click="ctl.apply()">
+            ng-disabled="ctl.scope.loading || !ctl.scope.location">
             Set Location
             <i class="folder open icon"></i>
         </button>
     </div>
-</modal>
+</form>

--- a/src/renderer/app/directives/set-location-modal/set-location-modal.template.html
+++ b/src/renderer/app/directives/set-location-modal/set-location-modal.template.html
@@ -1,15 +1,14 @@
-<form modal
+<modal
     size="tiny"
     id="setLocationModal"
     on-hidden="ctl.onHidden()"
-    ng-submit="ctl.apply()"
     ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
         Set Location
     </div>
     <div class="content">
-        <div class="ui form">
+        <form id="set-location-form" class="ui form" ng-submit="ctl.apply()">
             <p>Choose a new location for {{ ctl.getTargetLabel() }}.</p>
             <div class="field">
                 <label for="set-location-input">Location</label>
@@ -26,7 +25,7 @@
             <div class="ui negative message" ng-if="ctl.scope.error">
                 <p>{{ ctl.scope.error }}</p>
             </div>
-        </div>
+        </form>
     </div>
     <div class="actions">
         <button type="button" class="ui black button" ng-class="{ disabled: ctl.scope.loading }" ng-click="ctl.close()">
@@ -34,6 +33,7 @@
         </button>
         <button
             type="submit"
+            form="set-location-form"
             class="ui green right labeled icon button"
             data-role="set-location-apply"
             ng-class="{ disabled: ctl.scope.loading || !ctl.scope.location }"
@@ -42,4 +42,4 @@
             <i class="folder open icon"></i>
         </button>
     </div>
-</form>
+</modal>

--- a/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.template.html
+++ b/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.template.html
@@ -1,7 +1,8 @@
-<modal
+<form modal
     id="torrent-set-ratio-modal"
     size="tiny"
     on-hidden="ctl.onHidden()"
+    ng-submit="ctl.apply()"
     ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
@@ -9,7 +10,7 @@
         Set Ratio Limit
     </div>
     <div class="content">
-        <form class="ui form" ng-submit="ctl.apply()">
+        <div class="ui form">
             <p>Enter a ratio limit. The current limit is shown when all selected torrents share the same limit.</p>
             <div class="field">
                 <label for="torrent-set-ratio-value">Ratio limit</label>
@@ -25,21 +26,20 @@
             <div class="ui negative message" ng-if="ctl.scope.error">
                 <p>{{ ctl.scope.error }}</p>
             </div>
-        </form>
+        </div>
     </div>
     <div class="actions">
         <button type="button" class="ui black deny button" ng-class="{ disabled: ctl.scope.loading }" ng-click="ctl.close()">
             Cancel
         </button>
         <button
-            type="button"
+            type="submit"
             class="ui green right labeled icon button"
             data-role="torrent-set-ratio-apply"
             ng-class="{ disabled: ctl.scope.loading }"
-            ng-disabled="ctl.scope.loading"
-            ng-click="ctl.apply()">
+            ng-disabled="ctl.scope.loading">
             Apply
             <i class="checkmark icon"></i>
         </button>
     </div>
-</modal>
+</form>

--- a/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.template.html
+++ b/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.template.html
@@ -1,8 +1,7 @@
-<form modal
+<modal
     id="torrent-set-ratio-modal"
     size="tiny"
     on-hidden="ctl.onHidden()"
-    ng-submit="ctl.apply()"
     ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
@@ -10,7 +9,7 @@
         Set Ratio Limit
     </div>
     <div class="content">
-        <div class="ui form">
+        <form id="torrent-set-ratio-form" class="ui form" ng-submit="ctl.apply()">
             <p>Enter a ratio limit. The current limit is shown when all selected torrents share the same limit.</p>
             <div class="field">
                 <label for="torrent-set-ratio-value">Ratio limit</label>
@@ -26,7 +25,7 @@
             <div class="ui negative message" ng-if="ctl.scope.error">
                 <p>{{ ctl.scope.error }}</p>
             </div>
-        </div>
+        </form>
     </div>
     <div class="actions">
         <button type="button" class="ui black deny button" ng-class="{ disabled: ctl.scope.loading }" ng-click="ctl.close()">
@@ -34,6 +33,7 @@
         </button>
         <button
             type="submit"
+            form="torrent-set-ratio-form"
             class="ui green right labeled icon button"
             data-role="torrent-set-ratio-apply"
             ng-class="{ disabled: ctl.scope.loading }"
@@ -42,4 +42,4 @@
             <i class="checkmark icon"></i>
         </button>
     </div>
-</form>
+</modal>

--- a/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.template.html
+++ b/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.template.html
@@ -1,8 +1,7 @@
-<form modal
+<modal
     id="setSpeedLimitModal"
     size="tiny"
     on-hidden="ctl.onHidden()"
-    ng-submit="ctl.apply()"
     ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
@@ -10,7 +9,7 @@
         Set Speed Limits
     </div>
     <div class="content">
-        <div class="ui form">
+        <form id="torrent-speed-limit-form" class="ui form" ng-submit="ctl.apply()">
             <p>Enter limits in KB/s. Leave a field blank to keep the existing limit. Use 0 for unlimited.</p>
             <div class="field">
                 <label for="torrent-speed-limit-download">Download limit (KB/s)</label>
@@ -35,7 +34,7 @@
             <div class="ui negative message" ng-if="ctl.scope.error">
                 <p>{{ ctl.scope.error }}</p>
             </div>
-        </div>
+        </form>
     </div>
     <div class="actions">
         <button type="button" class="ui black deny button" ng-class="{ disabled: ctl.scope.loading }" ng-click="ctl.close()">
@@ -43,6 +42,7 @@
         </button>
         <button
             type="submit"
+            form="torrent-speed-limit-form"
             class="ui green right labeled icon button"
             data-role="torrent-speed-limit-apply"
             ng-class="{ disabled: ctl.scope.loading }"
@@ -51,4 +51,4 @@
             <i class="checkmark icon"></i>
         </button>
     </div>
-</form>
+</modal>

--- a/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.template.html
+++ b/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.template.html
@@ -1,7 +1,8 @@
-<modal
+<form modal
     id="setSpeedLimitModal"
     size="tiny"
     on-hidden="ctl.onHidden()"
+    ng-submit="ctl.apply()"
     ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
@@ -9,7 +10,7 @@
         Set Speed Limits
     </div>
     <div class="content">
-        <form class="ui form" ng-submit="ctl.apply()">
+        <div class="ui form">
             <p>Enter limits in KB/s. Leave a field blank to keep the existing limit. Use 0 for unlimited.</p>
             <div class="field">
                 <label for="torrent-speed-limit-download">Download limit (KB/s)</label>
@@ -34,21 +35,20 @@
             <div class="ui negative message" ng-if="ctl.scope.error">
                 <p>{{ ctl.scope.error }}</p>
             </div>
-        </form>
+        </div>
     </div>
     <div class="actions">
         <button type="button" class="ui black deny button" ng-class="{ disabled: ctl.scope.loading }" ng-click="ctl.close()">
             Cancel
         </button>
         <button
-            type="button"
+            type="submit"
             class="ui green right labeled icon button"
             data-role="torrent-speed-limit-apply"
             ng-class="{ disabled: ctl.scope.loading }"
-            ng-disabled="ctl.scope.loading"
-            ng-click="ctl.apply()">
+            ng-disabled="ctl.scope.loading">
             Apply
             <i class="checkmark icon"></i>
         </button>
     </div>
-</modal>
+</form>

--- a/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.template.html
+++ b/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.template.html
@@ -52,7 +52,7 @@
                 </dropdown>
             </div>
             <div class="field four wide">
-                <button class="ui button fluid" ng-click="options.category = null" ng-class="{'disabled': !options.category}">
+                <button type="button" class="ui button fluid" ng-click="options.category = null" ng-class="{'disabled': !options.category}">
                     Clear Category
                 </button>
             </div>

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -545,7 +545,7 @@ export class App {
     await input.clearValue()
     await input.setValue(nextName)
 
-    const approveButton = modal.$("button.approve")
+    const approveButton = modal.$("button[type='submit']")
     await approveButton.waitForEnabled()
     await approveButton.click()
     await waitForModalClose(modal, this.timeout)

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -306,7 +306,7 @@ export class Torrent {
     const labelNameElem = modal.$("input[name=label]")
     await labelNameElem.setValue(labelName)
 
-    const submit = modal.$("button.approve")
+    const submit = modal.$("button[type='submit']")
     await submit.waitForDisplayed()
     await submit.waitForClickable()
     await submit.waitForEnabled()


### PR DESCRIPTION
## Summary
- preserve `<modal>` directive hosts so `ng-ref` continues to expose the modal controller API
- submit each modal through an inner form, with primary action buttons associated through the HTML `form` attribute
- align native form approval with Semantic UI by rejecting only an explicit `false`
- update E2E helpers to target native submit buttons instead of the removed `.approve` implementation class

## Root cause
Changing modal hosts to `<form modal>` caused `ng-ref` to capture a form controller instead of `ModalController`, so calls such as `modalref.showModal()` failed. After preserving the hosts, CI exposed stale `.approve` selectors and a mismatch where `applyAndClose()` treated void approval callbacks as rejection even though Semantic UI treats only `false` as rejection.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/settings.spec.ts" --mochaOpts.grep "can rename a server"`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-labels.spec.ts" --mochaOpts.grep "applies a new label"`