### PR TITLE
refactor(renderer): class-based settings services

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -81,8 +81,8 @@ import { bittorrentService } from "@renderer/app/services/bittorrent"
 torrentApp.service("$bittorrent", bittorrentService)
 import { SettingsService } from "@renderer/app/services/settings"
 torrentApp.service("settingsService", SettingsService)
-import { notificationService } from "@renderer/app/services/notification"
-torrentApp.service("notificationService", notificationService)
+import { NotificationService } from "@renderer/app/services/notification"
+torrentApp.service("notificationService", NotificationService)
 import { CertificateResponseService } from "@renderer/app/services/certificate-response"
 torrentApp.service("certificateResponseService", CertificateResponseService)
 import { labelColorService } from "@renderer/app/services/label-colors"

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -79,8 +79,8 @@ import { httpFormService } from "@renderer/app/services/httpFormService"
 torrentApp.factory("httpFormService", httpFormService)
 import { bittorrentService } from "@renderer/app/services/bittorrent"
 torrentApp.service("$bittorrent", bittorrentService)
-import { settingsService } from "@renderer/app/services/settings"
-torrentApp.service("settingsService", settingsService)
+import { SettingsService } from "@renderer/app/services/settings"
+torrentApp.service("settingsService", SettingsService)
 import { notificationService } from "@renderer/app/services/notification"
 torrentApp.service("notificationService", notificationService)
 import { CertificateResponseService } from "@renderer/app/services/certificate-response"

--- a/src/renderer/app/directives/welcome-page/welcome-page.controller.ts
+++ b/src/renderer/app/directives/welcome-page/welcome-page.controller.ts
@@ -35,7 +35,7 @@ export class WelcomePageController {
 
 
         function saveServer(ip: string, port: number, username: string, password: string, client: string) {
-            const server = new Server(ip, port, username, password, client);
+            const server = new Server({ ip, port, user: username, password, client });
 
             $bittorrent.setServer(server);
 

--- a/src/renderer/app/services/notification.ts
+++ b/src/renderer/app/services/notification.ts
@@ -1,73 +1,70 @@
+import type { IRootScopeService } from "angular"
 
-export let notificationService = ["$rootScope", function ($rootScope) {
-    const electorrent = window.electorrent
+const ERR_SELF_SIGNED_CERT = "DEPTH_ZERO_SELF_SIGNED_CERT"
+const ERR_TLS_CERT_ALTNAME_INVALID = "ERR_TLS_CERT_ALTNAME_INVALID"
+const CERT_HAS_EXPIRED = "CERT_HAS_EXPIRED"
+const UNABLE_TO_VERIFY_LEAF_SIGNATURE = "UNABLE_TO_VERIFY_LEAF_SIGNATURE"
 
-    const ERR_SELF_SIGNED_CERT = 'DEPTH_ZERO_SELF_SIGNED_CERT'
-    const ERR_TLS_CERT_ALTNAME_INVALID = 'ERR_TLS_CERT_ALTNAME_INVALID'
-    const CERT_HAS_EXPIRED = 'CERT_HAS_EXPIRED'
-    const UNABLE_TO_VERIFY_LEAF_SIGNATURE = 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+const ERR_CODES = {
+    ERR_SELF_SIGNED_CERT: {
+        title: "Untrusted certificate",
+        msg: "Self signed certificate is not trusted with this server",
+    },
+    ERR_TLS_CERT_ALTNAME_INVALID: {
+        title: "Certificate error",
+        msg: "The certificate is not useable with this server because the common name of the certificate does not match the hostname of the server",
+    },
+    CERT_HAS_EXPIRED: {
+        title: "Certificate expired",
+        msg: "The certificate for this server has expired and is therefore not trusted",
+    },
+    UNABLE_TO_VERIFY_LEAF_SIGNATURE: {
+        title: "Invalid certificate chain",
+        msg: "The certificate could not be verified because the certificate chain is invalid. Consolidate your webserver TLS configuration",
+    },
+}
 
-    const ERR_CODES = {
-        ERR_SELF_SIGNED_CERT: {
-            title: 'Untrusted certificate',
-            msg: 'Self signed certificate is not trusted with this server',
-        },
-        ERR_TLS_CERT_ALTNAME_INVALID: {
-            title: 'Certificate error',
-            msg: 'The certificate is not useable with this server\
-                because the common name of the certificate does not match\
-                the hostname of the server',
-        },
-        CERT_HAS_EXPIRED: {
-            title: 'Certificate expired',
-            msg: 'The certificate for this server has expired\
-                and is therefore not trusted',
-        },
-        UNABLE_TO_VERIFY_LEAF_SIGNATURE: {
-            title: 'Invalid certificate chain',
-            msg: 'The certificate could not be verified because the certificate\
-                chain is invalid. Consolidate your webserver TLS configuration'
-        }
+type NotificationType = "negative" | "warning" | "positive"
+
+export class NotificationService {
+    static $inject = ["$rootScope"]
+
+    private notificationsDisabled = false
+
+    constructor(private readonly $rootScope: IRootScopeService) {
+        window.electorrent.notifications.onPush((data) => {
+            this.$rootScope.$applyAsync(() => {
+                this.sendNotification(data.title, data.message, data.type || "warning")
+            })
+        })
     }
 
-    var disableNotifications = false;
-
-    this.disableAll = function () {
-        disableNotifications = true;
+    disableAll(): void {
+        this.notificationsDisabled = true
     }
 
-    this.enableAll = function () {
-        disableNotifications = false;
+    enableAll(): void {
+        this.notificationsDisabled = false
     }
 
-    this.alert = function (title, message) {
-        sendNotification(title, message, "negative");
+    alert(title: string, message: string): void {
+        this.sendNotification(title, message, "negative")
     }
 
-    this.warning = function (title, message) {
-        sendNotification(title, message, "warning");
+    warning(title: string, message: string): void {
+        this.sendNotification(title, message, "warning")
     }
 
-    this.ok = function (title, message) {
-        sendNotification(title, message, "positive");
+    ok(title: string, message: string): void {
+        this.sendNotification(title, message, "positive")
     }
 
-    function sendNotification(title, message, type) {
-        if (disableNotifications) return;
-        var notification = {
-            title: title,
-            message: message,
-            type: type
-        }
-        $rootScope.$emit('notification', notification);
-    }
-
-    this.alertAuth = function (err) {
-        if (typeof err === 'string') {
-            this.alert('Connection problem', err)
-        } else if (typeof err !== 'object') {
+    alertAuth(err: any): void {
+        if (typeof err === "string") {
+            this.alert("Connection problem", err)
+        } else if (typeof err !== "object") {
             this.alert("Connection problem", "Could not connect to client.")
-        } else if (typeof err.message === 'string' && err.kind) {
+        } else if (typeof err.message === "string" && err.kind) {
             this.alert("Connection problem", err.message)
         } else if (err.status === -1) {
             this.alert("Connection problem", "Connection timed out.")
@@ -80,20 +77,16 @@ export let notificationService = ["$rootScope", function ($rootScope) {
         }
     }
 
-    this.torrentComplete = function (torrent) {
-        var torrentNotification = new Notification('Torrent Completed!', {
+    torrentComplete(torrent: { decodedName: string }): void {
+        const torrentNotification = new Notification("Torrent Completed!", {
             body: torrent.decodedName,
-            icon: 'img/electorrent-icon.png'
+            icon: "img/electorrent-icon.png",
         })
-
         torrentNotification.onclick = () => {}
     }
 
-    // Listen for incomming notifications from main process
-    electorrent.notifications.onPush(function (data) {
-        $rootScope.$applyAsync(function () {
-            sendNotification(data.title, data.message, data.type || 'warning');
-        })
-    })
-
-}];
+    private sendNotification(title: string, message: string, type: NotificationType | string): void {
+        if (this.notificationsDisabled) return
+        this.$rootScope.$emit("notification", { title, message, type })
+    }
+}

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -5,13 +5,9 @@ import type { TorrentClient } from "@renderer/app/bittorrent/torrentclient"
 import type { ColumnProps } from "@renderer/app/services/column"
 import { parseServerAddressInput, sanitizeServerAddress } from "@shared/server-address"
 import type { CertificateResponseService } from "@renderer/app/services/certificate-response"
+import type { NotificationService } from "@renderer/app/services/notification"
 import type { LabelColorHue, LabelColorOverrides, SavedLocationConfig, StoredServerConfig, TorrentUploadOptions } from "@shared/ipc-contract"
 import { normalizeLabelColorHue } from "@renderer/app/services/label-colors"
-
-type NotificationService = {
-    alert(title: string, message: string): void
-    alertAuth(error: unknown): void
-}
 
 type BittorrentService = {
     getClient(name: string): TorrentClient
@@ -101,30 +97,19 @@ export class Server implements Omit<StoredServerConfig, "columns"> {
         return Server
     }
 
-    constructor(data: StoredServerConfig)
-    constructor(ip: string, port: number, user: string, password: string, client: string)
-    constructor(ip?: string, proto?: string, port?: number, user?: string, password?: string, client?: string, path?: string)
-    constructor(ipOrData?: string | StoredServerConfig, protoOrPort?: string | number, portOrUser?: number | string, userOrPassword?: string, passwordOrClient?: string, client?: string, path?: string) {
+    constructor(config: Partial<StoredServerConfig> = {}) {
         this.certificateData = undefined
-        if (typeof ipOrData === "object") {
-            this.fromJson(ipOrData)
+        if (config.id) {
+            this.fromJson(config as StoredServerConfig)
         } else {
             this.id = generateGUID()
-            this.ip = ipOrData || ""
-            if (typeof protoOrPort === "number") {
-                this.proto = "http"
-                this.port = protoOrPort
-                this.user = String(portOrUser || "")
-                this.password = userOrPassword || ""
-                this.client = passwordOrClient
-            } else {
-                this.proto = protoOrPort
-                this.port = portOrUser as number
-                this.user = userOrPassword || ""
-                this.password = passwordOrClient || ""
-                this.client = client
-            }
-            this.path = path
+            this.ip = config.ip || ""
+            this.proto = config.proto || "http"
+            this.port = config.port
+            this.user = config.user || ""
+            this.password = config.password || ""
+            this.client = config.client
+            this.path = config.path
             this.lastused = -1
             this.columns = this.defaultColumns()
             this.savedLocations = []

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -1,372 +1,344 @@
 import _ from "underscore"
-import type { IPromise } from "angular"
 import { Torrent } from "@renderer/app/bittorrent"
+import type { TorrentClient } from "@renderer/app/bittorrent/torrentclient"
 import type { ColumnProps } from "@renderer/app/services/column"
 import { parseServerAddressInput, sanitizeServerAddress } from "@shared/server-address"
 import type { CertificateResponseService } from "@renderer/app/services/certificate-response"
 import type { LabelColorHue, LabelColorOverrides, SavedLocationConfig, StoredServerConfig, TorrentUploadOptions } from "@shared/ipc-contract"
 import { normalizeLabelColorHue } from "@renderer/app/services/label-colors"
 
-export interface Server extends Omit<StoredServerConfig, "columns"> {
-    columns: ColumnProps[]
-    certificateData?: Uint8Array
-    isConnected: boolean
-    connect(): IPromise<void>
-    getName(): string
-    getIcon(): string
-    getNameAtAddress(): string
-    getDisplayName(): string
-    updateLastUsed(): void
-    cleanPath(): string
-    setPath(): void
-    url(): string
-    isHTTPS(): boolean
-    askForCertificate(): IPromise<void>
-    getCertificate(): Uint8Array | undefined
-    equals(other: Server): boolean
-    parseColumns(columns?: string[]): ColumnProps[]
-    defaultColumns(): ColumnProps[]
-    addCustomColumns(columns: ColumnProps[]): ColumnProps[]
-    bootstrap(): void
-    json(): StoredServerConfig
+type NotificationService = {
+    alert(title: string, message: string): void
+    alertAuth(error: unknown): void
 }
 
-export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclients', 'certificateResponseService',
-    function($q, $notify, $bittorrent, $btclients, certificateResponseService: CertificateResponseService) {
-        const electorrent = window.electorrent
+type BittorrentService = {
+    getClient(name: string): TorrentClient
+    setServer(server: Server): void
+}
 
-        /*
-         * Well known error values used for error handling
-         */
-        const TLS_CERTIFICATE_ERROR_CODES = new Set([
-            "DEPTH_ZERO_SELF_SIGNED_CERT",
-            "SELF_SIGNED_CERT_IN_CHAIN",
-            "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-            "CERT_HAS_EXPIRED",
-            "ERR_TLS_CERT_ALTNAME_INVALID",
-        ])
+type BittorrentClientMetadata = Record<string, { name: string, icon: string }>
 
-        function isTlsCertificateError(err: any) {
-            if (!err) {
-                return false
-            }
+type ServerDependencies = {
+    $notify: NotificationService
+    $bittorrent: BittorrentService
+    $btclients: BittorrentClientMetadata
+    certificateResponseService: CertificateResponseService
+}
 
-            if (err.code && TLS_CERTIFICATE_ERROR_CODES.has(err.code)) {
-                return true
-            }
+const TLS_CERTIFICATE_ERROR_CODES = new Set([
+    "DEPTH_ZERO_SELF_SIGNED_CERT",
+    "SELF_SIGNED_CERT_IN_CHAIN",
+    "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+    "CERT_HAS_EXPIRED",
+    "ERR_TLS_CERT_ALTNAME_INVALID",
+])
 
-            if (Array.isArray(err.errors) && err.errors.some(isTlsCertificateError)) {
-                return true
-            }
+function isTlsCertificateError(err: any): boolean {
+    if (!err) return false
+    if (err.code && TLS_CERTIFICATE_ERROR_CODES.has(err.code)) return true
+    if (Array.isArray(err.errors) && err.errors.some(isTlsCertificateError)) return true
+    if (err.cause && isTlsCertificateError(err.cause)) return true
 
-            if (err.cause && isTlsCertificateError(err.cause)) {
-                return true
-            }
+    const message = String(err.message || err).toLowerCase()
+    return Array.from(TLS_CERTIFICATE_ERROR_CODES).some((code) => message.includes(code.toLowerCase()))
+        || message.includes("self signed certificate")
+        || message.includes("certificate")
+}
 
-            const message = String(err.message || err).toLowerCase()
-            return Array.from(TLS_CERTIFICATE_ERROR_CODES).some((code) => message.includes(code.toLowerCase()))
-                || message.includes("self signed certificate")
-                || message.includes("certificate")
-        }
+function isStaleConnectionError(err: any): boolean {
+    return err?.kind === "cancelled" || String(err?.message || err).toLowerCase().includes("stale bittorrent connection")
+}
 
-        function isStaleConnectionError(err: any) {
-            return err?.kind === "cancelled" || String(err?.message || err).toLowerCase().includes("stale bittorrent connection")
-        }
+function normalizeSavedLocations(savedLocations?: SavedLocationConfig[]): SavedLocationConfig[] {
+    if (!Array.isArray(savedLocations)) return []
+    return savedLocations
+        .filter((savedLocation) => !!savedLocation?.path && !!savedLocation?.icon)
+        .map((savedLocation) => ({ path: savedLocation.path, icon: savedLocation.icon }))
+}
 
-        /**
-         * Constructor, with class name
-         */
-        function Server(ip, proto, port, user, password, client, path) {
-            this.certificateData = undefined
-            if(arguments.length === 1) {
-                this.fromJson(arguments[0])
-            } else {
-                this.id = generateGUID()
-                this.ip = ip || ''
-                this.proto = proto
-                this.port = port
-                this.user = user || ''
-                this.password = password || ''
-                this.client = client
-                this.path = path
-                this.lastused = -1
-                this.columns = this.defaultColumns()
-                this.savedLocations = []
-                this.labelColors = {}
-                this.defaultUploadOptionsEnabled = false
-                this.defaultUploadOptions = normalizeDefaultUploadOptions()
-            }
-            this.isConnected = false
-        }
+function normalizeDefaultUploadOptions(options?: TorrentUploadOptions): TorrentUploadOptions {
+    return Object.assign({ startTorrent: true }, options || {})
+}
 
-        function normalizeSavedLocations(savedLocations?: SavedLocationConfig[]) {
-            if (!Array.isArray(savedLocations)) {
-                return []
-            }
+function normalizeLabelColors(labelColors?: LabelColorOverrides): LabelColorOverrides {
+    if (!labelColors || typeof labelColors !== "object") return {}
+    return Object.keys(labelColors).reduce((normalized: Record<string, LabelColorHue>, label) => {
+        const hue = normalizeLabelColorHue(labelColors[label])
+        if (label && hue !== undefined) normalized[label] = hue
+        return normalized
+    }, {})
+}
 
-            return savedLocations
-                .filter((savedLocation) => !!savedLocation?.path && !!savedLocation?.icon)
-                .map((savedLocation) => ({
-                    path: savedLocation.path,
-                    icon: savedLocation.icon,
-                }))
-        }
+export class Server implements Omit<StoredServerConfig, "columns"> {
+    private static dependencies: ServerDependencies
 
-        function normalizeDefaultUploadOptions(options?: TorrentUploadOptions) {
-            return Object.assign({ startTorrent: true }, options || {})
-        }
+    name?: string
+    id: string
+    ip: string
+    proto: string
+    port: number
+    user: string
+    password: string
+    client: string
+    path: string
+    default?: boolean
+    lastused?: number
+    certificate?: string
+    tlsSecurity?: "default" | "insecure"
+    columns: ColumnProps[]
+    savedLocations?: SavedLocationConfig[]
+    defaultUploadOptionsEnabled?: boolean
+    defaultUploadOptions?: TorrentUploadOptions
+    labelColors?: LabelColorOverrides
+    certificateData?: Uint8Array
+    isConnected: boolean
 
-        function normalizeLabelColors(labelColors?: LabelColorOverrides) {
-            if (!labelColors || typeof labelColors !== "object") {
-                return {}
-            }
-
-            return Object.keys(labelColors).reduce((normalized: Record<string, LabelColorHue>, label) => {
-                const hue = normalizeLabelColorHue(labelColors[label])
-                if (label && hue !== undefined) {
-                    normalized[label] = hue
-                }
-                return normalized
-            }, {})
-        }
-
-        Server.prototype.fromJson = function(data) {
-            this.name = data.name
-            this.id = data.id
-            this.ip = data.ip || ''
-            this.proto = data.proto || "http"
-            this.port = data.port
-            this.user = data.user || ''
-            this.password = data.password || ''
-            this.client = data.client
-            this.path = data.path || ''
-            this.default = data.default
-            this.lastused = data.lastused
-            this.certificate = data.certificate
-            this.tlsSecurity = data.tlsSecurity === "insecure" ? "insecure" : "default"
-            this.certificateData = data.certificateData ? new Uint8Array(data.certificateData) : undefined
-            this.columns = this.parseColumns(data.columns)
-            this.savedLocations = normalizeSavedLocations(data.savedLocations)
-            this.defaultUploadOptionsEnabled = data.defaultUploadOptionsEnabled === true
-            this.defaultUploadOptions = normalizeDefaultUploadOptions(data.defaultUploadOptions)
-            this.labelColors = normalizeLabelColors(data.labelColors)
-        };
-
-        Server.prototype.json = function() {
-            return {
-                name: this.name,
-                id: this.id,
-                ip: this.ip,
-                proto: this.proto,
-                port: this.port,
-                user: this.user,
-                password: this.password,
-                client: this.client,
-                path: this.path,
-                default: this.default,
-                lastused: this.lastused || -1,
-                certificate: this.tlsSecurity === "insecure" ? undefined : this.certificate,
-                tlsSecurity: this.isHTTPS() && this.tlsSecurity === "insecure" ? "insecure" : undefined,
-                columns: this.columns.filter((column) => column.enabled).map((column) => column.name),
-                savedLocations: normalizeSavedLocations(this.savedLocations),
-                defaultUploadOptionsEnabled: this.defaultUploadOptionsEnabled === true,
-                defaultUploadOptions: normalizeDefaultUploadOptions(this.defaultUploadOptions),
-                labelColors: normalizeLabelColors(this.labelColors),
-            }
-        };
-
-        Server.prototype.getName = function() {
-            return $btclients[this.client].name
-        };
-
-        Server.prototype.getIcon = function() {
-            return $btclients[this.client].icon
-        };
-
-        Server.prototype.getNameAtAddress = function() {
-            return this.getName() + " @ " + this.ip
-        };
-
-        Server.prototype.getDisplayName = function () {
-          return this.name || this.getNameAtAddress()
-        };
-
-        Server.prototype.updateLastUsed = function() {
-            this.lastused = new Date().getTime()
-        };
-
-        Server.prototype.cleanPath = function () {
-          let path = trim(this.path, "/")
-          if (path) {
-            return "/" + path
-          } else {
-            return ""
-          }
-        };
-
-        Server.prototype.url = function() {
-            const server = sanitizeServerAddress(this)
-            return `${server.proto}://${server.ip}:${server.port}${this.cleanPath()}`
-        };
-
-        Server.prototype.isHTTPS = function() {
-            const parsed = parseServerAddressInput(this.ip, this.proto)
-            return (parsed.protocol || this.proto) === 'https'
-        }
-
-        function trim(s, mask) {
-            /*jshint bitwise: false*/
-            while(~mask.indexOf(s[0])) {
-                s = s.slice(1);
-            }
-            while(~mask.indexOf(s[s.length - 1])) {
-                s = s.slice(0, -1);
-            }
-            return s;
-        }
-
-        Server.prototype.setPath = function() {
-            let client = $bittorrent.getClient(this.client)
-            if(client && client.defaultPath) {
-                this.path = client.defaultPath()
-            } else {
-                this.path = "/"
-            }
-        };
-
-        Server.prototype.connect = function() {
-            let self = this
-            Object.assign(this, sanitizeServerAddress(this))
-
-            if(!this.client) {
-                $notify.alert("Opps!", "Please select a client to connect to!")
-                return $q.reject()
-            }
-
-            let service = $bittorrent.getClient(this.client);
-
-            return service.connect(this).catch(function(err) {
-                self.isConnected = false
-                if (self.isHTTPS() && (err?.kind === "tls" || isTlsCertificateError(err))) {
-                    return self.askForCertificate().then(function() {
-                        return self.connect()
-                    })
-                }
-                if (!isStaleConnectionError(err)) {
-                    $notify.alertAuth(err)
-                }
-                return $q.reject(err, this)
-            }).then(function() {
-                self.isConnected = true
-                //$bittorrent.setClient(self.service);
-                $bittorrent.setServer(self)
-                return $q.resolve()
-            })
-        };
-
-        Server.prototype.askForCertificate = function() {
-            let self = this
-            const response = certificateResponseService.wait(self.id)
-
-            electorrent.certificates.fetch({
-                server: self.json() as StoredServerConfig,
-            }).catch((err: unknown) => {
-                certificateResponseService.reject(self.id, err)
-            })
-
-            return $q.when(response).then((result) => {
-                if (result && result.tlsSecurity === "insecure") {
-                    self.tlsSecurity = "insecure"
-                    self.certificate = undefined
-                    self.certificateData = undefined
-                    return
-                }
-
-                self.tlsSecurity = "default"
-                self.certificate = result.fingerprint
-                return electorrent.certificates.load(result.fingerprint).then((certificateData) => {
-                    self.certificateData = certificateData ? new Uint8Array(certificateData) : undefined
-                })
-            })
-        }
-
-        Server.prototype.getCertificate = function() {
-            return this.tlsSecurity === "insecure" ? undefined : this.certificateData
-        }
-
-        Server.prototype.equals = function(other) {
-            return (
-                this.ip === other.ip &&
-                this.proto === other.proto &&
-                this.port === other.port &&
-                this.user === other.user &&
-                this.password === other.password &&
-                this.client === other.client &&
-                this.path === other.path &&
-                this.certificate === other.certificate &&
-                this.tlsSecurity === other.tlsSecurity
-            )
-        }
-
-        function zipsort(obj, sor) {
-            return function(a, b) {
-                let i = sor.indexOf(a.name)
-                let j = sor.indexOf(b.name)
-                if(i === j) {
-                    return 0
-                } else if(i === -1) {
-                    return 1
-                } else if(j === -1) {
-                    return -1
-                } else {
-                    return i - j
-                }
-            }
-        }
-
-        Server.prototype.parseColumns = function(data) {
-            let columns = this.defaultColumns()
-            if(!data || data.length === 0) return columns
-            columns.sort(zipsort(columns, data))
-            columns.forEach((column) => {
-                column.enabled = data.some((entry) => (entry === column.name))
-            })
-            return columns
-        }
-
-        Server.prototype.defaultColumns = function() {
-            let columns = []
-            angular.copy(Torrent.COLUMNS, columns)
-            columns = this.addCustomColumns(columns)
-            return columns
-        }
-
-        Server.prototype.addCustomColumns = function (columns) {
-            if (this.client) {
-                let client = $bittorrent.getClient(this.client)
-                columns = _.union(columns, client.extraColumns)
-            }
-            return columns
-        };
-
-        Server.prototype.bootstrap = function () {
-            this.columns = this.addCustomColumns(this.columns)
-        };
-
-        function generateGUID() {
-            return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
-                s4() + '-' + s4() + s4() + s4();
-        }
-
-        function s4() {
-            return Math.floor((1 + Math.random()) * 0x10000)
-                .toString(16)
-                .substring(1);
-        }
-
-        /**
-         * Return the constructor function
-         */
-        return Server;
+    static configure(dependencies: ServerDependencies): typeof Server {
+        Server.dependencies = dependencies
+        return Server
     }
-];
+
+    constructor(data: StoredServerConfig)
+    constructor(ip: string, port: number, user: string, password: string, client: string)
+    constructor(ip?: string, proto?: string, port?: number, user?: string, password?: string, client?: string, path?: string)
+    constructor(ipOrData?: string | StoredServerConfig, protoOrPort?: string | number, portOrUser?: number | string, userOrPassword?: string, passwordOrClient?: string, client?: string, path?: string) {
+        this.certificateData = undefined
+        if (typeof ipOrData === "object") {
+            this.fromJson(ipOrData)
+        } else {
+            this.id = generateGUID()
+            this.ip = ipOrData || ""
+            if (typeof protoOrPort === "number") {
+                this.proto = "http"
+                this.port = protoOrPort
+                this.user = String(portOrUser || "")
+                this.password = userOrPassword || ""
+                this.client = passwordOrClient
+            } else {
+                this.proto = protoOrPort
+                this.port = portOrUser as number
+                this.user = userOrPassword || ""
+                this.password = passwordOrClient || ""
+                this.client = client
+            }
+            this.path = path
+            this.lastused = -1
+            this.columns = this.defaultColumns()
+            this.savedLocations = []
+            this.labelColors = {}
+            this.defaultUploadOptionsEnabled = false
+            this.defaultUploadOptions = normalizeDefaultUploadOptions()
+        }
+        this.isConnected = false
+    }
+
+    fromJson(data: StoredServerConfig & { certificateData?: Uint8Array }): void {
+        this.name = data.name
+        this.id = data.id
+        this.ip = data.ip || ""
+        this.proto = data.proto || "http"
+        this.port = data.port
+        this.user = data.user || ""
+        this.password = data.password || ""
+        this.client = data.client
+        this.path = data.path || ""
+        this.default = data.default
+        this.lastused = data.lastused
+        this.certificate = data.certificate
+        this.tlsSecurity = data.tlsSecurity === "insecure" ? "insecure" : "default"
+        this.certificateData = data.certificateData ? new Uint8Array(data.certificateData) : undefined
+        this.columns = this.parseColumns(data.columns)
+        this.savedLocations = normalizeSavedLocations(data.savedLocations)
+        this.defaultUploadOptionsEnabled = data.defaultUploadOptionsEnabled === true
+        this.defaultUploadOptions = normalizeDefaultUploadOptions(data.defaultUploadOptions)
+        this.labelColors = normalizeLabelColors(data.labelColors)
+    }
+
+    json(): StoredServerConfig {
+        return {
+            name: this.name,
+            id: this.id,
+            ip: this.ip,
+            proto: this.proto,
+            port: this.port,
+            user: this.user,
+            password: this.password,
+            client: this.client,
+            path: this.path,
+            default: this.default,
+            lastused: this.lastused || -1,
+            certificate: this.tlsSecurity === "insecure" ? undefined : this.certificate,
+            tlsSecurity: this.isHTTPS() && this.tlsSecurity === "insecure" ? "insecure" : undefined,
+            columns: this.columns.filter((column) => column.enabled).map((column) => column.name),
+            savedLocations: normalizeSavedLocations(this.savedLocations),
+            defaultUploadOptionsEnabled: this.defaultUploadOptionsEnabled === true,
+            defaultUploadOptions: normalizeDefaultUploadOptions(this.defaultUploadOptions),
+            labelColors: normalizeLabelColors(this.labelColors),
+        }
+    }
+
+    getName(): string {
+        return Server.dependencies.$btclients[this.client].name
+    }
+
+    getIcon(): string {
+        return Server.dependencies.$btclients[this.client].icon
+    }
+
+    getNameAtAddress(): string {
+        return this.getName() + " @ " + this.ip
+    }
+
+    getDisplayName(): string {
+        return this.name || this.getNameAtAddress()
+    }
+
+    updateLastUsed(): void {
+        this.lastused = new Date().getTime()
+    }
+
+    cleanPath(): string {
+        const path = trim(this.path, "/")
+        return path ? "/" + path : ""
+    }
+
+    url(): string {
+        const server = sanitizeServerAddress(this)
+        return `${server.proto}://${server.ip}:${server.port}${this.cleanPath()}`
+    }
+
+    isHTTPS(): boolean {
+        const parsed = parseServerAddressInput(this.ip, this.proto)
+        return (parsed.protocol || this.proto) === "https"
+    }
+
+    setPath(): void {
+        const client = Server.dependencies.$bittorrent.getClient(this.client)
+        this.path = client?.defaultPath ? client.defaultPath() : "/"
+    }
+
+    connect(): Promise<void> {
+        const { $notify, $bittorrent } = Server.dependencies
+        Object.assign(this, sanitizeServerAddress(this))
+
+        if (!this.client) {
+            $notify.alert("Opps!", "Please select a client to connect to!")
+            return Promise.reject()
+        }
+
+        return $bittorrent.getClient(this.client).connect(this).catch((err: any) => {
+            this.isConnected = false
+            if (this.isHTTPS() && (err?.kind === "tls" || isTlsCertificateError(err))) {
+                return this.askForCertificate().then(() => this.connect())
+            }
+            if (!isStaleConnectionError(err)) $notify.alertAuth(err)
+            return Promise.reject(err)
+        }).then(() => {
+            this.isConnected = true
+            $bittorrent.setServer(this)
+            return Promise.resolve()
+        })
+    }
+
+    askForCertificate(): Promise<void> {
+        const { certificateResponseService } = Server.dependencies
+        const response = certificateResponseService.wait(this.id)
+
+        window.electorrent.certificates.fetch({ server: this.json() }).catch((err: unknown) => {
+            certificateResponseService.reject(this.id, err)
+        })
+
+        return Promise.resolve(response).then((result) => {
+            if ("tlsSecurity" in result) {
+                this.tlsSecurity = "insecure"
+                this.certificate = undefined
+                this.certificateData = undefined
+                return
+            }
+
+            this.tlsSecurity = "default"
+            this.certificate = result.fingerprint
+            return window.electorrent.certificates.load(result.fingerprint).then((certificateData) => {
+                this.certificateData = certificateData ? new Uint8Array(certificateData) : undefined
+            })
+        })
+    }
+
+    getCertificate(): Uint8Array | undefined {
+        return this.tlsSecurity === "insecure" ? undefined : this.certificateData
+    }
+
+    equals(other: Server): boolean {
+        return this.ip === other.ip
+            && this.proto === other.proto
+            && this.port === other.port
+            && this.user === other.user
+            && this.password === other.password
+            && this.client === other.client
+            && this.path === other.path
+            && this.certificate === other.certificate
+            && this.tlsSecurity === other.tlsSecurity
+    }
+
+    parseColumns(data?: string[]): ColumnProps[] {
+        const columns = this.defaultColumns()
+        if (!data || data.length === 0) return columns
+        columns.sort(zipSort(data))
+        columns.forEach((column) => {
+            column.enabled = data.some((entry) => entry === column.name)
+        })
+        return columns
+    }
+
+    defaultColumns(): ColumnProps[] {
+        let columns: ColumnProps[] = []
+        angular.copy(Torrent.COLUMNS, columns)
+        columns = this.addCustomColumns(columns)
+        return columns
+    }
+
+    addCustomColumns(columns: ColumnProps[]): ColumnProps[] {
+        if (!this.client) return columns
+        const client = Server.dependencies.$bittorrent.getClient(this.client)
+        return _.union(columns, client.extraColumns)
+    }
+
+    bootstrap(): void {
+        this.columns = this.addCustomColumns(this.columns)
+    }
+}
+
+function trim(value: string, mask: string): string {
+    while (~mask.indexOf(value[0])) value = value.slice(1)
+    while (~mask.indexOf(value[value.length - 1])) value = value.slice(0, -1)
+    return value
+}
+
+function zipSort(order: string[]) {
+    return (a: ColumnProps, b: ColumnProps): number => {
+        const left = order.indexOf(a.name)
+        const right = order.indexOf(b.name)
+        if (left === right) return 0
+        if (left === -1) return 1
+        if (right === -1) return -1
+        return left - right
+    }
+}
+
+function generateGUID(): string {
+    return s4() + s4() + "-" + s4() + "-" + s4() + "-" + s4() + "-" + s4() + s4() + s4()
+}
+
+function s4(): string {
+    return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1)
+}
+
+export const serverService = ["notificationService", "$bittorrent", "$btclients", "certificateResponseService",
+    ($notify: NotificationService, $bittorrent: BittorrentService, $btclients: BittorrentClientMetadata, certificateResponseService: CertificateResponseService) => Server.configure({
+        $notify,
+        $bittorrent,
+        $btclients,
+        certificateResponseService,
+    }),
+]

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -1,4 +1,5 @@
 import _ from "underscore"
+import type { IPromise, IQService } from "angular"
 import { Torrent } from "@renderer/app/bittorrent"
 import type { TorrentClient } from "@renderer/app/bittorrent/torrentclient"
 import type { ColumnProps } from "@renderer/app/services/column"
@@ -20,6 +21,7 @@ type BittorrentService = {
 type BittorrentClientMetadata = Record<string, { name: string, icon: string }>
 
 type ServerDependencies = {
+    $q: IQService
     $notify: NotificationService
     $bittorrent: BittorrentService
     $btclients: BittorrentClientMetadata
@@ -218,38 +220,38 @@ export class Server implements Omit<StoredServerConfig, "columns"> {
         this.path = client?.defaultPath ? client.defaultPath() : "/"
     }
 
-    connect(): Promise<void> {
-        const { $notify, $bittorrent } = Server.dependencies
+    connect(): IPromise<void> {
+        const { $q, $notify, $bittorrent } = Server.dependencies
         Object.assign(this, sanitizeServerAddress(this))
 
         if (!this.client) {
             $notify.alert("Opps!", "Please select a client to connect to!")
-            return Promise.reject()
+            return $q.reject()
         }
 
-        return $bittorrent.getClient(this.client).connect(this).catch((err: any) => {
+        return $q.when($bittorrent.getClient(this.client).connect(this) as any).catch((err: any) => {
             this.isConnected = false
             if (this.isHTTPS() && (err?.kind === "tls" || isTlsCertificateError(err))) {
                 return this.askForCertificate().then(() => this.connect())
             }
             if (!isStaleConnectionError(err)) $notify.alertAuth(err)
-            return Promise.reject(err)
+            return $q.reject(err)
         }).then(() => {
             this.isConnected = true
             $bittorrent.setServer(this)
-            return Promise.resolve()
+            return $q.resolve()
         })
     }
 
-    askForCertificate(): Promise<void> {
-        const { certificateResponseService } = Server.dependencies
+    askForCertificate(): IPromise<void> {
+        const { $q, certificateResponseService } = Server.dependencies
         const response = certificateResponseService.wait(this.id)
 
         window.electorrent.certificates.fetch({ server: this.json() }).catch((err: unknown) => {
             certificateResponseService.reject(this.id, err)
         })
 
-        return Promise.resolve(response).then((result) => {
+        return $q.when(response as any).then((result) => {
             if ("tlsSecurity" in result) {
                 this.tlsSecurity = "insecure"
                 this.certificate = undefined
@@ -259,7 +261,7 @@ export class Server implements Omit<StoredServerConfig, "columns"> {
 
             this.tlsSecurity = "default"
             this.certificate = result.fingerprint
-            return window.electorrent.certificates.load(result.fingerprint).then((certificateData) => {
+            return $q.when(window.electorrent.certificates.load(result.fingerprint) as any).then((certificateData) => {
                 this.certificateData = certificateData ? new Uint8Array(certificateData) : undefined
             })
         })
@@ -334,8 +336,9 @@ function s4(): string {
     return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1)
 }
 
-export const serverService = ["notificationService", "$bittorrent", "$btclients", "certificateResponseService",
-    ($notify: NotificationService, $bittorrent: BittorrentService, $btclients: BittorrentClientMetadata, certificateResponseService: CertificateResponseService) => Server.configure({
+export const serverService = ["$q", "notificationService", "$bittorrent", "$btclients", "certificateResponseService",
+    ($q: IQService, $notify: NotificationService, $bittorrent: BittorrentService, $btclients: BittorrentClientMetadata, certificateResponseService: CertificateResponseService) => Server.configure({
+        $q,
         $notify,
         $bittorrent,
         $btclients,

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -1,199 +1,130 @@
-import { IRootScopeService } from "angular";
-import type { AppSettings, StoredServerConfig } from "@shared/ipc-contract";
-import type { Server } from "@renderer/app/services/server";
+import type { IRootScopeService } from "angular"
+import type { AppSettings, StoredServerConfig } from "@shared/ipc-contract"
+import { Server } from "@renderer/app/services/server"
 
-export interface SettingsService {
-    whenReady(): Promise<AppSettings<Server>>
-    initSettings(): Promise<AppSettings<Server>>
-    appendServer(server: Server): void
-    getAllSettings(): AppSettings<Server>
-    getAllSettingsCopy(): AppSettings<Server>
-    setCurrentServerAsDefault(): void
-    setDefault(server: Server, skipSave?: boolean): void
-    saveAllSettings(newSettings?: Partial<AppSettings<Server>>): Promise<void>
-    trustCertificate(certificate: { fingerprint: string }): Promise<void>
-    enableInsecureTls(serverId: string): Promise<void>
-    disableInsecureTls(server: Server): Promise<void>
-    saveServer(server: Server): Promise<void>
-    saveServer(ip: string, port: number, user: string, password: string, client: string): Promise<void>
-    removeServer(server: Server): void
-    updateServer(server: Partial<Server> & Pick<Server, "id">): Promise<void>
-    getServer(id: string): Server | undefined
-    getServers(): Server[]
-    getDefaultServer(): Server | undefined
-    getRecentServer(): Server | undefined
+type NotificationService = {
+    alert(title: string, message: string): void
+    warning(title: string, message: string): void
+    ok(title: string, message: string): void
 }
 
-export let settingsService = ['$rootScope', '$bittorrent', 'notificationService', '$q', 'Server', function($rootScope: IRootScopeService, $bittorrent, $notify, $q, Server) {
-    const electorrent = window.electorrent
+type BittorrentService = {
+    setServer(server: Server): void
+}
 
-    var settings: AppSettings<any> = {
-        startup: 'default',
-        systemStartup: 'disabled',
+type ServerConstructor = typeof Server
+
+export class SettingsService {
+    static $inject = ["$rootScope", "$bittorrent", "notificationService", "Server"]
+
+    private readonly settings: AppSettings<Server> = {
+        startup: "default",
+        systemStartup: "disabled",
         refreshRate: 2000,
         automaticUpdates: true,
         closeToTray: true,
         debugMode: false,
         autoRemoveTorrents: false,
         alwaysPromptUploadOptions: false,
-        watchDirectory: '',
+        watchDirectory: "",
         ui: {
-            resizeMode: '',
+            resizeMode: "",
             notifications: true,
-            displaySize: 'normal',
+            displaySize: "normal",
             displayCompact: false,
             cleanNames: true,
             fixedHeader: false,
-            theme: 'system',
+            theme: "system",
             sidebarCollapsed: false,
         },
         servers: [],
-        certificates: []
-    };
+        certificates: [],
+    }
 
-    function loadServerCertificate(server: any) {
-        if (server?.tlsSecurity === "insecure") {
-            server.certificate = undefined
-            server.certificateData = undefined
-            return Promise.resolve()
-        }
+    private readonly readyPromise: Promise<AppSettings<Server>>
 
-        if (!server?.certificate) {
-            server.certificateData = undefined
-            return Promise.resolve()
-        }
+    constructor(
+        private readonly $rootScope: IRootScopeService,
+        private readonly $bittorrent: BittorrentService,
+        private readonly $notify: NotificationService,
+        private readonly ServerClass: ServerConstructor,
+    ) {
+        this.readyPromise = window.electorrent.settings.getAll().then((settings: AppSettings<StoredServerConfig>) => {
+            this.mergeSettings(settings)
+            return this.loadServerCertificates(this.settings.servers).then(() => this.settings)
+        })
 
-        return electorrent.certificates.load(server.certificate).then((certificateData) => {
-            server.certificateData = certificateData ? new Uint8Array(certificateData) : undefined
+        this.$rootScope.$on("certificate-installed", (_event: unknown, serverId: string, fingerprint: string) => {
+            const server = this.getServer(serverId)
+            if (!server) return
+
+            server.tlsSecurity = "default"
+            server.certificate = fingerprint
+            this.loadServerCertificate(server)
+                .then(() => this.saveAllSettings())
+                .catch((err: unknown) => this.$notify.alert("Certificate cache error", String(err)))
         })
     }
 
-    function loadServerCertificates(servers: any[]) {
-        return Promise.all(servers.map((server) => loadServerCertificate(server))).then(() => undefined)
+    whenReady(): Promise<AppSettings<Server>> {
+        return this.readyPromise
     }
 
-    function hydrateServer(server: any) {
-        return typeof server?.connect === "function" ? server : new Server(server)
+    initSettings(): Promise<AppSettings<Server>> {
+        return this.readyPromise
     }
 
-    function replaceServers(servers: any[]) {
-        settings.servers.splice(0, settings.servers.length, ...servers.map((server) => hydrateServer(server)))
+    appendServer(server: Server): void {
+        this.settings.servers.push(server)
     }
 
-    function mergeSettings(newSettings: Partial<AppSettings<any>>) {
-        const { servers, ui, ...rest } = newSettings
-        Object.assign(settings, rest)
-        settings.ui = Object.assign({}, settings.ui, ui || {})
-        if (Array.isArray(servers)) {
-            replaceServers(servers)
-        }
+    getAllSettings(): AppSettings<Server> {
+        return this.settings
     }
 
-    const readyPromise = electorrent.settings.getAll().then((org: AppSettings<StoredServerConfig>) => {
-        mergeSettings(org)
-        return loadServerCertificates(settings.servers).then(() => settings)
-    });
+    getAllSettingsCopy(): AppSettings<Server> {
+        return angular.copy(this.settings)
+    }
 
-    $rootScope.$on("certificate-installed", (_event: unknown, serverId: string, fingerprint: string) => {
-        const server = this.getServer(serverId)
-        if (!server) {
+    setCurrentServerAsDefault(): void {
+        if (!this.$rootScope.$server) {
+            this.$notify.warning("Can't set default server", "You need to chose a server to set it as default")
             return
         }
-
-        server.tlsSecurity = "default"
-        server.certificate = fingerprint
-        loadServerCertificate(server).then(() => {
-            return this.saveAllSettings()
-        }).catch((err: unknown) => {
-            $notify.alert("Certificate cache error", String(err))
-        })
-    })
-
-    this.whenReady = function() {
-        return readyPromise;
+        this.setDefault(this.$rootScope.$server)
     }
 
-    this.initSettings = function() {
-        return readyPromise;
-    }
-
-    function isDefault(server) {
-        return server.default === true
-    }
-
-    this.appendServer = function(server) {
-        settings.servers.push(server)
-    }
-
-    this.getAllSettings = function() {
-        return settings;
-    }
-
-    this.getAllSettingsCopy = function() {
-      return angular.copy(settings)
-    }
-
-    this.setCurrentServerAsDefault = function() {
-        if (!$rootScope.$server) {
-            $notify.warning('Can\'t set default server', 'You need to chose a server to set it as default')
-        }
-        this.setDefault($rootScope.$server)
-    }
-
-    this.setDefault = function(server, skipsave) {
-        let found = this.getServer(server.id)
+    setDefault(server: Server, skipSave?: boolean): void {
+        const found = this.getServer(server.id)
         if (!found) return
-        settings.servers.forEach(function(value) {
+        this.settings.servers.forEach((value) => {
             value.default = false
         })
         found.default = true
-        if (!skipsave) {
+        if (!skipSave) {
             this.saveAllSettings().then(() => {
-                $notify.ok('Default server saved', 'You default server is now ' + server.getNameAtAddress())
-            }).catch(function() {
-                $notify.alert('I/O Error', 'Could not save default server. Local configuration file could not be written to?!')
+                this.$notify.ok("Default server saved", "You default server is now " + server.getNameAtAddress())
+            }).catch(() => {
+                this.$notify.alert("I/O Error", "Could not save default server. Local configuration file could not be written to?!")
             })
         }
     }
 
-    function settingsToJson() {
-        let copy: any = {}
-        angular.copy(settings, copy)
-        copy.servers = copy.servers.map((server) => {
-            return server.json()
-        })
-        return copy
+    saveAllSettings(newSettings?: Partial<AppSettings<Server>>): Promise<void> {
+        if (newSettings) this.mergeSettings(newSettings)
+        return this.loadServerCertificates(this.settings.servers)
+            .then(() => window.electorrent.settings.saveAll(this.settingsToJson()))
+            .then(() => this.updateServerReference())
     }
 
-
-    this.saveAllSettings = function(newSettings) {
-        if (newSettings) {
-            mergeSettings(newSettings)
-        }
-        return loadServerCertificates(settings.servers).then(() => electorrent.settings.saveAll(settingsToJson())).then(function() {
-            updateServerReference()
-        });
-    }
-
-    function updateServerReference() {
-      if (!$rootScope.$server) return
-      let server = settings.servers.find(function(s) {
-          return s.id === $rootScope.$server.id
-      })
-      if (!server) return
-      $bittorrent.setServer(server)
-    }
-
-    this.trustCertificate = function(cert) {
-        settings.certificates.push(cert.fingerprint)
+    trustCertificate(certificate: { fingerprint: string }): Promise<void> {
+        this.settings.certificates.push(certificate.fingerprint)
         return this.saveAllSettings()
     }
 
-    this.enableInsecureTls = function(serverId: string) {
+    enableInsecureTls(serverId: string): Promise<void> {
         const server = this.getServer(serverId)
-        if (!server) {
-            return $q.reject(`Server with id ${serverId} not found`)
-        }
+        if (!server) return Promise.reject(`Server with id ${serverId} not found`)
 
         server.tlsSecurity = "insecure"
         server.certificate = undefined
@@ -201,56 +132,97 @@ export let settingsService = ['$rootScope', '$bittorrent', 'notificationService'
         return this.saveAllSettings()
     }
 
-    this.disableInsecureTls = function(server) {
+    disableInsecureTls(server: Server): Promise<void> {
         server.tlsSecurity = "default"
         return this.saveAllSettings()
     }
 
-    this.saveServer = function(ip, port, user, password, client) {
-        if(arguments.length === 1) {
-            this.appendServer(arguments[0]);
-        } else {
-            this.appendServer(new Server(ip, port, user, password, client))
-        }
+    saveServer(server: Server): Promise<void>
+    saveServer(ip: string, port: number, user: string, password: string, client: string): Promise<void>
+    saveServer(serverOrIp: Server | string, port?: number, user?: string, password?: string, client?: string): Promise<void> {
+        const server = typeof serverOrIp === "string"
+            ? new this.ServerClass(serverOrIp, port, user, password, client)
+            : serverOrIp
+        this.appendServer(server)
         return this.saveAllSettings()
     }
 
-    this.removeServer = function(server) {
-        settings.servers = settings.servers.filter((s) => {
-            return s.id !== server.id
-        })
+    removeServer(server: Server): void {
+        this.settings.servers.splice(0, this.settings.servers.length, ...this.settings.servers.filter((candidate) => candidate.id !== server.id))
     }
 
-    this.updateServer = function(update) {
-        let server = this.getServer(update.id);
-        if(!server) return $q.reject('Server with id ' + update.id + ' not found')
+    updateServer(update: Partial<Server> & Pick<Server, "id">): Promise<void> {
+        const server = this.getServer(update.id)
+        if (!server) return Promise.reject("Server with id " + update.id + " not found")
         angular.merge(server, update)
         return this.saveAllSettings()
     }
 
-    this.getServer = function(id) {
-        return settings.servers.find((server) => server.id === id)
+    getServer(id: string): Server | undefined {
+        return this.settings.servers.find((server) => server.id === id)
     }
 
-    this.getServers = function() {
-        return settings.servers
+    getServers(): Server[] {
+        return this.settings.servers
     }
 
-    this.getDefaultServer = function() {
-        if (settings.servers.length === 1) {
-            return settings.servers[0]
+    getDefaultServer(): Server | undefined {
+        if (this.settings.servers.length === 1) return this.settings.servers[0]
+        return this.settings.servers.find((server) => server.default === true)
+    }
+
+    getRecentServer(): Server | undefined {
+        return this.settings.servers.reduce<Server | undefined>((mostRecent, server) => {
+            if (!mostRecent || (server.lastused || -1) > (mostRecent.lastused || -1)) return server
+            return mostRecent
+        }, undefined)
+    }
+
+    private loadServerCertificate(server: Server): Promise<void> {
+        if (server.tlsSecurity === "insecure") {
+            server.certificate = undefined
+            server.certificateData = undefined
+            return Promise.resolve()
         }
-        return settings.servers.find(isDefault)
-    }
-
-    this.getRecentServer = function() {
-        let maxServer = settings.servers[0]
-        settings.servers.forEach(function(server){
-            if (server.lastused > maxServer.lastused){
-                maxServer = server
-            }
+        if (!server.certificate) {
+            server.certificateData = undefined
+            return Promise.resolve()
+        }
+        return window.electorrent.certificates.load(server.certificate).then((certificateData) => {
+            server.certificateData = certificateData ? new Uint8Array(certificateData) : undefined
         })
-        return maxServer
     }
 
-}];
+    private loadServerCertificates(servers: Server[]): Promise<void> {
+        return Promise.all(servers.map((server) => this.loadServerCertificate(server))).then(() => undefined)
+    }
+
+    private hydrateServer(server: Server | StoredServerConfig): Server {
+        return typeof (server as Server)?.connect === "function" ? server as Server : new this.ServerClass(server as StoredServerConfig)
+    }
+
+    private replaceServers(servers: Array<Server | StoredServerConfig>): void {
+        this.settings.servers.splice(0, this.settings.servers.length, ...servers.map((server) => this.hydrateServer(server)))
+    }
+
+    private mergeSettings(newSettings: Partial<AppSettings<Server | StoredServerConfig>>): void {
+        const { servers, ui, ...rest } = newSettings
+        Object.assign(this.settings, rest)
+        this.settings.ui = Object.assign({}, this.settings.ui, ui || {})
+        if (Array.isArray(servers)) this.replaceServers(servers)
+    }
+
+    private settingsToJson(): AppSettings<StoredServerConfig> {
+        const copy = angular.copy(this.settings) as AppSettings<Server>
+        return {
+            ...copy,
+            servers: this.settings.servers.map((server) => server.json()),
+        }
+    }
+
+    private updateServerReference(): void {
+        if (!this.$rootScope.$server) return
+        const server = this.settings.servers.find((candidate) => candidate.id === this.$rootScope.$server.id)
+        if (server) this.$bittorrent.setServer(server)
+    }
+}

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -1,12 +1,7 @@
 import type { IRootScopeService } from "angular"
 import type { AppSettings, StoredServerConfig } from "@shared/ipc-contract"
 import { Server } from "@renderer/app/services/server"
-
-type NotificationService = {
-    alert(title: string, message: string): void
-    warning(title: string, message: string): void
-    ok(title: string, message: string): void
-}
+import type { NotificationService } from "@renderer/app/services/notification"
 
 type BittorrentService = {
     setServer(server: Server): void
@@ -137,12 +132,7 @@ export class SettingsService {
         return this.saveAllSettings()
     }
 
-    saveServer(server: Server): Promise<void>
-    saveServer(ip: string, port: number, user: string, password: string, client: string): Promise<void>
-    saveServer(serverOrIp: Server | string, port?: number, user?: string, password?: string, client?: string): Promise<void> {
-        const server = typeof serverOrIp === "string"
-            ? new this.ServerClass(serverOrIp, port, user, password, client)
-            : serverOrIp
+    saveServer(server: Server): Promise<void> {
         this.appendServer(server)
         return this.saveAllSettings()
     }


### PR DESCRIPTION
## What changed

- replace the `SettingsService` interface and AngularJS constructor function with an exported ES6 class
- replace the `Server` interface and prototype implementation with an exported ES6 class
- register `SettingsService` directly with AngularJS and retain a thin factory that configures and exposes the injectable `Server` constructor
- preserve existing server hydration and legacy constructor call forms

## Why

The previous interfaces described runtime objects implemented separately as AngularJS services. Using the classes themselves as both implementation and type removes that duplication and lets other classes reference the concrete service types.

## Impact

No intended user-facing behavior change. Existing AngularJS injection names remain unchanged.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/settings.spec.ts"` (15 passing)