### PR TITLE
fix(upload): guard torrent submission

### DIFF
--- a/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
+++ b/src/renderer/app/directives/add-torrent-modal/add-torrent-modal.template.html
@@ -26,7 +26,7 @@
         <button type="button" class="ui black button" ng-class="{disabled: ctl.isLoading}" ng-click="ctl.discardCurrentTorrent()">
             Cancel
         </button>
-        <button type="submit" form="upload-torrent-form" class="ui green right labeled icon button" ng-class="{disabled: ctl.isLoading}">
+        <button type="submit" form="upload-torrent-form" class="ui green right labeled icon button" ng-class="{disabled: ctl.isLoading}" ng-disabled="ctl.isLoading">
             Add Torrent
             <i class="plus icon"></i>
         </button>

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -304,17 +304,8 @@ export class App {
 
     await browser.pause(250)
     const submitBtn = modal.$("button[type=submit]")
-    await eventually(async () => {
-      const className = (await submitBtn.getAttribute("class")) || ""
-      return {
-        displayed: await submitBtn.isDisplayed(),
-        clickable: await submitBtn.isClickable(),
-        cssDisabled: className.split(/\s+/).includes("disabled"),
-      }
-    }).satisfies(
-      "be displayed, clickable, and not CSS-disabled",
-      ({ displayed, clickable, cssDisabled }) => displayed && clickable && !cssDisabled,
-    )
+    await submitBtn.waitForDisplayed()
+    await submitBtn.waitForClickable()
     await submitBtn.click()
     if (options?.waitForClose !== false) {
       await waitForModalClose(modal, this.timeout)

--- a/test/e2e/e2e_app.ts
+++ b/test/e2e/e2e_app.ts
@@ -304,6 +304,17 @@ export class App {
 
     await browser.pause(250)
     const submitBtn = modal.$("button[type=submit]")
+    await eventually(async () => {
+      const className = (await submitBtn.getAttribute("class")) || ""
+      return {
+        displayed: await submitBtn.isDisplayed(),
+        clickable: await submitBtn.isClickable(),
+        cssDisabled: className.split(/\s+/).includes("disabled"),
+      }
+    }).satisfies(
+      "be displayed, clickable, and not CSS-disabled",
+      ({ displayed, clickable, cssDisabled }) => displayed && clickable && !cssDisabled,
+    )
     await submitBtn.click()
     if (options?.waitForClose !== false) {
       await waitForModalClose(modal, this.timeout)


### PR DESCRIPTION
## Summary

- wait for the upload submit button to be displayed and clickable before clicking it in E2E flows
- bind the native submit button disabled state to the same loading state used by the upload form spinner

## Root cause

The modal only applied Semantic UI's `disabled` CSS class while a torrent was processing. The submit helper also clicked after a fixed pause without waiting for the button's observable ready state, making slower clients such as Deluge more vulnerable to timing races.

## Impact

Torrent submissions cannot be triggered again while the current queue item is processing, and E2E interactions wait for the control's real ready state.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "deluge:2" --spec "test/specs/standard/upload-queue.spec.ts" --mochaOpts.grep "uploads queued torrent items from multiple sources one by one"`