### PR TITLE
fix: consume launch arguments once

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -381,26 +381,6 @@ async function bootstrap() {
         pendingLaunchPayload.torrentFilePaths.push(...getTorrentFilePaths(args))
     }
 
-    async function sendMagnetLinks(args: string[]) {
-        const magnetLinks = getMagnetLinks(args).map((uri) => torrents.serializeMagnetLink(uri))
-        if (magnetLinks.length === 0 || !torrentWindow || torrentWindow.isDestroyed()) return
-        torrentWindow.webContents.send(IPC_CHANNELS.launch.magnets, magnetLinks)
-    }
-
-    async function sendTorrentFiles(args: string[]) {
-        logger.info('Main searching for files in', args)
-        const torrentFiles = getTorrentFilePaths(args)
-        if (torrentFiles.length === 0 || !torrentWindow || torrentWindow.isDestroyed()) return
-        logger.info('Main sending torrent files', torrentFiles)
-        const files = await torrents.readFiles(torrentFiles, false)
-        if (files.length === 0) return
-        if (!rendererLoaded) {
-            pendingLaunchPayload.torrentFilePaths.push(...torrentFiles)
-            return
-        }
-        torrentWindow.webContents.send(IPC_CHANNELS.launch.torrentFiles, files)
-    }
-
     async function consumePendingLaunchPayload() {
         return {
             magnets: pendingLaunchPayload.magnets.splice(0),
@@ -409,6 +389,23 @@ async function bootstrap() {
                 ...torrentFileWatcher.consumePendingPromptedTorrentFiles(),
             ],
         }
+    }
+
+    async function flushPendingLaunchPayload() {
+        if (!rendererLoaded || !torrentWindow || torrentWindow.isDestroyed()) return
+
+        const payload = await consumePendingLaunchPayload()
+        if (payload.magnets.length > 0) {
+            torrentWindow.webContents.send(IPC_CHANNELS.launch.magnets, payload.magnets)
+        }
+        if (payload.torrentFiles.length > 0) {
+            torrentWindow.webContents.send(IPC_CHANNELS.launch.torrentFiles, payload.torrentFiles)
+        }
+    }
+
+    function queueAndFlushPendingLaunchArgs(args: string[]) {
+        queuePendingLaunchArgs(args)
+        void flushPendingLaunchPayload()
     }
 
     ipcHandlers.registerHandlers({
@@ -439,35 +436,19 @@ async function bootstrap() {
         app.quit()
     } else {
         app.on('second-instance', function(_event: ElectronEvent, args: string[]) {
-            if (torrentWindow) {
-                sendMagnetLinks(args)
-                sendTorrentFiles(args)
-                showTorrentWindow()
-            } else {
-                queuePendingLaunchArgs(args)
-                showOrCreateTorrentWindow()
-            }
+            queueAndFlushPendingLaunchArgs(args)
+            showOrCreateTorrentWindow()
         })
     }
 
     app.on('open-url', function(_event: ElectronEvent, url: string) {
-        if (torrentWindow) {
-            sendMagnetLinks([url])
-            showTorrentWindow()
-        } else {
-            queuePendingLaunchArgs([url])
-            showOrCreateTorrentWindow()
-        }
+        queueAndFlushPendingLaunchArgs([url])
+        showOrCreateTorrentWindow()
     })
 
     app.on('open-file', function(_event: ElectronEvent, filePath: string) {
-        if (torrentWindow) {
-            sendTorrentFiles([filePath])
-            showTorrentWindow()
-        } else {
-            queuePendingLaunchArgs([filePath])
-            showOrCreateTorrentWindow()
-        }
+        queueAndFlushPendingLaunchArgs([filePath])
+        showOrCreateTorrentWindow()
     })
 
     app.on('ready', function() {

--- a/src/renderer/app/directives/app-shell/app-shell.controller.ts
+++ b/src/renderer/app/directives/app-shell/app-shell.controller.ts
@@ -45,6 +45,8 @@ export class AppShellController {
         let loadingTimer: angular.IPromise<void> | undefined;
         let page: string | null = null;
         let activeConnectionId = 0;
+        let initialLaunchPayloadDelivered = false;
+        let initialLaunchPayloadPromise: Promise<LaunchPayload> | null = null;
         let pendingMagnets: Array<PendingTorrentUploadLink & { askUploadOptions?: boolean }> = [];
         let pendingTorrentFiles: Array<PendingTorrentUploadFile & { askUploadOptions?: boolean }> = [];
 
@@ -228,11 +230,16 @@ export class AppShellController {
                 $scope.statusText = "Loading Torrents";
                 settingsService.updateServer(server);
                 pageTorrents(true);
-                return electorrent.launch.getPending().then((payload: LaunchPayload) => {
-                    if (!isCurrentConnection()) {
+                if (initialLaunchPayloadDelivered) {
+                    return;
+                }
+                initialLaunchPayloadPromise ||= electorrent.launch.getPending();
+                return initialLaunchPayloadPromise.then((payload: LaunchPayload) => {
+                    if (!isCurrentConnection() || initialLaunchPayloadDelivered) {
                         return;
                     }
 
+                    initialLaunchPayloadDelivered = true;
                     queueMagnetLinks(payload.magnets || []);
                     queueTorrentFiles(payload.torrentFiles || []);
                     drainPendingLaunchPayloads();

--- a/test/specs/mock/multiple-servers.spec.ts
+++ b/test/specs/mock/multiple-servers.spec.ts
@@ -1,5 +1,5 @@
 import chai from "chai"
-import { $$, browser } from "@wdio/globals"
+import { $, $$, browser } from "@wdio/globals"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec } from "../../framework/fixture"
 import { restartApplication } from "../../shared"
@@ -40,6 +40,36 @@ describe("mock multiple servers", function () {
       await connectServer.call(this, index)
       await expectOnlyTorrent(mockServers[index].torrentName)
     }
+  })
+
+  it("uploads launch magnets once across consecutive app invocations", async function () {
+    const firstMagnet = "magnet:?xt=urn:btih:0000000000000000000000000000000000000356"
+    const secondMagnet = "magnet:?xt=urn:btih:0000000000000000000000000000000000000357"
+    const firstTorrentName = "Mock Magnet 0000000000000000000000000000000000000356"
+    const secondTorrentName = "Mock Magnet 0000000000000000000000000000000000000357"
+
+    await emitSecondInstanceDuringRendererReload(firstMagnet)
+    await this.app.serverSelectionPageIsVisible()
+    await this.app.connectServerSelection(0)
+    await this.app.torrentsPageIsVisible()
+    await eventually(getTorrentNames).satisfies(
+      "include the first launch magnet",
+      (names) => names.includes(firstTorrentName),
+    )
+
+    await emitSecondInstance(secondMagnet)
+    await eventually(getTorrentNames).satisfies(
+      "include both launch magnets",
+      (names) => names.includes(firstTorrentName) && names.includes(secondTorrentName),
+    )
+
+    await openServerSelection()
+    await this.app.connectServerSelection(1)
+    await this.app.torrentsPageIsVisible()
+    await eventually(getTorrentNames).satisfies(
+      "not replay launch magnets on the second server",
+      (names) => !names.includes(firstTorrentName) && !names.includes(secondTorrentName),
+    )
   })
 })
 
@@ -88,6 +118,32 @@ async function invokeMockAction(action: string, ...args: any[]) {
   await browser.execute(async (request) => {
     await (window as any).electorrent.bittorrent.invokeAction(request)
   }, { action, args })
+}
+
+async function emitSecondInstance(magnet: string) {
+  await browser.electron.execute((electron, uri) => {
+    electron.app.emit("second-instance", {} as Electron.Event, [electron.app.getPath("exe"), uri], process.cwd())
+  }, magnet)
+}
+
+async function emitSecondInstanceDuringRendererReload(magnet: string) {
+  await browser.electron.execute(async (electron, uri) => {
+    const window = electron.BrowserWindow.getAllWindows()[0]
+    await new Promise<void>((resolve) => {
+      window.webContents.once("did-start-loading", () => {
+        electron.app.emit("second-instance", {} as Electron.Event, [electron.app.getPath("exe"), uri], process.cwd())
+        resolve()
+      })
+      window.webContents.reload()
+    })
+  }, magnet)
+}
+
+async function openServerSelection() {
+  await browser.electron.execute((electron) => {
+    electron.BrowserWindow.getAllWindows()[0]?.webContents.send("menu:action", { type: "show-servers" })
+  })
+  await $("#page-server-selection").waitForDisplayed()
 }
 
 async function addMockedTorrent(torrent: MockTorrent) {


### PR DESCRIPTION
## Summary

- route startup, open-file, open-url, and second-instance torrent inputs through one main-process queue
- drain the initial renderer backlog only once across server changes
- preserve inputs received while the renderer is reloading and deliver later invocations live

## Root cause

Later app invocations bypassed the pending launch queue, while each server connection could request the initial launch payload again. This made launch-item lifetime depend on the connection flow and allowed stale startup inputs to be replayed.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "mock" --spec "test/specs/mock/multiple-servers.spec.ts"`