### PR TITLE
feat: select torrent location from saved paths

### DIFF
--- a/src/renderer/app/directives/saved-location-modal/saved-location-modal.controller.ts
+++ b/src/renderer/app/directives/saved-location-modal/saved-location-modal.controller.ts
@@ -1,5 +1,6 @@
 import { IRootScopeService, IScope } from "angular";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
+import type { SettingsService } from "@renderer/app/services/settings";
 import type { SavedLocationConfig } from "@shared/ipc-contract";
 import { SAVED_LOCATION_ICONS } from "./saved-location-icons";
 
@@ -41,7 +42,7 @@ export class SavedLocationModalController {
     constructor(
         private readonly scope: SavedLocationModalScope,
         private readonly rootScope: IRootScopeService,
-        private readonly settingsService: { getAllSettingsCopy: () => unknown, saveAllSettings: () => Promise<void> },
+        private readonly settingsService: SettingsService,
     ) {
         this.modalId = scope.modalId || "savedLocationModal";
     }

--- a/src/renderer/app/directives/set-location-modal/set-location-modal.controller.ts
+++ b/src/renderer/app/directives/set-location-modal/set-location-modal.controller.ts
@@ -1,6 +1,7 @@
 import { IScope } from "angular";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
+import type { SavedLocationConfig } from "@shared/ipc-contract";
 
 export interface SetLocationModalScope extends IScope {
   torrents: any[];
@@ -10,16 +11,18 @@ export interface SetLocationModalScope extends IScope {
 }
 
 export class SetLocationModalController {
-  static $inject = ["$scope", "$rootScope"];
+  static $inject = ["$scope", "$rootScope", "settingsService"];
 
   scope: SetLocationModalScope;
   rootScope: ElectorrentRootScope;
   modalref: ModalController;
+  savedLocations: SavedLocationConfig[] = [];
   private unsubscribeOpen?: () => void;
 
   constructor(
     scope: SetLocationModalScope,
     rootScope: ElectorrentRootScope,
+    private readonly settingsService: { getServer: (id: string) => { savedLocations?: SavedLocationConfig[] } | undefined },
   ) {
     this.scope = scope;
     this.rootScope = rootScope;
@@ -54,8 +57,12 @@ export class SetLocationModalController {
   }
 
   open(torrents: any[]) {
+    const serverId = this.rootScope.$server?.id;
+    const server = serverId ? this.settingsService.getServer(serverId) : undefined;
+    this.savedLocations = Array.isArray(server?.savedLocations) ? server.savedLocations : [];
     this.scope.torrents = torrents.slice();
-    this.scope.location = this.getSharedLocation(torrents);
+    const sharedLocation = this.getSharedLocation(torrents);
+    this.scope.location = this.savedLocations.some(({ path }) => path === sharedLocation) ? sharedLocation : "";
     this.scope.error = null;
     this.scope.loading = false;
 

--- a/src/renderer/app/directives/set-location-modal/set-location-modal.controller.ts
+++ b/src/renderer/app/directives/set-location-modal/set-location-modal.controller.ts
@@ -1,5 +1,6 @@
 import { IScope } from "angular";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
+import type { SettingsService } from "@renderer/app/services/settings";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import type { SavedLocationConfig } from "@shared/ipc-contract";
 
@@ -22,7 +23,7 @@ export class SetLocationModalController {
   constructor(
     scope: SetLocationModalScope,
     rootScope: ElectorrentRootScope,
-    private readonly settingsService: { getServer: (id: string) => { savedLocations?: SavedLocationConfig[] } | undefined },
+    private readonly settingsService: SettingsService,
   ) {
     this.scope = scope;
     this.rootScope = rootScope;

--- a/src/renderer/app/directives/set-location-modal/set-location-modal.template.html
+++ b/src/renderer/app/directives/set-location-modal/set-location-modal.template.html
@@ -28,8 +28,8 @@
                         <span>{{ savedLocation.path }}</span>
                     </dropdown-group>
                 </dropdown>
-                <div class="ui mini message" data-role="set-location-empty" ng-if="!ctl.savedLocations.length">
-                    No saved locations are available for this server.
+                <div class="ui small info message" data-role="set-location-empty" ng-if="!ctl.savedLocations.length">
+                    No saved locations are available for this server. Add saved locations in Settings &rarr; Advanced.
                 </div>
             </div>
             <div class="ui negative message" ng-if="ctl.scope.error">

--- a/src/renderer/app/directives/set-location-modal/set-location-modal.template.html
+++ b/src/renderer/app/directives/set-location-modal/set-location-modal.template.html
@@ -11,15 +11,25 @@
         <form id="set-location-form" class="ui form" ng-submit="ctl.apply()">
             <p>Choose a new location for {{ ctl.getTargetLabel() }}.</p>
             <div class="field">
-                <label for="set-location-input">Location</label>
-                <div class="ui fluid left icon input">
-                    <i class="folder open icon"></i>
-                    <input
-                        id="set-location-input"
-                        type="text"
-                        name="location"
-                        ng-model="ctl.scope.location"
-                        placeholder="/downloads/new/location">
+                <label for="set-location-dropdown">Location</label>
+                <dropdown
+                    title="Select saved location"
+                    id="set-location-dropdown"
+                    class="fluid"
+                    open-on-focus="false"
+                    ng-model="ctl.scope.location"
+                    ng-disabled="!ctl.savedLocations.length">
+                    <dropdown-group
+                        ng-repeat="savedLocation in ctl.savedLocations track by savedLocation.path"
+                        title="savedLocation.path"
+                        value="savedLocation.path"
+                        data-path="{{ savedLocation.path }}">
+                        <i class="{{ savedLocation.icon }} icon"></i>
+                        <span>{{ savedLocation.path }}</span>
+                    </dropdown-group>
+                </dropdown>
+                <div class="ui mini message" data-role="set-location-empty" ng-if="!ctl.savedLocations.length">
+                    No saved locations are available for this server.
                 </div>
             </div>
             <div class="ui negative message" ng-if="ctl.scope.error">

--- a/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.controller.ts
+++ b/src/renderer/app/directives/torrent-upload-form/torrent-upload-form.controller.ts
@@ -1,5 +1,6 @@
 import { IScope } from "angular";
 import { TorrentUploadOptions, TorrentUploadOptionsEnable } from "@renderer/app/bittorrent/torrentclient";
+import type { SettingsService } from "@renderer/app/services/settings";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import type { SavedLocationConfig } from "@shared/ipc-contract";
 
@@ -19,7 +20,7 @@ export class TorrentUploadFormController {
     savedLocations: SavedLocationConfig[] = []
     selectedSavedLocationPath = ""
 
-    constructor(scope: TorrentUploadFormScope, rootScope: ElectorrentRootScope, private readonly settingsService: { getServer: (id: string) => { savedLocations?: SavedLocationConfig[] } | undefined }) {
+    constructor(scope: TorrentUploadFormScope, rootScope: ElectorrentRootScope, private readonly settingsService: SettingsService) {
         this.scope = scope
         this.rootScope = rootScope
         this.refreshFormState()

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -1,8 +1,34 @@
 import _ from "underscore"
+import type { IPromise } from "angular"
 import { Torrent } from "@renderer/app/bittorrent"
+import type { ColumnProps } from "@renderer/app/services/column"
 import { parseServerAddressInput, sanitizeServerAddress } from "@shared/server-address"
 import type { CertificateResponseService } from "@renderer/app/services/certificate-response"
 import type { SavedLocationConfig, StoredServerConfig, TorrentUploadOptions } from "@shared/ipc-contract"
+
+export interface Server extends Omit<StoredServerConfig, "columns"> {
+    columns: ColumnProps[]
+    certificateData?: Uint8Array
+    isConnected: boolean
+    connect(): IPromise<void>
+    getName(): string
+    getIcon(): string
+    getNameAtAddress(): string
+    getDisplayName(): string
+    updateLastUsed(): void
+    cleanPath(): string
+    setPath(): void
+    url(): string
+    isHTTPS(): boolean
+    askForCertificate(): IPromise<void>
+    getCertificate(): Uint8Array | undefined
+    equals(other: Server): boolean
+    parseColumns(columns?: string[]): ColumnProps[]
+    defaultColumns(): ColumnProps[]
+    addCustomColumns(columns: ColumnProps[]): ColumnProps[]
+    bootstrap(): void
+    json(): StoredServerConfig
+}
 
 export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclients', 'certificateResponseService',
     function($q, $notify, $bittorrent, $btclients, certificateResponseService: CertificateResponseService) {

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -1,5 +1,28 @@
 import { IRootScopeService } from "angular";
 import type { AppSettings, StoredServerConfig } from "@shared/ipc-contract";
+import type { Server } from "@renderer/app/services/server";
+
+export interface SettingsService {
+    whenReady(): Promise<AppSettings<Server>>
+    initSettings(): Promise<AppSettings<Server>>
+    appendServer(server: Server): void
+    getAllSettings(): AppSettings<Server>
+    getAllSettingsCopy(): AppSettings<Server>
+    setCurrentServerAsDefault(): void
+    setDefault(server: Server, skipSave?: boolean): void
+    saveAllSettings(newSettings?: Partial<AppSettings<Server>>): Promise<void>
+    trustCertificate(certificate: { fingerprint: string }): Promise<void>
+    enableInsecureTls(serverId: string): Promise<void>
+    disableInsecureTls(server: Server): Promise<void>
+    saveServer(server: Server): Promise<void>
+    saveServer(ip: string, port: number, user: string, password: string, client: string): Promise<void>
+    removeServer(server: Server): void
+    updateServer(server: Partial<Server> & Pick<Server, "id">): Promise<void>
+    getServer(id: string): Server | undefined
+    getServers(): Server[]
+    getDefaultServer(): Server | undefined
+    getRecentServer(): Server | undefined
+}
 
 export let settingsService = ['$rootScope', '$bittorrent', 'notificationService', '$q', 'Server', function($rootScope: IRootScopeService, $bittorrent, $notify, $q, Server) {
     const electorrent = window.electorrent

--- a/src/renderer/types/angular.d.ts
+++ b/src/renderer/types/angular.d.ts
@@ -1,20 +1,6 @@
 declare namespace angular {
     type TorrentClient = import("@renderer/app/bittorrent/torrentclient").TorrentClient
-    type StoredServerConfig = import("@shared/ipc-contract").StoredServerConfig
-    type ColumnProps = import("@renderer/app/services/column").ColumnProps
-
-    interface ElectorrentServer extends Omit<StoredServerConfig, "columns"> {
-        columns: ColumnProps[]
-        isConnected: boolean
-        connect(): IPromise<void>
-        getName(): string
-        getIcon(): string
-        getNameAtAddress(): string
-        getDisplayName(): string
-        setPath(): void
-        url(): string
-        json(): StoredServerConfig
-    }
+    type ElectorrentServer = import("@renderer/app/services/server").Server
 
     interface SyncConnectionStatus {
         state: "normal" | "slow" | "broken"

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -200,10 +200,15 @@ export class Torrent {
 
   async setLocation(location: string) {
     const modal = await this.openSetLocationModal();
-    const input = modal.$("input[name='location']");
-    await input.waitForDisplayed();
-    await input.clearValue();
-    await input.setValue(location);
+    const dropdown = modal.$("#set-location-dropdown");
+    await dropdown.waitForDisplayed();
+    await dropdown.waitForClickable();
+    await dropdown.click();
+
+    const locationItem = dropdown.$(`[data-path="${location}"]`);
+    await locationItem.waitForDisplayed();
+    await locationItem.waitForClickable();
+    await locationItem.click();
 
     const approve = modal.$("button[data-role='set-location-apply']");
     await approve.waitForEnabled();

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -197,6 +197,12 @@ describe("torrent actions", function () {
     await backend.exec(["chmod", "777", targetDirectory])
     await backend.exec(["test", "-d", targetDirectory])
 
+    await this.app.openSettings()
+    await this.app.settingsGotoTab("advanced")
+    await this.app.addSettingsSavedLocation({ path: targetDirectory, icon: "folder open" })
+    await this.app.settingsSave()
+    await this.app.torrentsPageIsVisible()
+
     const fastTorrent = await this.app.uploadTorrent({ filename: torrentPath })
 
     try {


### PR DESCRIPTION
## What changed

- replace the Set Location free-text field with a dropdown of saved locations for the active server
- disable the empty dropdown and show an informational message directing users to Settings → Advanced
- allow the selected location to be submitted with the Enter key
- update the torrent action browser helper and test to save, select, and keyboard-submit the destination

## Why

Torrent move destinations should be limited to paths explicitly saved for the connected server, avoiding arbitrary or mistyped paths while clearly guiding users when none are configured.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-actions.spec.ts" --mochaOpts.grep "moves downloaded content via Set Location"`