### PR TITLE
feat: expand label color picker

### DIFF
--- a/src/renderer/app/directives/label-color-modal/label-color-modal.template.html
+++ b/src/renderer/app/directives/label-color-modal/label-color-modal.template.html
@@ -19,9 +19,7 @@
                 ng-repeat="hue in ctl.hues track by hue"
                 ng-class="{'is-selected': ctl.isSelected(hue)}"
                 ng-attr-style="--label-hue: {{ hue }}"
-                ng-click="ctl.selectHue(hue)">
-                <span class="label-color-picker-dot"></span>
-            </button>
+                ng-click="ctl.selectHue(hue)"></button>
         </div>
     </div>
     <div class="actions">

--- a/src/renderer/app/directives/settings-advanced/settings-advanced.template.html
+++ b/src/renderer/app/directives/settings-advanced/settings-advanced.template.html
@@ -71,9 +71,6 @@
                         <span class="settings-label-color-chip" label-chip="label" label-color-overrides="server.labelColors">
                             <span class="label-chip-text">{{ label }}</span>
                         </span>
-                        <span class="settings-label-color-hue" title="Hue {{ ctl.getLabelHue(label) }}" ng-attr-style="--label-hue: {{ ctl.getLabelHue(label) }}">
-                            <span class="label-color-preview-dot"></span>
-                        </span>
                         <button
                             type="button"
                             class="ui tiny button"
@@ -90,6 +87,9 @@
                             ng-disabled="!ctl.hasCustomLabelColor(label)">
                             <i class="undo icon"></i>
                         </button>
+                        <span class="settings-label-color-hue" title="Hue {{ ctl.getLabelHue(label) }}" ng-attr-style="--label-hue: {{ ctl.getLabelHue(label) }}">
+                            <span class="label-color-preview-dot"></span>
+                        </span>
                     </div>
                 </div>
             </div>

--- a/src/renderer/app/services/label-colors.ts
+++ b/src/renderer/app/services/label-colors.ts
@@ -1,6 +1,6 @@
 import type { LabelColorHue, LabelColorOverrides } from "@shared/ipc-contract";
 
-export const LABEL_COLOR_HUE_STEP = 20;
+export const LABEL_COLOR_HUE_STEP = 10;
 export const LABEL_COLOR_HUES: LabelColorHue[] = Array.from(
     { length: 360 / LABEL_COLOR_HUE_STEP },
     (_unused, index) => index * LABEL_COLOR_HUE_STEP,

--- a/src/renderer/styles/app/partials/settings.less
+++ b/src/renderer/styles/app/partials/settings.less
@@ -84,8 +84,7 @@
     width: 2rem;
 }
 
-.label-color-preview-dot,
-.label-color-picker-dot {
+.label-color-preview-dot {
     background: oklch(@labelChipDotLightness @labelChipDotChroma var(--label-hue, 225));
     border-radius: 999px;
     display: inline-block;
@@ -98,33 +97,27 @@
 
 .label-color-picker-grid {
     display: grid;
-    gap: .45rem;
-    grid-template-columns: repeat(auto-fill, minmax(2.4rem, 1fr));
+    gap: .6rem;
+    grid-template-columns: repeat(auto-fill, 1.8rem);
+    justify-content: center;
 }
 
 .label-color-picker-option {
-    align-items: center;
-    background: transparent;
-    border: 1px solid @borderColor;
+    background: oklch(@labelChipDotLightness @labelChipDotChroma var(--label-hue, 225));
+    border: 0;
     border-radius: 999px;
     cursor: pointer;
-    display: inline-flex;
-    height: 2.4rem;
-    justify-content: center;
+    height: 1.8rem;
     padding: 0;
+    width: 1.8rem;
 }
 
 .label-color-picker-option:hover,
+.label-color-picker-option:focus-visible,
 .label-color-picker-option.is-selected {
-    background: @highlightBackground;
-    border-color: @selectedBorderColor;
+    box-shadow: 0 0 0 2px @pageBackground, 0 0 0 4px @selectedBorderColor;
 }
 
 .label-color-picker-option.is-selected {
-    box-shadow: 0 0 0 2px oklch(@labelChipDotLightness @labelChipDotChroma var(--label-hue, 225));
-}
-
-.label-color-picker-dot {
-    height: 1.05rem;
-    width: 1.05rem;
+    outline: 2px solid transparent;
 }


### PR DESCRIPTION
## Summary

- expand the label color palette from 18 to 36 hues
- render picker choices as simple filled circular swatches
- align each advanced-settings color indicator at the right edge

## Impact

Labels can be customized with finer hue choices through a simpler, more compact picker.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/settings.spec.ts"` *(blocked before test execution: Electron WebDriver session refused the local connection)*