### PR TITLE
test: generate slow torrents at runtime

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -6,7 +6,7 @@ x-peer: &peer
     - ./shared/opentracker/data/shared:/shared
   tmpfs:
     - /srv
-  entrypoint: ["/usr/local/bin/gen-torrent"]
+  entrypoint: ["tail", "-f", "/dev/null"]
 
 services:
   # Opentracker (http://erdgeist.org/arts/software/opentracker/)
@@ -30,7 +30,6 @@ services:
   peer:
     <<: *peer
     hostname: peer
-    command: ["--foreground", "--torrent-name", "slow", "--upload-speed", "1", "--download-speed", "1", "--file-size", "100000"]
 
   nginx:
     build: ./shared/nginx

--- a/test/specs/standard/settings.spec.ts
+++ b/test/specs/standard/settings.spec.ts
@@ -1,14 +1,13 @@
 import chai from "chai"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import { $ } from "@wdio/globals"
 import * as e2e from "../../e2e"
 import { eventually } from "../../e2e/eventually"
-import { configureSpec } from "../../framework/fixture"
+import { configureSpec, getTestFixture } from "../../framework/fixture"
 import { restartApplication } from "../../shared"
+import { createSlowTorrentFile } from "../../torrent"
 
 const assert: Chai.AssertStatic = chai.assert
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const tracker = getTestFixture().tracker
 describe("settings", function () {
   configureSpec()
 
@@ -108,7 +107,7 @@ describe("settings", function () {
   })
 
   it("can enable always ask for upload options", async function () {
-    const torrentFile = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const torrentFile = await createSlowTorrentFile(tracker)
     let torrent: e2e.Torrent | undefined
 
     await this.app.settingsGotoTab("general")

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -1,12 +1,11 @@
 import fs from "node:fs"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import parseTorrent from "parse-torrent"
 import * as e2e from "../../e2e"
 import { eventually } from "../../e2e/eventually"
-import { configureSpec, formatBytes, requireFeature } from "../../framework/fixture"
+import { configureSpec, formatBytes, getTestFixture, requireFeature } from "../../framework/fixture"
+import { createSlowTorrentFile } from "../../torrent"
 
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const tracker = getTestFixture().tracker
 describe("torrent details", function () {
   configureSpec()
   requireFeature(({ features }) => features.torrentDetails === true)
@@ -15,7 +14,7 @@ describe("torrent details", function () {
   let torrentMetadata: parseTorrent.Instance
 
   before(async function () {
-    const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const filename = await createSlowTorrentFile(tracker)
     torrentMetadata = parseTorrent(fs.readFileSync(filename)) as parseTorrent.Instance
     torrent = await this.app.uploadTorrent({ filename })
     await torrent.waitForExist()

--- a/test/specs/standard/torrent-file-selection.spec.ts
+++ b/test/specs/standard/torrent-file-selection.spec.ts
@@ -1,12 +1,11 @@
 import chai from "chai"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import { $ } from "@wdio/globals"
 import * as e2e from "../../e2e"
 import { waitForModalClose, waitForModalOpen } from "../../e2e/modal"
-import { configureSpec, requireFeature } from "../../framework/fixture"
+import { configureSpec, getTestFixture, requireFeature } from "../../framework/fixture"
+import { createSlowTorrentFile } from "../../torrent"
 
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const tracker = getTestFixture().tracker
 
 describe("torrent file selection", function () {
   configureSpec()
@@ -15,7 +14,7 @@ describe("torrent file selection", function () {
   let torrent: e2e.Torrent
 
   before(async function () {
-    const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const filename = await createSlowTorrentFile(tracker)
     torrent = await this.app.uploadTorrent({ filename })
     await torrent.waitForExist()
   })

--- a/test/specs/standard/torrent-labels.spec.ts
+++ b/test/specs/standard/torrent-labels.spec.ts
@@ -1,10 +1,7 @@
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 import * as e2e from "../../e2e"
 import { configureSpec, createUniqueLabel, getTestFixture, requireFeature } from "../../framework/fixture"
-import { createTorrentFile } from "../../torrent"
+import { createSlowTorrentFile, createTorrentFile } from "../../torrent"
 
-const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
 const tracker = getTestFixture().tracker
 const noLabelFilter = "__electorrent_no_label__"
 
@@ -19,7 +16,7 @@ describe("torrent labels", function () {
   let unlabeledTorrent: e2e.Torrent
 
   before(async function () {
-    const filename = path.join(testDir, "shared/opentracker/data/shared/slow.torrent")
+    const filename = await createSlowTorrentFile(tracker)
     const unlabeledFilename = await createTorrentFile(tracker, { torrentName: createUniqueLabel("unlabeled") })
     torrent = await this.app.uploadTorrent({ filename })
     unlabeledTorrent = await this.app.uploadTorrent({ filename: unlabeledFilename })

--- a/test/torrent.ts
+++ b/test/torrent.ts
@@ -45,3 +45,14 @@ export async function createTorrentFile(tracker: DockerComposeService, options: 
     const torrentPath = path.join(__dirname, `shared/opentracker/data/shared/${torrentName}.torrent`)
     return torrentPath;
 }
+
+/** Create the large, bandwidth-limited torrent used by slower integration tests. */
+export function createSlowTorrentFile(tracker: DockerComposeService): Promise<string> {
+    const randomString = Math.random().toString(36).substring(2, 10);
+    return createTorrentFile(tracker, {
+        torrentName: `slow-${randomString}`,
+        fileSize: 100000,
+        downloadSpeed: 1,
+        uploadSpeed: 1,
+    });
+}


### PR DESCRIPTION
## Summary

- keep the peer service idle instead of generating `slow.torrent` during Docker Compose startup
- add a runtime helper that creates uniquely named slow torrents with the original size and bandwidth limits
- update every affected spec to generate its torrent during test execution

## Why

Startup-generated torrent state couples tests to a shared static artifact and allows concurrent client capabilities to overwrite the same file. Runtime generation makes each test responsible for its own fixture and unique naming avoids cross-capability collisions.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts"` (3 passing)