### PR TITLE
refactor: remove dead settings exports

### DIFF
--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -186,10 +186,6 @@ export function getDefaultSettings() {
     return copy(defaultSettings)
 }
 
-export function settingsReference() {
-    return data
-}
-
 export function write() {
     saveSync()
 }
@@ -209,35 +205,4 @@ export function get(key: string) {
         value = copy(data[key])
     }
     return value
-}
-
-export function getServer(id: string) {
-    load()
-    return data.servers.find((s: { id: string }) => s.id === id)
-}
-
-export function saveServer(server: { id: string }, callback: (err?: Error | null) => void) {
-    load()
-    let ok = false
-    data.servers = data.servers.map((s: { id: string }) => {
-        if (s.id === server.id) {
-            ok = true
-            return Object.assign(s, server)
-        }
-        return s
-    })
-
-    if (!ok) {
-        return callback(new Error('Could not save server. Server not found'))
-    }
-
-    save(callback)
-}
-
-export function unset(key: string, callback: (err?: Error | null) => void) {
-    load()
-    if (key in data) {
-        delete data[key]
-        save(callback)
-    }
 }


### PR DESCRIPTION
## What changed

Removed four unused exports from the main-process settings module: `settingsReference`, `getServer`, `saveServer`, and `unset`.

## Why

Repo-wide search found no callers. These functions enlarged the module interface and implied supported mutable settings behavior without providing leverage to any caller. Deleting them improves locality and keeps the interface aligned with actual usage.

## Impact

No runtime behavior changes for existing callers. The change removes 35 lines of dead code.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/settings.spec.ts"` (15 passing)