### PR TITLE
feat: add delete-with-data shortcut

### DIFF
--- a/src/main/lib/menu.ts
+++ b/src/main/lib/menu.ts
@@ -160,6 +160,11 @@ function editMenuItems(): MenuItemConstructorOptions[] {
             click: () => sendAction({ type: 'remove-selected' }),
         },
         {
+            label: 'Remove and Delete',
+            accelerator: 'Shift+Delete',
+            click: () => sendAction({ type: 'remove-and-delete-selected' }),
+        },
+        {
             label: 'Select All',
             accelerator: 'CmdOrCtrl+A',
             click: () => sendAction({ type: 'select-all' }),

--- a/src/main/lib/menu.ts
+++ b/src/main/lib/menu.ts
@@ -161,7 +161,7 @@ function editMenuItems(): MenuItemConstructorOptions[] {
         },
         {
             label: 'Remove and Delete',
-            accelerator: 'Shift+Delete',
+            accelerator: 'CmdOrCtrl+Delete',
             click: () => sendAction({ type: 'remove-and-delete-selected' }),
         },
         {

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
@@ -133,7 +133,7 @@ export class TitleBarMenuController {
             { label: "Copy", accelerator: "Ctrl+C", action: { type: "edit-command", command: "copy" } },
             { label: "Paste", accelerator: "Ctrl+V", action: { type: "edit-command", command: "paste" } },
             { label: "Remove", accelerator: "Delete", action: { type: "remove-selected" } },
-            { label: "Remove and Delete", accelerator: "Shift+Delete", action: { type: "remove-and-delete-selected" } },
+            { label: "Remove and Delete", accelerator: "Ctrl+Delete", action: { type: "remove-and-delete-selected" } },
             { label: "Select All", accelerator: "Ctrl+A", action: { type: "select-all" } },
         ];
 

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
@@ -133,6 +133,7 @@ export class TitleBarMenuController {
             { label: "Copy", accelerator: "Ctrl+C", action: { type: "edit-command", command: "copy" } },
             { label: "Paste", accelerator: "Ctrl+V", action: { type: "edit-command", command: "paste" } },
             { label: "Remove", accelerator: "Delete", action: { type: "remove-selected" } },
+            { label: "Remove and Delete", accelerator: "Shift+Delete", action: { type: "remove-and-delete-selected" } },
             { label: "Select All", accelerator: "Ctrl+A", action: { type: "select-all" } },
         ];
 

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -256,6 +256,13 @@ export class TorrentsPageController {
             remove();
         });
 
+        $scope.$on("remove-and-delete:torrents", () => {
+            const deleteAction = findContextActionByRole($rootScope.$btclient?.contextMenu || [], "delete");
+            if (deleteAction && selected.length > 0) {
+                openDeleteConfirmation(deleteAction.click, deleteAction.label);
+            }
+        });
+
         $scope.$on("torrentLocation:updated", () => {
             syncAfterTorrentMutation();
         });
@@ -290,6 +297,21 @@ export class TorrentsPageController {
                 torrents: selected.slice(),
             };
             $scope.deleteModalref?.showModal();
+        }
+
+        function findContextActionByRole(items: any[], role: string): any | null {
+            for (const item of items) {
+                if (item.role === role) {
+                    return item;
+                }
+
+                const nestedAction = findContextActionByRole(item.menu || [], role);
+                if (nestedAction) {
+                    return nestedAction;
+                }
+            }
+
+            return null;
         }
 
         function getDeleteConfirmationTarget(torrents: any[]) {

--- a/src/renderer/app/lib/menu-action-handler.ts
+++ b/src/renderer/app/lib/menu-action-handler.ts
@@ -65,6 +65,11 @@ export function createMenuActionHandler({
                     $rootScope.$broadcast("remove:torrents");
                 }
                 break;
+            case "remove-and-delete-selected":
+                if (document.activeElement?.nodeName !== "INPUT" && currentPage() === PAGE_TORRENTS) {
+                    $rootScope.$broadcast("remove-and-delete:torrents");
+                }
+                break;
             case "open-add-torrent":
                 electorrent.torrents.openFiles(!!action.askUploadOptions).then((files: Array<PendingTorrentUploadFile & { askUploadOptions?: boolean }>) => {
                     files.forEach((item) => broadcastTorrentFile(item, !!item.askUploadOptions));

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -295,6 +295,7 @@ export type MenuAction =
     | { type: "search-torrent" }
     | { type: "select-all" }
     | { type: "remove-selected" }
+    | { type: "remove-and-delete-selected" }
     | { type: "open-add-torrent"; askUploadOptions?: boolean }
     | { type: "paste-torrent-url"; askUploadOptions?: boolean }
     | { type: "open-external"; url: string }

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -2,10 +2,10 @@ import chai from "chai"
 import fs from "node:fs"
 import path from "node:path"
 import parseTorrent from "parse-torrent"
-import { $ } from "@wdio/globals"
+import { $, browser } from "@wdio/globals"
 import * as e2e from "../../e2e"
 import { eventually } from "../../e2e/eventually"
-import { waitForModalClose } from "../../e2e/modal"
+import { waitForModalClose, waitForModalOpen } from "../../e2e/modal"
 import { createTorrentFile } from "../../torrent"
 import { configureSpec, createUniqueLabel, getTestFixture } from "../../framework/fixture"
 
@@ -25,6 +25,28 @@ function findDownloadedContentCommand(downloadRoot: string, contentName: string)
 
 function findDownloadedDirectoryCommand(downloadRoot: string, contentName: string) {
   return `find ${shellQuote(downloadRoot)} -maxdepth 5 -type d -name ${shellQuote(contentName)} -print -quit`
+}
+
+async function sendRemoveAndDeleteShortcut() {
+  await browser.electron.execute((electron) => {
+    const win = electron.BrowserWindow.getFocusedWindow()
+      || electron.BrowserWindow.getAllWindows().find((window) => !window.isDestroyed())
+
+    if (!win) throw new Error("No Electron window found")
+
+    const menu = electron.Menu.getApplicationMenu()
+    const editMenu = menu?.items.find((item) => item.id === "edit" || item.label === "Edit")
+    const menuItem = editMenu?.submenu?.items.find((item) => item.label === "Remove and Delete")
+
+    if (!menuItem || !menuItem.visible || !menuItem.enabled) {
+      throw new Error("Remove and Delete menu item is unavailable")
+    }
+    if (menuItem.accelerator !== "Shift+Delete") {
+      throw new Error(`Unexpected Remove and Delete accelerator: ${menuItem.accelerator}`)
+    }
+
+    menuItem.click({}, win, win.webContents)
+  })
 }
 
 describe("torrent actions", function () {
@@ -79,6 +101,19 @@ describe("torrent actions", function () {
     await cancelButton.waitForDisplayed()
     await cancelButton.waitForClickable()
     await cancelButton.click()
+    await waitForModalClose(modal)
+
+    await torrent.waitForExist()
+  })
+
+  it("Shift+Delete shows the delete confirmation modal", async function () {
+    await $(torrent.query).click()
+    await sendRemoveAndDeleteShortcut()
+
+    const modal = $("#deleteTorrentModal")
+    await waitForModalOpen(modal, torrent.timeout)
+    await eventually(() => modal.$(".content").getText()).contains("Are you sure")
+    await modal.$("button.deny").click()
     await waitForModalClose(modal)
 
     await torrent.waitForExist()

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -41,7 +41,7 @@ async function sendRemoveAndDeleteShortcut() {
     if (!menuItem || !menuItem.visible || !menuItem.enabled) {
       throw new Error("Remove and Delete menu item is unavailable")
     }
-    if (menuItem.accelerator !== "Shift+Delete") {
+    if (menuItem.accelerator !== "CmdOrCtrl+Delete") {
       throw new Error(`Unexpected Remove and Delete accelerator: ${menuItem.accelerator}`)
     }
 
@@ -106,7 +106,7 @@ describe("torrent actions", function () {
     await torrent.waitForExist()
   })
 
-  it("Shift+Delete shows the delete confirmation modal", async function () {
+  it("CmdOrCtrl+Delete shows the delete confirmation modal", async function () {
     await $(torrent.query).click()
     await sendRemoveAndDeleteShortcut()
 

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -2,10 +2,10 @@ import chai from "chai"
 import fs from "node:fs"
 import path from "node:path"
 import parseTorrent from "parse-torrent"
-import { $, browser } from "@wdio/globals"
+import { $ } from "@wdio/globals"
 import * as e2e from "../../e2e"
 import { eventually } from "../../e2e/eventually"
-import { waitForModalClose, waitForModalOpen } from "../../e2e/modal"
+import { waitForModalClose } from "../../e2e/modal"
 import { createTorrentFile } from "../../torrent"
 import { configureSpec, createUniqueLabel, getTestFixture } from "../../framework/fixture"
 
@@ -79,19 +79,6 @@ describe("torrent actions", function () {
     await cancelButton.waitForDisplayed()
     await cancelButton.waitForClickable()
     await cancelButton.click()
-    await waitForModalClose(modal)
-
-    await torrent.waitForExist()
-  })
-
-  it("Shift+Delete shows the delete confirmation modal", async function () {
-    await $(torrent.query).click()
-    await browser.keys(["Shift", "Delete"])
-
-    const modal = $("#deleteTorrentModal")
-    await waitForModalOpen(modal, torrent.timeout)
-    await eventually(() => modal.$(".content").getText()).contains("Are you sure")
-    await modal.$("button.deny").click()
     await waitForModalClose(modal)
 
     await torrent.waitForExist()

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -2,10 +2,10 @@ import chai from "chai"
 import fs from "node:fs"
 import path from "node:path"
 import parseTorrent from "parse-torrent"
-import { $ } from "@wdio/globals"
+import { $, browser } from "@wdio/globals"
 import * as e2e from "../../e2e"
 import { eventually } from "../../e2e/eventually"
-import { waitForModalClose } from "../../e2e/modal"
+import { waitForModalClose, waitForModalOpen } from "../../e2e/modal"
 import { createTorrentFile } from "../../torrent"
 import { configureSpec, createUniqueLabel, getTestFixture } from "../../framework/fixture"
 
@@ -79,6 +79,19 @@ describe("torrent actions", function () {
     await cancelButton.waitForDisplayed()
     await cancelButton.waitForClickable()
     await cancelButton.click()
+    await waitForModalClose(modal)
+
+    await torrent.waitForExist()
+  })
+
+  it("Shift+Delete shows the delete confirmation modal", async function () {
+    await $(torrent.query).click()
+    await browser.keys(["Shift", "Delete"])
+
+    const modal = $("#deleteTorrentModal")
+    await waitForModalOpen(modal, torrent.timeout)
+    await eventually(() => modal.$(".content").getText()).contains("Are you sure")
+    await modal.$("button.deny").click()
     await waitForModalClose(modal)
 
     await torrent.waitForExist()


### PR DESCRIPTION
## Summary
- add Cmd/Ctrl+Delete as a delete-with-data accelerator
- expose Remove and Delete in native and custom title menus
- reuse each client's destructive context action and existing confirmation modal
- test the shortcut wiring by invoking the native menu item in Electron's main process, which exercises the real `sendAction` path without emulating OS keyboard input

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-actions.spec.ts" --mochaOpts.grep "CmdOrCtrl\\+Delete shows the delete confirmation modal"` (1 passing)