### PR TITLE
fix: toggle focused dropdown with space

### DIFF
--- a/src/renderer/app/directives/drop/drop.directive.ts
+++ b/src/renderer/app/directives/drop/drop.directive.ts
@@ -126,18 +126,12 @@ export class DropdownElementDirective implements IDirective {
             }
         };
 
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (event.code === "Space") {
-                event.preventDefault();
-                toggle();
+        const onKeyDown = (event: JQuery.KeyDownEvent) => {
+            if (!scope.is_open && event.code !== "Space") {
                 return;
             }
 
-            if (!scope.is_open) {
-                return;
-            }
-
-            if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].indexOf(event.code) > -1) {
+            if (["Space", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].indexOf(event.code) > -1) {
                 event.preventDefault();
             }
 
@@ -147,6 +141,9 @@ export class DropdownElementDirective implements IDirective {
                 break;
             case "ArrowDown":
                 controller.next();
+                break;
+            case "Space":
+                toggle();
                 break;
             default:
                 break;
@@ -180,7 +177,7 @@ export class DropdownElementDirective implements IDirective {
         element.on("focus", onFocus);
         element.on("mousedown", onMouseDown);
         element.on("blur", onBlur);
-        element[0].addEventListener("keydown", onKeyDown);
+        element.on("keydown", onKeyDown);
         document.body.addEventListener("click", onBodyClick);
         window.addEventListener("keyup", onKeyUp);
         window.addEventListener("mouseup", onMouseUp);
@@ -190,7 +187,7 @@ export class DropdownElementDirective implements IDirective {
             element.off("focus", onFocus);
             element.off("mousedown", onMouseDown);
             element.off("blur", onBlur);
-            element[0].removeEventListener("keydown", onKeyDown);
+            element.off("keydown", onKeyDown);
             document.body.removeEventListener("click", onBodyClick);
             window.removeEventListener("keyup", onKeyUp);
             window.removeEventListener("mouseup", onMouseUp);

--- a/src/renderer/app/directives/drop/drop.directive.ts
+++ b/src/renderer/app/directives/drop/drop.directive.ts
@@ -127,7 +127,7 @@ export class DropdownElementDirective implements IDirective {
         };
 
         const onKeyDown = (event: KeyboardEvent) => {
-            if (event.code === "Space" && event.target === element[0]) {
+            if (event.code === "Space") {
                 event.preventDefault();
                 toggle();
                 return;
@@ -180,9 +180,9 @@ export class DropdownElementDirective implements IDirective {
         element.on("focus", onFocus);
         element.on("mousedown", onMouseDown);
         element.on("blur", onBlur);
+        element[0].addEventListener("keydown", onKeyDown);
         document.body.addEventListener("click", onBodyClick);
         window.addEventListener("keyup", onKeyUp);
-        window.addEventListener("keydown", onKeyDown);
         window.addEventListener("mouseup", onMouseUp);
 
         scope.$on("$destroy", () => {
@@ -190,9 +190,9 @@ export class DropdownElementDirective implements IDirective {
             element.off("focus", onFocus);
             element.off("mousedown", onMouseDown);
             element.off("blur", onBlur);
+            element[0].removeEventListener("keydown", onKeyDown);
             document.body.removeEventListener("click", onBodyClick);
             window.removeEventListener("keyup", onKeyUp);
-            window.removeEventListener("keydown", onKeyDown);
             window.removeEventListener("mouseup", onMouseUp);
         });
     }

--- a/src/renderer/app/directives/drop/drop.directive.ts
+++ b/src/renderer/app/directives/drop/drop.directive.ts
@@ -127,11 +127,17 @@ export class DropdownElementDirective implements IDirective {
         };
 
         const onKeyDown = (event: KeyboardEvent) => {
+            if (event.code === "Space" && event.target === element[0]) {
+                event.preventDefault();
+                toggle();
+                return;
+            }
+
             if (!scope.is_open) {
                 return;
             }
 
-            if (["Space", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].indexOf(event.code) > -1) {
+            if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].indexOf(event.code) > -1) {
                 event.preventDefault();
             }
 
@@ -141,9 +147,6 @@ export class DropdownElementDirective implements IDirective {
                 break;
             case "ArrowDown":
                 controller.next();
-                break;
-            case "Space":
-                toggle();
                 break;
             default:
                 break;


### PR DESCRIPTION
## What changed

- Handle keyboard input on each dropdown element instead of globally on `window`.
- Toggle a focused dropdown open or closed when Space is pressed.
- Preserve existing arrow-key navigation for open dropdowns.

## Why

The global keydown listener required closed dropdowns to return early so one Space press would not open every dropdown instance. That also prevented a focused closed dropdown from reaching `toggle()`.

Binding keydown to the dropdown element gives the event a single owner, allowing Space to toggle either state without target heuristics or affecting other dropdowns.

## Impact

Keyboard users can use Space consistently to open and close focused dropdowns, including dropdowns configured not to open automatically on focus.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/upload-options.spec.ts"` (10 passing, 1 feature-based skip)

No new test cases were added, as requested.