### PR TITLE
feat: extend selection with shift arrows

### DIFF
--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -645,7 +645,16 @@ export class TorrentsPageController {
             const targetIndex = Math.max(0, Math.min(currentIndex + direction, $scope.arrayTorrents.length - 1));
             const target = $scope.arrayTorrents[targetIndex];
 
-            singleSelect(target);
+            if (event.shiftKey && selectedIndexes.length > 0) {
+                if (!target.selected) {
+                    target.selected = true;
+                    selected.push(target);
+                    lastSelected = target;
+                    syncDetailsPanel();
+                }
+            } else {
+                singleSelect(target);
+            }
             $scope.torrentLimit = Math.max($scope.torrentLimit, targetIndex + 1);
             $timeout(() => {
                 document.querySelector<HTMLElement>(`#torrentTable tbody tr[data-hash="${target.hash.toLowerCase()}"]`)

--- a/test/specs/mock/sorting.spec.ts
+++ b/test/specs/mock/sorting.spec.ts
@@ -211,6 +211,21 @@ describe("mock torrent table sorting", function () {
     await expectSelectedHashes([hashes[1]])
   })
 
+  it("extends the torrent selection with shift and arrow keys", async function () {
+    const rows = await $$("#torrentTable tbody tr[data-hash]")
+    const hashes = await rows.map((row) => row.getAttribute("data-hash"))
+
+    await rows[2].click()
+    await browser.keys([Key.Shift, Key.ArrowDown])
+    await expectSelectedHashes(hashes.slice(2, 4))
+
+    await browser.keys([Key.Shift, Key.ArrowDown])
+    await expectSelectedHashes(hashes.slice(2, 5))
+
+    await browser.keys([Key.Shift, Key.ArrowUp])
+    await expectSelectedHashes(hashes.slice(1, 5))
+  })
+
   it("collapses multiple selections from the directional edge", async function () {
     const rows = await $$("#torrentTable tbody tr[data-hash]")
     const hashes = await rows.map((row) => row.getAttribute("data-hash"))


### PR DESCRIPTION
## Summary

- extend torrent table selection by one row with Shift+Up or Shift+Down
- preserve the existing single-selection behavior for unmodified arrow keys
- cover repeated downward extension and upward extension with a mock Electron browser test

## Why

The torrent table keyboard handler always collapsed navigation to a single row, even while Shift was held. This made it impossible to grow a multi-row selection from the keyboard.

## User impact

Keyboard users can now add the adjacent torrent at the selected range's directional edge while keeping the existing selection intact.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "mock" --spec "test/specs/mock/sorting.spec.ts"` (7 passing)