### PR TITLE
fix(test): make generated torrents private

### DIFF
--- a/test/shared/opentracker/peer/rootfs/usr/local/bin/gen-torrent
+++ b/test/shared/opentracker/peer/rootfs/usr/local/bin/gen-torrent
@@ -50,7 +50,7 @@ fi
 TORRENT_FILE="/shared/${TORRENT_NAME}.torrent"
 # Create a torrent file and save it in the shared folder.
 rm -f "$TORRENT_FILE"
-mktorrent -a "$TRACKER_URL" -o "$TORRENT_FILE" "$CONTENT_PATH" >/dev/null
+mktorrent -p -a "$TRACKER_URL" -o "$TORRENT_FILE" "$CONTENT_PATH" >/dev/null
 # Generate a random unprivileged port (1024-65535)
 P2P_PORT=$((1024 + RANDOM % 64512))
 # Seed the torrent file (and contents)


### PR DESCRIPTION
## Summary

- pass `-p` to the shared `mktorrent` invocation
- ensure every generated test torrent disables DHT and peer exchange
- prevent test torrents from leaking into the public DHT

## Root cause

The test seeder disabled DHT locally, but the generated metainfo did not contain the BitTorrent private flag. Real clients used by the integration suite could therefore announce those torrents to the public DHT.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-uploads.spec.ts"`
- verified a freshly generated metainfo file parses with `private: true`

Closes #671