### PR TITLE
fix: navigate torrent table with arrow keys

### DIFF
--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -622,6 +622,35 @@ export class TorrentsPageController {
             } else {
                 singleSelect(torrent);
             }
+
+            (event.currentTarget as HTMLElement).closest("table")?.focus({ preventScroll: true });
+        };
+
+        $scope.navigateSelection = (event: KeyboardEvent) => {
+            if ((event.key !== "ArrowUp" && event.key !== "ArrowDown") || $scope.arrayTorrents.length === 0) {
+                return;
+            }
+
+            event.preventDefault();
+            const direction = event.key === "ArrowUp" ? -1 : 1;
+            const selectedIndexes = $scope.arrayTorrents.reduce((indexes: number[], torrent: any, index: number) => {
+                if (torrent.selected) {
+                    indexes.push(index);
+                }
+                return indexes;
+            }, []);
+            const currentIndex = selectedIndexes.length === 0
+                ? (direction < 0 ? $scope.arrayTorrents.length : -1)
+                : (direction < 0 ? Math.min(...selectedIndexes) : Math.max(...selectedIndexes));
+            const targetIndex = Math.max(0, Math.min(currentIndex + direction, $scope.arrayTorrents.length - 1));
+            const target = $scope.arrayTorrents[targetIndex];
+
+            singleSelect(target);
+            $scope.torrentLimit = Math.max($scope.torrentLimit, targetIndex + 1);
+            $timeout(() => {
+                document.querySelector<HTMLElement>(`#torrentTable tbody tr[data-hash="${target.hash.toLowerCase()}"]`)
+                    ?.scrollIntoView({ block: "nearest" });
+            });
         };
 
         function getSelectedHashes() {

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -73,6 +73,9 @@
             <div infinite-scroll-parent="true" infinite-scroll="showMore()" infinite-scroll-distance="0.5">
                 <table
                     id="torrentTable"
+                    tabindex="0"
+                    aria-label="Torrents"
+                    ng-keydown="navigateSelection($event)"
                     ng-class="{ 'compact': settings.ui.displayCompact, 'is-sticky': settings.ui.fixedHeader }"
                     rz-table
                     rz-busy="guiBusy"

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -239,6 +239,9 @@ torrent-sidebar + .main-panel {
     --torrent-sidebar-width: 260px;
     --torrent-sidebar-collapsed-width: 72px;
 }
+#torrentTable:focus {
+    outline: none;
+}
 #page-torrents.is-sidebar-collapsed {
     --torrent-sidebar-width: var(--torrent-sidebar-collapsed-width);
 }

--- a/test/specs/mock/sorting.spec.ts
+++ b/test/specs/mock/sorting.spec.ts
@@ -1,5 +1,6 @@
 import chai from "chai"
 import { $, $$, browser } from "@wdio/globals"
+import { Key } from "webdriverio"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec } from "../../framework/fixture"
 import { restartApplication } from "../../shared"
@@ -111,6 +112,37 @@ describe("mock torrent table sorting", function () {
     return values
   }
 
+  async function getSelectedHashes() {
+    const rows = await $$("#torrentTable tbody tr.active[data-hash]")
+    const hashes: string[] = []
+    for (const row of rows) {
+      hashes.push(await row.getAttribute("data-hash"))
+    }
+    return hashes
+  }
+
+  async function expectSelectedHashes(expected: string[]) {
+    await eventually(async () => (await getSelectedHashes()).join(","))
+      .equals(expected.join(","))
+  }
+
+  async function shiftClick(row: ReturnType<typeof $>) {
+    await browser.actions([
+      browser.action("key")
+        .down(Key.Shift)
+        .pause(0)
+        .pause(0)
+        .pause(0)
+        .up(Key.Shift),
+      browser.action("pointer")
+        .pause(0)
+        .move({ origin: row, duration: 0 })
+        .down({ button: 0 })
+        .up({ button: 0 })
+        .pause(0),
+    ])
+  }
+
   function parseBytes(value: string) {
     const match = value.match(/^(\d+(?:\.\d+)?)\s+([KMGT]?B)$/)
     assert.isNotNull(match, `Expected byte value, got ${value}`)
@@ -166,6 +198,29 @@ describe("mock torrent table sorting", function () {
       return rows.slice(index + 1).some((other) => row.progress === other.progress && row.status !== other.status)
     }), "Expected at least one equal-progress group with different statuses")
   }
+
+  it("navigates the selected torrent with arrow keys", async function () {
+    const rows = await $$("#torrentTable tbody tr[data-hash]")
+    const hashes = await rows.map((row) => row.getAttribute("data-hash"))
+
+    await rows[1].click()
+    await browser.keys([Key.ArrowDown])
+    await expectSelectedHashes([hashes[2]])
+
+    await browser.keys([Key.ArrowUp])
+    await expectSelectedHashes([hashes[1]])
+  })
+
+  it("collapses multiple selections from the directional edge", async function () {
+    const rows = await $$("#torrentTable tbody tr[data-hash]")
+    const hashes = await rows.map((row) => row.getAttribute("data-hash"))
+
+    await rows[1].click()
+    await shiftClick(rows[3])
+    await expectSelectedHashes(hashes.slice(1, 4))
+    await browser.keys([Key.ArrowDown])
+    await expectSelectedHashes([hashes[4]])
+  })
 
   it("sorts by size and persists that sort after restart", async function () {
     await clickColumn("Size")


### PR DESCRIPTION
## Summary
- make the torrent table focusable and retain focus after row selection
- navigate visible torrents with Up and Down while keeping the active row in view
- collapse multi-selections from the directional edge for predictable movement
- cover single and multi-selection navigation in the mock table spec

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "mock" --spec "test/specs/mock/sorting.spec.ts"`