### PR TITLE
feat(qbittorrent): group queue actions

### DIFF
--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -311,24 +311,29 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
         icon: "checkmark",
       },
       {
-        label: "Move Up Queue",
-        click: this.increasePrio,
-        icon: "arrow up",
-      },
-      {
-        label: "Move Queue Down",
-        click: this.decreasePrio,
-        icon: "arrow down",
-      },
-      {
-        label: "Queue Top",
-        click: this.topPrio,
-        icon: "chevron circle up",
-      },
-      {
-        label: "Queue Bottom",
-        click: this.bottomPrio,
-        icon: "chevron circle down",
+        label: "Queue",
+        menu: [
+          {
+            label: "Move Up Queue",
+            click: this.increasePrio,
+            icon: "arrow up",
+          },
+          {
+            label: "Move Queue Down",
+            click: this.decreasePrio,
+            icon: "arrow down",
+          },
+          {
+            label: "Queue Top",
+            click: this.topPrio,
+            icon: "chevron circle up",
+          },
+          {
+            label: "Queue Bottom",
+            click: this.bottomPrio,
+            icon: "chevron circle down",
+          },
+        ],
       },
       {
         label: "Sequential Download",


### PR DESCRIPTION
## Summary

- group qBittorrent queue commands under a single **Queue** context-menu submenu
- preserve the existing queue action labels, handlers, and icons
- reduce the height of the torrent right-click menu

## Validation

- `npm run lint` — passed
- `npm run build` — passed
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-actions.spec.ts"` — 6 passed; the unrelated **Set Location** case failed after the qBittorrent test service disconnected (`socket hang up`)

No new test cases were added, as requested.