### PR TITLE
feat: add hierarchical torrent file selection

### DIFF
--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -167,7 +167,9 @@ export interface TorrentDetailsFileColumn {
     sortType?: "alphabetical" | "numeric"
 }
 
-export interface TorrentDetailsFileItem extends BittorrentTorrentDetailsFile {}
+export interface TorrentDetailsFileItem extends BittorrentTorrentDetailsFile {
+    wanted: boolean
+}
 
 export interface TorrentDetailsPanelData {
     info: {
@@ -372,10 +374,10 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
 
     protected getTorrentDetailsFilesColumns(_torrent: T, _details: BittorrentTorrentDetailsData): TorrentDetailsFileColumn[] {
         return [
+            { id: "wanted", label: "", format: "text", sortType: "alphabetical" },
             { id: "name", label: "Name", format: "text", sortType: "alphabetical" },
             { id: "size", label: "Size", format: "bytes", sortType: "numeric" },
             { id: "progress", label: "Progress", format: "progress", sortType: "numeric" },
-            { id: "wanted", label: "Wanted", format: "text", sortType: "alphabetical" },
             { id: "availability", label: "Availability", format: "percent", sortType: "numeric" },
             { id: "priority", label: "Priority", format: "number", sortType: "numeric" },
             { id: "path", label: "Path", format: "text", sortType: "alphabetical" },
@@ -387,7 +389,7 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
         _details: BittorrentTorrentDetailsData,
         file: BittorrentTorrentDetailsFile,
     ): TorrentDetailsFileItem {
-        return { ...file }
+        return { ...file, wanted: file.wanted !== false }
     }
 
     protected createTorrentDetailsField(

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -165,6 +165,7 @@ export interface TorrentDetailsFileColumn {
     label: string
     format?: "text" | "bytes" | "progress" | "percent" | "number"
     sortType?: "alphabetical" | "numeric"
+    sortable?: boolean
 }
 
 export interface TorrentDetailsFileItem extends BittorrentTorrentDetailsFile {
@@ -374,7 +375,7 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
 
     protected getTorrentDetailsFilesColumns(_torrent: T, _details: BittorrentTorrentDetailsData): TorrentDetailsFileColumn[] {
         return [
-            { id: "wanted", label: "", format: "text", sortType: "alphabetical" },
+            { id: "wanted", label: "", format: "text", sortType: "alphabetical", sortable: false },
             { id: "name", label: "Name", format: "text", sortType: "alphabetical" },
             { id: "size", label: "Size", format: "bytes", sortType: "numeric" },
             { id: "progress", label: "Progress", format: "progress", sortType: "numeric" },

--- a/src/renderer/app/directives/sorting/sorting.directive.ts
+++ b/src/renderer/app/directives/sorting/sorting.directive.ts
@@ -58,6 +58,12 @@ export class SortDirective implements IDirective {
         const column = $(element);
         scope.sort = scope.$eval(attr.sort || "");
 
+        if (attr.sortDisabled && scope.$eval(attr.sortDisabled)) {
+            scope.update = () => undefined;
+            column.addClass("sorting-disabled");
+            return;
+        }
+
         const setSortingArrow = (sortDesc?: boolean) => {
             if (controller.last) {
                 controller.last.removeClass("sortdown sortup");

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -498,6 +498,7 @@ export class TorrentDetailsPanelController {
 
     try {
       await client.setTorrentFileSelection(this.scope.torrent, files);
+      this.scheduleDetailsFilesUpdate(this.scope.torrent);
     } catch (err) {
       previous.forEach((entry) => { entry.file.wanted = entry.wanted; });
       this.scope.selectionError = err && err.message ? err.message : "Failed to update file selection";
@@ -506,6 +507,14 @@ export class TorrentDetailsPanelController {
       this.scope.selectionUpdating = false;
       this.scope.$evalAsync();
     }
+  }
+
+  private scheduleDetailsFilesUpdate(torrent: any) {
+    this.scope.$evalAsync(() => {
+      if (this.scope.isOpen && this.scope.torrent === torrent) {
+        void this.loadDetails(torrent);
+      }
+    });
   }
 
   private syncResizeBindings() {

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -16,9 +16,29 @@ export interface TorrentDetailsPanelScope extends IScope {
   torrent: any;
   panel: TorrentDetailsPanelData;
   activeTab: "info" | "files";
-  sortedFiles: TorrentDetailsFileItem[];
+  sortedFiles: TorrentDetailsFileRow[];
+  selectionUpdating: boolean;
+  selectionError: string | null;
   resizeMode: string;
   resizeProfile: string;
+}
+
+interface TorrentDetailsFileRow {
+  key: string;
+  depth: number;
+  isDirectory: boolean;
+  file?: TorrentDetailsFileItem;
+  filesInSubtree: TorrentDetailsFileItem[];
+  data: TorrentDetailsFileItem;
+}
+
+interface TorrentDetailsFileNode {
+  name: string;
+  path: string;
+  children: Map<string, TorrentDetailsFileNode>;
+  file?: TorrentDetailsFileItem;
+  filesInSubtree: TorrentDetailsFileItem[];
+  data: TorrentDetailsFileItem;
 }
 
 export class TorrentDetailsPanelController {
@@ -37,6 +57,7 @@ export class TorrentDetailsPanelController {
   private panelHeight = this.defaultPanelHeight;
   private loadRequestId = 0;
   private stopResizeListeners?: () => void;
+  private readonly collapsedFolders = new Set<string>();
 
   constructor(
     public scope: TorrentDetailsPanelScope,
@@ -51,6 +72,8 @@ export class TorrentDetailsPanelController {
     this.scope.torrent = null;
     this.scope.activeTab = "info";
     this.scope.sortedFiles = [];
+    this.scope.selectionUpdating = false;
+    this.scope.selectionError = null;
     this.scope.resizeMode = "OverflowResizer";
     this.scope.resizeProfile = this.getResizeProfile();
     this.scope.panel = {
@@ -180,6 +203,58 @@ export class TorrentDetailsPanelController {
     this.sortFiles();
   };
 
+  canSelectFiles() {
+    return !!this.rootScope.$btclient?.features.fileSelection;
+  }
+
+  isFolderExpanded(row: TorrentDetailsFileRow) {
+    return row.isDirectory && !this.collapsedFolders.has(row.data.path);
+  }
+
+  toggleFolder(row: TorrentDetailsFileRow, event?: Event) {
+    event?.stopPropagation();
+    if (!row.isDirectory) {
+      return;
+    }
+
+    if (this.collapsedFolders.has(row.data.path)) {
+      this.collapsedFolders.delete(row.data.path);
+    } else {
+      this.collapsedFolders.add(row.data.path);
+    }
+    this.sortFiles();
+  }
+
+  rowWanted(row: TorrentDetailsFileRow) {
+    return row.filesInSubtree.length > 0 && row.filesInSubtree.every((file) => file.wanted !== false);
+  }
+
+  rowSelectionIndeterminate(row: TorrentDetailsFileRow) {
+    const wanted = row.filesInSubtree.filter((file) => file.wanted !== false).length;
+    return wanted > 0 && wanted < row.filesInSubtree.length;
+  }
+
+  allFilesWanted() {
+    const files = this.scope.panel.files.items;
+    return files.length > 0 && files.every((file) => file.wanted !== false);
+  }
+
+  allFilesSelectionIndeterminate() {
+    const files = this.scope.panel.files.items;
+    const wanted = files.filter((file) => file.wanted !== false).length;
+    return wanted > 0 && wanted < files.length;
+  }
+
+  toggleAllFiles(event: Event) {
+    event.stopPropagation();
+    return this.updateFileSelection(this.scope.panel.files.items, !this.allFilesWanted());
+  }
+
+  toggleRowSelection(row: TorrentDetailsFileRow, event: Event) {
+    event.stopPropagation();
+    return this.updateFileSelection(row.filesInSubtree, !this.rowWanted(row));
+  }
+
   formatFieldValue(field: TorrentDetailsInfoField) {
     switch (field.format) {
       case "bytes":
@@ -263,6 +338,10 @@ export class TorrentDetailsPanelController {
       }
 
       this.scope.panel = panel || this.scope.panel;
+      this.scope.panel.files.items.forEach((file) => {
+        file.wanted = file.wanted !== false;
+      });
+      this.scope.selectionError = null;
       this.loadSortingSettings();
       this.sortFiles();
     } catch (err) {
@@ -281,27 +360,152 @@ export class TorrentDetailsPanelController {
 
   private sortFiles() {
     const columns = this.scope.panel?.files?.columns || [];
-    const items = [...(this.scope.panel?.files?.items || [])];
     const column = columns.find((entry) => entry.id === this.fileSortKey) || columns[0];
     const sortKey = column?.id || "name";
     const sortType = column?.sortType || (sortKey === "name" || sortKey === "path" ? "alphabetical" : "numeric");
+    const root = this.buildFileTree(this.scope.panel?.files?.items || []);
+    const rows: TorrentDetailsFileRow[] = [];
 
-    items.sort((left, right) => {
-      const leftValue = left[sortKey];
-      const rightValue = right[sortKey];
-
-      if (sortType === "alphabetical") {
-        return String(leftValue || "").toLowerCase().localeCompare(String(rightValue || "").toLowerCase());
+    const compareNodes = (left: TorrentDetailsFileNode, right: TorrentDetailsFileNode) => {
+      const leftIsDirectory = left.children.size > 0 && !left.file;
+      const rightIsDirectory = right.children.size > 0 && !right.file;
+      if (leftIsDirectory !== rightIsDirectory) {
+        return leftIsDirectory ? -1 : 1;
       }
 
-      return Number(leftValue || 0) - Number(rightValue || 0);
+      const leftValue = left.data[sortKey];
+      const rightValue = right.data[sortKey];
+      const compared = sortType === "alphabetical"
+        ? String(leftValue ?? "").toLowerCase().localeCompare(String(rightValue ?? "").toLowerCase())
+        : Number(leftValue ?? 0) - Number(rightValue ?? 0);
+      const ordered = this.fileSortDescending ? -compared : compared;
+      return ordered || left.name.localeCompare(right.name);
+    };
+
+    const visit = (node: TorrentDetailsFileNode, depth: number, visible: boolean) => {
+      const isDirectory = node.children.size > 0 && !node.file;
+      if (visible) {
+        rows.push({
+          key: isDirectory ? `folder:${node.path}` : `file:${node.file?.index}`,
+          depth,
+          isDirectory,
+          file: node.file,
+          filesInSubtree: node.filesInSubtree,
+          data: node.data,
+        });
+      }
+
+      const childrenVisible = visible && (!isDirectory || !this.collapsedFolders.has(node.path));
+      Array.from(node.children.values()).sort(compareNodes).forEach((child) => visit(child, depth + 1, childrenVisible));
+    };
+
+    Array.from(root.children.values()).sort(compareNodes).forEach((node) => visit(node, 0, true));
+    this.scope.sortedFiles = rows;
+  }
+
+  private buildFileTree(files: TorrentDetailsFileItem[]) {
+    const emptyData = (name = "", path = ""): TorrentDetailsFileItem => ({
+      index: -1,
+      name,
+      path,
+      size: 0,
+      progress: 0,
+      wanted: false,
+    });
+    const root: TorrentDetailsFileNode = {
+      name: "",
+      path: "",
+      children: new Map(),
+      filesInSubtree: [],
+      data: emptyData(),
+    };
+
+    files.forEach((file) => {
+      const normalizedPath = (file.path || file.name || "").replace(/\\/g, "/");
+      const parts = normalizedPath.split("/").filter(Boolean);
+      if (!parts.length) {
+        return;
+      }
+
+      let node = root;
+      let currentPath = "";
+      parts.forEach((part, index) => {
+        currentPath = currentPath ? `${currentPath}/${part}` : part;
+        let child = node.children.get(part);
+        if (!child) {
+          child = {
+            name: part,
+            path: currentPath,
+            children: new Map(),
+            filesInSubtree: [],
+            data: emptyData(part, currentPath),
+          };
+          node.children.set(part, child);
+        }
+        if (index === parts.length - 1) {
+          child.file = file;
+          child.data = file;
+        }
+        node = child;
+      });
     });
 
-    if (this.fileSortDescending) {
-      items.reverse();
+    const aggregate = (node: TorrentDetailsFileNode): TorrentDetailsFileItem[] => {
+      if (node.file) {
+        node.filesInSubtree = [node.file];
+        return node.filesInSubtree;
+      }
+
+      node.filesInSubtree = Array.from(node.children.values()).flatMap(aggregate);
+      const totalSize = node.filesInSubtree.reduce((sum, file) => sum + (Number(file.size) || 0), 0);
+      const weightedValue = (key: "progress" | "availability") => {
+        const values = node.filesInSubtree.filter((file) => Number.isFinite(Number(file[key])));
+        if (!values.length) {
+          return undefined;
+        }
+        if (totalSize > 0) {
+          return values.reduce((sum, file) => sum + Number(file[key]) * (Number(file.size) || 0), 0) / totalSize;
+        }
+        return values.reduce((sum, file) => sum + Number(file[key]), 0) / values.length;
+      };
+      const priorities = new Set(node.filesInSubtree.map((file) => file.priority).filter((value) => value != null));
+      node.data = {
+        ...node.data,
+        size: totalSize,
+        progress: weightedValue("progress") || 0,
+        availability: weightedValue("availability"),
+        wanted: node.filesInSubtree.every((file) => file.wanted !== false),
+        priority: priorities.size === 1 ? priorities.values().next().value : undefined,
+      };
+      return node.filesInSubtree;
+    };
+
+    aggregate(root);
+    return root;
+  }
+
+  private async updateFileSelection(files: TorrentDetailsFileItem[], wanted: boolean) {
+    const client = this.rootScope.$btclient;
+    if (!this.canSelectFiles() || !client || !this.scope.torrent || this.scope.selectionUpdating || !files.length) {
+      return;
     }
 
-    this.scope.sortedFiles = items;
+    const previous = files.map((file) => ({ file, wanted: file.wanted }));
+    files.forEach((file) => { file.wanted = wanted; });
+    this.scope.selectionUpdating = true;
+    this.scope.selectionError = null;
+    this.sortFiles();
+
+    try {
+      await client.setTorrentFileSelection(this.scope.torrent, files);
+    } catch (err) {
+      previous.forEach((entry) => { entry.file.wanted = entry.wanted; });
+      this.scope.selectionError = err && err.message ? err.message : "Failed to update file selection";
+      this.sortFiles();
+    } finally {
+      this.scope.selectionUpdating = false;
+      this.scope.$evalAsync();
+    }
   }
 
   private syncResizeBindings() {
@@ -328,11 +532,14 @@ export class TorrentDetailsPanelController {
   private resetPanelState() {
     this.scope.loading = false;
     this.scope.error = null;
+    this.scope.selectionError = null;
+    this.scope.selectionUpdating = false;
     this.scope.torrent = null;
     this.scope.panel = {
       info: { sections: [] },
       files: { columns: [], items: [] },
     };
     this.scope.sortedFiles = [];
+    this.collapsedFolders.clear();
   }
 }

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -69,6 +69,9 @@
       ng-if="!ctl.showStateMessage() && ctl.isActiveTab('files')"
     >
       <div class="torrent-details-files-content">
+        <div class="ui tiny negative message torrent-details-files-error" ng-if="ctl.scope.selectionError">
+          {{ ctl.scope.selectionError }}
+        </div>
         <table
           id="torrentDetailsFilesTable"
           data-role="torrent-details-files-table"
@@ -93,29 +96,73 @@
                 rz-col="column.id"
                 sort="column.id"
               >
-                <span class="torrent-details-files-header-label">{{ column.label }}</span>
+                <div ng-if="column.id === 'wanted'" class="ui checkbox torrent-details-file-checkbox">
+                  <input
+                    type="checkbox"
+                    aria-label="Select all files"
+                    data-role="torrent-details-files-select-all"
+                    ng-checked="ctl.allFilesWanted()"
+                    indeterminate-value="ctl.allFilesSelectionIndeterminate()"
+                    ng-disabled="!ctl.canSelectFiles() || ctl.scope.selectionUpdating"
+                    ng-click="ctl.toggleAllFiles($event)"
+                  />
+                  <label></label>
+                </div>
+                <span ng-if="column.id !== 'wanted'" class="torrent-details-files-header-label">{{ column.label }}</span>
               </th>
             </tr>
           </thead>
           <tbody>
-            <tr ng-repeat="file in ctl.scope.sortedFiles track by file.index" data-file-index="{{ file.index }}">
+            <tr
+              ng-repeat="row in ctl.scope.sortedFiles track by row.key"
+              ng-class="{ 'torrent-details-folder-row': row.isDirectory }"
+              data-file-index="{{ row.file.index }}"
+              data-file-path="{{ row.data.path }}"
+            >
               <td ng-repeat="column in ctl.scope.panel.files.columns track by column.id" data-col="{{ column.id }}">
                 <div ng-if="column.id === 'wanted'" class="torrent-details-file-cell">
-                  <i
-                    ng-if="file.wanted"
-                    class="tiny check icon"
-                    data-role="torrent-details-file-wanted-check"
-                    aria-label="Wanted"
-                  ></i>
+                  <div class="ui checkbox torrent-details-file-checkbox">
+                    <input
+                      type="checkbox"
+                      aria-label="{{ row.isDirectory ? 'Select folder ' : 'Select file ' }}{{ row.data.name }}"
+                      data-role="torrent-details-file-checkbox"
+                      ng-checked="ctl.rowWanted(row)"
+                      indeterminate-value="ctl.rowSelectionIndeterminate(row)"
+                      ng-disabled="!ctl.canSelectFiles() || ctl.scope.selectionUpdating"
+                      ng-click="ctl.toggleRowSelection(row, $event)"
+                    />
+                    <label></label>
+                  </div>
                 </div>
                 <div ng-if="column.id !== 'wanted'" ng-switch="column.format" class="torrent-details-file-cell">
                   <div ng-switch-when="progress" class="torrent-details-file-progress">
                     <div class="ui tiny indicating progress">
-                      <div class="bar" ng-style="{ width: ctl.fileProgressPercent(file) + '%' }"></div>
+                      <div class="bar" ng-style="{ width: ctl.fileProgressPercent(row.data) + '%' }"></div>
                     </div>
-                    <span>{{ ctl.fileProgressPercent(file) | number:1 }}%</span>
+                    <span>{{ ctl.fileProgressPercent(row.data) | number:1 }}%</span>
                   </div>
-                  <span ng-switch-default>{{ ctl.formatFileCell(column, file) }}</span>
+                  <div
+                    ng-switch-default
+                    ng-if="column.id === 'name'"
+                    class="torrent-details-file-name"
+                    ng-style="{ 'padding-left': (row.depth * 18) + 'px' }"
+                    title="{{ row.data.path }}"
+                    ng-click="row.isDirectory && ctl.toggleFolder(row, $event)"
+                  >
+                    <button
+                      ng-if="row.isDirectory"
+                      type="button"
+                      class="ui icon basic button torrent-details-folder-toggle"
+                      aria-label="{{ ctl.isFolderExpanded(row) ? 'Collapse' : 'Expand' }} {{ row.data.name }}"
+                      aria-expanded="{{ ctl.isFolderExpanded(row) }}"
+                      ng-click="ctl.toggleFolder(row, $event)"
+                    >
+                      <i class="icon" ng-class="ctl.isFolderExpanded(row) ? 'caret down' : 'caret right'"></i>
+                    </button>
+                    <i ng-if="!row.isDirectory" class="file outline icon torrent-details-file-icon"></i>
+                    <span>{{ row.data.name }}</span>
+                  </div>
+                  <span ng-switch-default ng-if="column.id !== 'name'">{{ ctl.formatFileCell(column, row.data) }}</span>
                 </div>
               </td>
             </tr>

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -95,6 +95,8 @@
                 ng-repeat="column in ctl.scope.panel.files.columns track by column.id"
                 rz-col="column.id"
                 sort="column.id"
+                sort-disabled="column.sortable === false"
+                ng-class="{ 'torrent-details-file-selection-column': column.id === 'wanted' }"
               >
                 <div ng-if="column.id === 'wanted'" class="ui checkbox torrent-details-file-checkbox">
                   <input

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -838,8 +838,21 @@ torrent-sidebar + .main-panel {
             display: flex;
             align-items: center;
             justify-content: center;
+            flex: 0 0 17px;
+            width: 17px;
+            height: 17px;
             min-height: 17px;
             min-width: 17px;
+
+            > input,
+            > label {
+                width: 17px;
+                height: 17px;
+            }
+
+            > label {
+                padding: 0;
+            }
         }
 
         .torrent-details-files-content .torrent.table th.torrent-details-file-selection-column,

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -826,6 +826,55 @@ torrent-sidebar + .main-panel {
                 margin: 0;
             }
         }
+
+        .torrent-details-files-error {
+            position: sticky;
+            top: 0;
+            z-index: 2;
+            margin: 0;
+        }
+
+        .torrent-details-file-checkbox {
+            min-height: 17px;
+            min-width: 17px;
+        }
+
+        .torrent-details-file-name {
+            display: flex;
+            align-items: center;
+            min-width: 0;
+            cursor: default;
+
+            > span {
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+
+        .torrent-details-folder-row .torrent-details-file-name {
+            cursor: pointer;
+            font-weight: 600;
+        }
+
+        .torrent-details-folder-toggle.ui.button {
+            flex: 0 0 18px;
+            width: 18px;
+            min-height: 18px;
+            margin: 0 2px 0 0;
+            padding: 0;
+            border: 0;
+            box-shadow: none;
+
+            .icon {
+                width: auto;
+                margin: 0;
+            }
+        }
+
+        .torrent-details-file-icon {
+            flex: 0 0 18px;
+            margin: 0 2px 0 0;
+        }
     }
 
     .status-bar {

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -835,8 +835,33 @@ torrent-sidebar + .main-panel {
         }
 
         .torrent-details-file-checkbox {
+            display: flex;
+            align-items: center;
+            justify-content: center;
             min-height: 17px;
             min-width: 17px;
+        }
+
+        .torrent-details-files-content .torrent.table th.torrent-details-file-selection-column,
+        .torrent-details-files-content .torrent.table td[data-col="wanted"] {
+            width: 38px !important;
+            min-width: 25px;
+            max-width: 38px;
+            padding-right: 0;
+            padding-left: 0;
+            vertical-align: middle;
+            text-align: center;
+        }
+
+        .torrent-details-file-selection-column .rz-handle {
+            display: none;
+        }
+
+        td[data-col="wanted"] .torrent-details-file-cell {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 17px;
         }
 
         .torrent-details-file-name {

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -114,8 +114,21 @@ describe("torrent details", function () {
     selectionHandleDisplayed.should.equal(false)
     selectionSortIconExists.should.equal(false)
 
+    const selectionCell = filesTable.$("tbody td[data-col='wanted']")
+    const selectionCheckbox = selectionCell.$(".torrent-details-file-checkbox")
+    const cellLocation = await selectionCell.getLocation()
+    const cellSize = await selectionCell.getSize()
+    const checkboxLocation = await selectionCheckbox.getLocation()
+    const checkboxSize = await selectionCheckbox.getSize()
+    checkboxLocation.x.should.be.at.least(cellLocation.x)
+    checkboxLocation.y.should.be.at.least(cellLocation.y)
+    const checkboxRight = checkboxLocation.x + checkboxSize.width
+    const checkboxBottom = checkboxLocation.y + checkboxSize.height
+    checkboxRight.should.be.at.most(cellLocation.x + cellSize.width)
+    checkboxBottom.should.be.at.most(cellLocation.y + cellSize.height)
+
     const firstResizableHeader = headers[1]
-    const controlledHeader = headers[2]
+    const controlledHeader = firstResizableHeader
     const handle = firstResizableHeader.$(".rz-handle")
     await handle.waitForDisplayed({ timeout: 10_000 })
 

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -3,7 +3,7 @@ import parseTorrent from "parse-torrent"
 import * as e2e from "../../e2e"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec, formatBytes, getTestFixture, requireFeature } from "../../framework/fixture"
-import { createSlowTorrentFile } from "../../torrent"
+import { createTorrentFile } from "../../torrent"
 
 const tracker = getTestFixture().tracker
 describe("torrent details", function () {
@@ -14,7 +14,15 @@ describe("torrent details", function () {
   let torrentMetadata: parseTorrent.Instance
 
   before(async function () {
-    const filename = await createSlowTorrentFile(tracker)
+    const filename = await createTorrentFile(tracker, {
+      files: {
+        "documents/readme.txt": 100_000,
+        "documents/guides/setup.txt": 100_000,
+        "media/preview.jpg": 100_000,
+      },
+      downloadSpeed: 1,
+      uploadSpeed: 1,
+    })
     torrentMetadata = parseTorrent(fs.readFileSync(filename)) as parseTorrent.Instance
     torrent = await this.app.uploadTorrent({ filename })
     await torrent.waitForExist()
@@ -59,6 +67,18 @@ describe("torrent details", function () {
 
     const progressBar = filesTab.$(".torrent-details-file-progress .bar")
     await progressBar.waitForExist({ timeout: 10_000 })
+
+    const firstHeaderCheckbox = filesTab.$("thead th:first-child input[type='checkbox']")
+    await firstHeaderCheckbox.waitForExist({ timeout: 10_000 })
+
+    const folderRow = filesTab.$("tbody tr.torrent-details-folder-row")
+    await folderRow.waitForDisplayed({ timeout: 10_000 })
+    const visibleRowsBeforeCollapse = await filesTab.$$("tbody tr")
+    const rowCountBeforeCollapse = await visibleRowsBeforeCollapse.length
+
+    await folderRow.$(".torrent-details-folder-toggle").click()
+    await eventually(async () => (await filesTab.$$("tbody tr")).length)
+      .satisfies("decrease after collapsing a folder", (count) => count < rowCountBeforeCollapse)
 
     await torrent.closeDetailsPanel()
   })

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -58,11 +58,21 @@ describe("torrent details", function () {
 
     const filesTab = panel.$("[data-role='torrent-details-files']")
     const expectedFile = torrentMetadata.files?.[0]
+    const expectedPath = expectedFile?.path || ""
+    const torrentRoot = `${torrentMetadata.name || ""}/`
+    const expectedRelativePath = expectedPath.startsWith(torrentRoot)
+      ? expectedPath.slice(torrentRoot.length)
+      : expectedPath
+    const expectedPaths = new Set([expectedPath, expectedRelativePath].filter(Boolean))
 
-    await eventually(() => filesTab.getText()).contains(expectedFile?.path || "", { timeout: 30_000 })
+    await eventually(() => filesTab.getText()).satisfies(
+      `contain a client-normalized path for ${expectedPath}`,
+      (text) => Array.from(expectedPaths).some((path) => text.includes(path)),
+      { timeout: 30_000 },
+    )
 
     const filesText = await filesTab.getText()
-    filesText.should.contain(expectedFile?.path || "")
+    Array.from(expectedPaths).some((path) => filesText.includes(path)).should.equal(true)
     filesText.should.contain(formatBytes(expectedFile?.length || 0))
 
     const progressBar = filesTab.$(".torrent-details-file-progress .bar")

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -106,14 +106,23 @@ describe("torrent details", function () {
       .satisfies("be greater than 1", (count) => count > 1, { timeout: 30_000 })
 
     const headers = await filesTable.$$("thead th")
-    const firstHeader = headers[0]
-    const handle = firstHeader.$(".rz-handle")
+    const selectionHeader = headers[0]
+    const selectionWidth = (await selectionHeader.getSize()).width
+    selectionWidth.should.be.at.most(40)
+    const selectionHandleDisplayed = await selectionHeader.$(".rz-handle").isDisplayed()
+    const selectionSortIconExists = await selectionHeader.$(".sorting.icon").isExisting()
+    selectionHandleDisplayed.should.equal(false)
+    selectionSortIconExists.should.equal(false)
+
+    const firstResizableHeader = headers[1]
+    const controlledHeader = headers[2]
+    const handle = firstResizableHeader.$(".rz-handle")
     await handle.waitForDisplayed({ timeout: 10_000 })
 
-    const initialWidth = (await firstHeader.getSize()).width
+    const initialWidth = (await controlledHeader.getSize()).width
     await handle.dragAndDrop({ x: 40, y: 0 })
 
-    await eventually(async () => (await firstHeader.getSize()).width)
+    await eventually(async () => (await controlledHeader.getSize()).width)
       .satisfies(`change by at least 10 from ${initialWidth}`, (nextWidth) => Math.abs(nextWidth - initialWidth) >= 10)
 
     await torrent.closeDetailsPanel()

--- a/test/specs/standard/torrent-file-selection.spec.ts
+++ b/test/specs/standard/torrent-file-selection.spec.ts
@@ -1,6 +1,7 @@
 import chai from "chai"
 import { $ } from "@wdio/globals"
 import * as e2e from "../../e2e"
+import { eventually } from "../../e2e/eventually"
 import { waitForModalClose, waitForModalOpen } from "../../e2e/modal"
 import { configureSpec, getTestFixture, requireFeature } from "../../framework/fixture"
 import { createSlowTorrentFile } from "../../torrent"
@@ -23,6 +24,30 @@ describe("torrent file selection", function () {
     if (torrent && await torrent.isExisting()) {
       await torrent.delete()
     }
+  })
+
+  it("persists file wanted state via torrent details", async function () {
+    this.timeout(60 * 1000)
+
+    const panel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("files")
+
+    const firstFileCheckbox = panel.$("[data-role='torrent-details-file-checkbox']")
+    await firstFileCheckbox.waitForEnabled({ timeout: 30_000 })
+
+    const initialSelected = await firstFileCheckbox.isSelected()
+    await firstFileCheckbox.click()
+    await eventually(() => firstFileCheckbox.isSelected()).equals(!initialSelected)
+
+    await torrent.closeDetailsPanel()
+    const reopenedPanel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("files")
+
+    const checkboxAfter = reopenedPanel.$("[data-role='torrent-details-file-checkbox']")
+    await checkboxAfter.waitForEnabled({ timeout: 30_000 })
+    await eventually(() => checkboxAfter.isSelected()).equals(!initialSelected)
+
+    await torrent.closeDetailsPanel()
   })
 
   it("persists file wanted state via Files modal", async function () {

--- a/test/specs/standard/upload-file-selection.spec.ts
+++ b/test/specs/standard/upload-file-selection.spec.ts
@@ -43,13 +43,15 @@ describe("upload file selection", function () {
 
     const firstFileWanted = $("[data-role='torrent-details-files-table'] tbody tr[data-file-index='0'] td[data-col='wanted']")
     await firstFileWanted.waitForDisplayed({ timeout: 30 * 1000 })
-    await eventually(() => firstFileWanted.getText()).equals("", { timeout: 30 * 1000 })
-    const firstFileWantedIconExists = await firstFileWanted.$("[data-role='torrent-details-file-wanted-check']").isExisting()
-    firstFileWantedIconExists.should.equal(false)
+    const firstFileWantedCheckbox = firstFileWanted.$("[data-role='torrent-details-file-checkbox']")
+    await firstFileWantedCheckbox.waitForExist({ timeout: 30 * 1000 })
+    await eventually(() => firstFileWantedCheckbox.isSelected()).equals(false, { timeout: 30 * 1000 })
 
     const secondFileWanted = $("[data-role='torrent-details-files-table'] tbody tr[data-file-index='1'] td[data-col='wanted']")
     await secondFileWanted.waitForDisplayed({ timeout: 30 * 1000 })
-    await secondFileWanted.$("[data-role='torrent-details-file-wanted-check']").waitForDisplayed({ timeout: 30 * 1000 })
+    const secondFileWantedCheckbox = secondFileWanted.$("[data-role='torrent-details-file-checkbox']")
+    await secondFileWantedCheckbox.waitForExist({ timeout: 30 * 1000 })
+    await eventually(() => secondFileWantedCheckbox.isSelected()).equals(true, { timeout: 30 * 1000 })
 
     await torrent.closeDetailsPanel()
   })


### PR DESCRIPTION
## What changed

- render torrent files as an expandable folder hierarchy
- add first-column tri-state selection controls for all files, folders, and individual files
- aggregate folder size, progress, availability, priority, and wanted state
- persist selective-download changes through the existing client-agnostic API
- roll back optimistic selection changes and show an inline error when an update fails
- add end-to-end coverage for hierarchy collapsing and selection persistence

## Why

The torrent details file table previously showed a flat list and only displayed wanted state. Users could not understand nested file structure or change which files should download from the details panel.

## Impact

Users can browse nested torrent contents, collapse folders, and select or deselect entire torrents, folders, or individual files. Clients without file-selection support keep the hierarchy but show disabled selection controls.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts"`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-file-selection.spec.ts"`