### PR TITLE
feat(menu): unify title menu model

### DIFF
--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -15,9 +15,23 @@ import * as settings from "../settings"
 import { createRuntime } from "./registry"
 import type { BittorrentRuntime } from "./types"
 
+export interface BittorrentSessionState {
+    activeServerId: string | null
+    activeClientId: string | null
+    isConnected: boolean
+}
+
+const EMPTY_SESSION_STATE: BittorrentSessionState = {
+    activeServerId: null,
+    activeClientId: null,
+    isConnected: false,
+}
+
 class BittorrentManager {
     private sessions = new Map<number, BittorrentRuntime>()
     private pendingConnections = new Map<number, Promise<TorrentClientConnection>>()
+    private sessionStates = new Map<number, BittorrentSessionState>()
+    private sessionListeners = new Set<() => void>()
 
     private async getSession(sender: WebContents) {
         const senderId = sender.id
@@ -55,6 +69,11 @@ class BittorrentManager {
 
     async connect(sender: WebContents, server: BittorrentServerConfig) {
         const senderId = sender.id
+        this.setSessionState(senderId, {
+            activeServerId: server.id || null,
+            activeClientId: server.client || null,
+            isConnected: false,
+        })
         const pendingConnect = (async () => {
             const existing = this.sessions.get(senderId)
             if (existing) {
@@ -73,6 +92,11 @@ class BittorrentManager {
                 throw new Error("Stale bittorrent connection")
             }
             this.sessions.set(senderId, runtime)
+            this.setSessionState(senderId, {
+                activeServerId: server.id || null,
+                activeClientId: server.client || null,
+                isConnected: true,
+            })
             return connection
         })()
 
@@ -95,12 +119,14 @@ class BittorrentManager {
 
         const existing = this.sessions.get(senderId)
         if (!existing) {
+            this.setSessionState(senderId, EMPTY_SESSION_STATE)
             return
         }
         if (typeof existing.disconnect === "function") {
             await existing.disconnect()
         }
         this.sessions.delete(senderId)
+        this.setSessionState(senderId, EMPTY_SESSION_STATE)
     }
 
     async getSnapshot(sender: WebContents, fullUpdate?: boolean) {
@@ -181,6 +207,25 @@ class BittorrentManager {
         }
 
         return this.sessions.has(sender.id)
+    }
+
+    getSessionState(sender: Pick<WebContents, "id"> | null | undefined): BittorrentSessionState {
+        if (!sender) return EMPTY_SESSION_STATE
+        return this.sessionStates.get(sender.id) || EMPTY_SESSION_STATE
+    }
+
+    subscribe(listener: () => void) {
+        this.sessionListeners.add(listener)
+        return () => this.sessionListeners.delete(listener)
+    }
+
+    private setSessionState(senderId: number, state: BittorrentSessionState) {
+        if (state.activeServerId) {
+            this.sessionStates.set(senderId, state)
+        } else {
+            this.sessionStates.delete(senderId)
+        }
+        this.sessionListeners.forEach((listener) => listener())
     }
 }
 

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -166,8 +166,11 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
             })
         })
 
-        menu.refresh()
         await onSettingsSaved?.(newSettings)
+    })
+
+    ipcMain.handle(IPC_CHANNELS.menu.getModel, async function() {
+        return menu.getModel()
     })
 
     ipcMain.handle(IPC_CHANNELS.settings.listThemes, async function() {
@@ -215,10 +218,8 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
     })
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }) {
-        menu.setActiveServer(server, false)
         try {
             const connection = await bittorrentManager.connect(event.sender, server)
-            menu.setActiveServer(server, true)
             await onBittorrentConnected?.()
             return { ok: true, connection }
         } catch (error) {
@@ -228,7 +229,6 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.disconnect, async function(event: IpcMainInvokeEvent) {
         await bittorrentManager.disconnect(event.sender)
-        menu.setActiveServer(null)
     })
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.getSnapshot, async function(event: IpcMainInvokeEvent, { fullUpdate } = {}) {

--- a/src/main/lib/menu.ts
+++ b/src/main/lib/menu.ts
@@ -1,352 +1,109 @@
-import { app, Menu, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+import { app, Menu, type BrowserWindow, type MenuItemConstructorOptions } from "electron"
 
-import { CLIENT_METADATA } from '@shared/client-metadata'
-import { IPC_CHANNELS } from '@shared/ipc'
-import type { AppSettings, StoredServerConfig } from '@shared/ipc-contract'
-import * as settings from './settings'
-
-type MenuSessionState = {
-    isDebug: boolean
-    activeServerId: string | null
-    activeClientId: string | null
-    isConnected: boolean
-}
+import { IPC_CHANNELS } from "@shared/ipc"
+import type { TitleMenuAction, TitleMenuItem, TitleMenuPlatform } from "@shared/title-menu"
+import { TitleMenuModel } from "@shared/title-menu"
+import { bittorrentManager } from "./bittorrent"
+import * as settings from "./settings"
 
 let mainWindow: BrowserWindow | null = null
-let menuState: MenuSessionState = {
-    isDebug: false,
-    activeServerId: null,
-    activeClientId: null,
-    isConnected: false,
-}
-const defaultMenuSettings: AppSettings = settings.getDefaultSettings()
-let menuSettings: AppSettings = defaultMenuSettings
+let isDebug = false
+let model: TitleMenuModel | null = null
 
-function normalizeMenuSettings(settingsValue: Partial<AppSettings> | null | undefined): AppSettings {
-    return {
-        ...defaultMenuSettings,
-        ...settingsValue,
-        ui: {
-            ...defaultMenuSettings.ui,
-            ...(settingsValue?.ui || {}),
-        },
-        servers: Array.isArray(settingsValue?.servers) ? settingsValue.servers : [],
+function getWindow() {
+    return mainWindow && !mainWindow.isDestroyed() ? mainWindow : null
+}
+
+function sendAction(action: TitleMenuAction) {
+    const window = getWindow()
+    if (!window) return
+    window.webContents.send(IPC_CHANNELS.menu.action, action)
+}
+
+function runAction(action: TitleMenuAction, focusedWindow?: BrowserWindow) {
+    const window = focusedWindow && !focusedWindow.isDestroyed() ? focusedWindow : getWindow()
+
+    switch (action.type) {
+        case "quit":
+            app.quit()
+            break
+        case "edit-command":
+            if (window) window.webContents[action.command]()
+            break
+        case "window-command":
+            if (!window) return
+            if (action.command === "reload") window.reload()
+            if (action.command === "toggle-full-screen") window.setFullScreen(!window.isFullScreen())
+            if (action.command === "toggle-dev-tools") window.webContents.toggleDevTools()
+            if (action.command === "minimize") window.minimize()
+            if (action.command === "close") window.close()
+            break
+        default:
+            sendAction(action)
+            break
     }
+}
+
+function toNativeMenuItem(item: TitleMenuItem): MenuItemConstructorOptions {
+    if (item.type === "separator") return { type: "separator" }
+
+    const nativeItem: MenuItemConstructorOptions = {
+        id: item.id,
+        label: item.label,
+        accelerator: item.accelerator,
+        type: item.type,
+        checked: item.checked,
+        enabled: item.enabled,
+        visible: item.visible,
+        role: item.nativeRole,
+        submenu: item.submenu?.map(toNativeMenuItem),
+    }
+
+    if (!item.nativeRole && item.action) {
+        nativeItem.click = (_menuItem, focusedWindow) => runAction(item.action!, focusedWindow as BrowserWindow | undefined)
+    }
+
+    return nativeItem
+}
+
+function render(menu: TitleMenuItem[]) {
+    Menu.setApplicationMenu(Menu.buildFromTemplate(menu.map(toNativeMenuItem)))
+
+    const window = getWindow()
+    if (window) window.webContents.send(IPC_CHANNELS.menu.changed, menu)
+}
+
+function ensureModel() {
+    if (model) return model
+
+    model = new TitleMenuModel({
+        appName: app.name,
+        platform: process.platform as TitleMenuPlatform,
+        isDebug,
+    }, {
+        getSettings: () => settings.getAllSettings(),
+        subscribeSettings: (listener) => settings.subscribe(listener),
+        getSession: () => bittorrentManager.getSessionState(getWindow()?.webContents),
+        subscribeSession: (listener) => bittorrentManager.subscribe(listener),
+    })
+    model.subscribe(render)
+    return model
 }
 
 export function setWindow(window: BrowserWindow) {
     mainWindow = window
-    buildMenu()
+    ensureModel().refresh()
 }
 
-function sendAction(action: unknown) {
-    if (!mainWindow || mainWindow.isDestroyed()) return
-    mainWindow.webContents.send(IPC_CHANNELS.menu.action, action)
+export function configure(state: { isDebug: boolean }) {
+    isDebug = state.isDebug
+    ensureModel().setState({ isDebug })
 }
 
-function serverAccelerator(index: number) {
-    if (index > 0 && index <= 10) {
-        return `CmdOrCtrl+${index % 10}`
-    }
-
-    return undefined
-}
-
-function getServerLabel(server: StoredServerConfig) {
-    const clientName = CLIENT_METADATA[server.client]?.name || server.client || 'Server'
-    const address = server.ip || 'unknown host'
-    return server.name || `${clientName} @ ${address}`
-}
-
-function hasActiveServer() {
-    return !!menuState.activeServerId
-}
-
-function hasConnectedServer() {
-    return hasActiveServer() && menuState.isConnected
-}
-
-function advancedUploadVisible() {
-    return !!menuState.activeClientId && !!CLIENT_METADATA[menuState.activeClientId]?.showAdvancedUploadMenu
-}
-
-function advancedUploadEnabled() {
-    return hasConnectedServer() && advancedUploadVisible()
-}
-
-function serverMenuItems(): MenuItemConstructorOptions[] {
-    const submenu: MenuItemConstructorOptions[] = [
-        {
-            label: 'Add new server...',
-            accelerator: 'CmdOrCtrl+N',
-            click: () => sendAction({ type: 'add-server' }),
-        },
-        {
-            label: 'Set current as default',
-            enabled: hasActiveServer(),
-            click: () => sendAction({ type: 'set-current-default-server' }),
-        },
-        { type: 'separator' },
-    ]
-
-    if (!menuSettings.servers.length) {
-        submenu.push({
-            label: 'No servers',
-            enabled: false,
-        })
-        return submenu
-    }
-
-    menuSettings.servers.forEach((server, index) => {
-        submenu.push({
-            label: getServerLabel(server),
-            accelerator: serverAccelerator(index + 1),
-            type: 'radio',
-            checked: server.id === menuState.activeServerId,
-            click: () => sendAction({ type: 'connect-server', serverId: server.id }),
-        })
-    })
-
-    return submenu
-}
-
-function fileMenuItems(): MenuItemConstructorOptions[] {
-    return [
-        {
-            label: 'Add Torrent',
-            accelerator: 'CmdOrCtrl+O',
-            enabled: hasConnectedServer(),
-            click: () => sendAction({ type: 'open-add-torrent', askUploadOptions: false }),
-        },
-        {
-            label: 'Add Torrent (Advanced)',
-            accelerator: process.platform === 'darwin' ? 'CmdOrCtrl+Alt+O' : 'CmdOrCtrl+Shift+O',
-            visible: advancedUploadVisible(),
-            enabled: advancedUploadEnabled(),
-            click: () => sendAction({ type: 'open-add-torrent', askUploadOptions: true }),
-        },
-        {
-            label: 'Paste Torrent URL',
-            accelerator: 'CmdOrCtrl+I',
-            enabled: hasConnectedServer(),
-            click: () => sendAction({ type: 'paste-torrent-url', askUploadOptions: false }),
-        },
-        {
-            label: 'Paste Torrent URL (Advanced)',
-            accelerator: process.platform === 'darwin' ? 'CmdOrCtrl+Alt+I' : 'CmdOrCtrl+Shift+I',
-            visible: advancedUploadVisible(),
-            enabled: advancedUploadEnabled(),
-            click: () => sendAction({ type: 'paste-torrent-url', askUploadOptions: true }),
-        },
-    ]
-}
-
-function editMenuItems(): MenuItemConstructorOptions[] {
-    return [
-        { label: 'Undo', accelerator: 'CmdOrCtrl+Z', role: 'undo' },
-        { label: 'Redo', accelerator: 'Shift+CmdOrCtrl+Z', role: 'redo' },
-        { type: 'separator' },
-        {
-            label: 'Find',
-            accelerator: 'CmdOrCtrl+F',
-            click: () => sendAction({ type: 'search-torrent' }),
-        },
-        { label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
-        { label: 'Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' },
-        { label: 'Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' },
-        {
-            label: 'Remove',
-            accelerator: 'Delete',
-            click: () => sendAction({ type: 'remove-selected' }),
-        },
-        {
-            label: 'Remove and Delete',
-            accelerator: 'CmdOrCtrl+Delete',
-            click: () => sendAction({ type: 'remove-and-delete-selected' }),
-        },
-        {
-            label: 'Select All',
-            accelerator: 'CmdOrCtrl+A',
-            click: () => sendAction({ type: 'select-all' }),
-        },
-    ]
-}
-
-function viewMenuItems(): MenuItemConstructorOptions[] {
-    return [
-        {
-            label: 'Reload',
-            visible: !!menuState.isDebug,
-            accelerator: 'CmdOrCtrl+R',
-            click(_item, focusedWindow) {
-                if (focusedWindow) (focusedWindow as BrowserWindow).reload()
-            },
-        },
-        {
-            label: 'Toggle Full Screen',
-            accelerator: process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
-            click(_item, focusedWindow) {
-                if (focusedWindow) {
-                    const browserWindow = focusedWindow as BrowserWindow
-                    browserWindow.setFullScreen(!browserWindow.isFullScreen())
-                }
-            },
-        },
-        {
-            label: 'Toggle Developer Tools',
-            visible: !!menuState.isDebug,
-            accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-            click(_item, focusedWindow) {
-                if (focusedWindow) {
-                    (focusedWindow as BrowserWindow).webContents.toggleDevTools()
-                }
-            },
-        },
-    ]
-}
-
-function helpMenuItems(): MenuItemConstructorOptions[] {
-    return [
-        {
-            label: 'Learn More',
-            click: () => sendAction({ type: 'open-external', url: 'https://github.com/tympanix/Electorrent' }),
-        },
-        {
-            label: 'Check For Updates',
-            click: () => sendAction({ type: 'check-for-updates', verbose: true }),
-        },
-    ]
-}
-
-function buildDarwinTemplate(): MenuItemConstructorOptions[] {
-    const name = app.name
-
-    return [
-        {
-            label: name,
-            submenu: [
-                { label: `About ${name}`, role: 'about' },
-                { type: 'separator' },
-                {
-                    label: 'Preferences',
-                    accelerator: 'Command+,',
-                    click: () => sendAction({ type: 'show-settings' }),
-                },
-                { label: 'Services', role: 'services', submenu: [] },
-                { type: 'separator' },
-                { label: `Hide ${name}`, accelerator: 'Command+H', role: 'hide' },
-                { label: 'Hide Others', accelerator: 'Command+Alt+H', role: 'hideOthers' },
-                { label: 'Show All', role: 'unhide' },
-                { type: 'separator' },
-                { label: 'Quit', accelerator: 'Command+Q', role: 'quit' },
-            ],
-        },
-        {
-            label: 'File',
-            id: 'file',
-            submenu: fileMenuItems(),
-        },
-        {
-            label: 'Edit',
-            submenu: editMenuItems(),
-        },
-        {
-            label: 'View',
-            submenu: viewMenuItems(),
-        },
-        {
-            label: 'Servers',
-            id: 'servers',
-            submenu: serverMenuItems(),
-        },
-        {
-            label: 'Window',
-            role: 'window',
-            submenu: [
-                { label: 'Close', accelerator: 'CmdOrCtrl+W', role: 'close' },
-                { label: 'Minimize', accelerator: 'CmdOrCtrl+M', role: 'minimize' },
-                { label: 'Zoom', role: 'zoom' },
-                { type: 'separator' },
-                { label: 'Bring All to Front', role: 'front' },
-            ],
-        },
-        {
-            label: 'Help',
-            role: 'help',
-            submenu: helpMenuItems(),
-        },
-    ]
-}
-
-function buildDefaultTemplate(): MenuItemConstructorOptions[] {
-    return [
-        {
-            label: 'File',
-            id: 'file',
-            submenu: [
-                ...fileMenuItems(),
-                { type: 'separator' },
-                {
-                    label: 'Settings',
-                    accelerator: 'Ctrl+,',
-                    click: () => sendAction({ type: 'show-settings' }),
-                },
-                { type: 'separator' },
-                { label: 'Exit', role: 'quit' },
-            ],
-        },
-        {
-            label: 'Edit',
-            submenu: editMenuItems(),
-        },
-        {
-            label: 'View',
-            submenu: viewMenuItems(),
-        },
-        {
-            label: 'Servers',
-            id: 'servers',
-            submenu: serverMenuItems(),
-        },
-        {
-            label: 'Window',
-            role: 'window',
-            submenu: [
-                { label: 'Minimize', accelerator: 'CmdOrCtrl+M', role: 'minimize' },
-                { label: 'Close', accelerator: 'CmdOrCtrl+W', role: 'close' },
-            ],
-        },
-        {
-            label: 'Help',
-            role: 'help',
-            submenu: helpMenuItems(),
-        },
-    ]
-}
-
-function buildMenu() {
-    const template = process.platform === 'darwin'
-        ? buildDarwinTemplate()
-        : buildDefaultTemplate()
-
-    Menu.setApplicationMenu(Menu.buildFromTemplate(template))
-}
-
-export function configure(state: Pick<MenuSessionState, 'isDebug'>) {
-    menuState = Object.assign({}, menuState, state)
-    refresh()
-}
-
-export function setActiveServer(server?: { id?: string | null; client?: string | null } | null, isConnected = !!server) {
-    menuState = Object.assign({}, menuState, {
-        activeServerId: server?.id || null,
-        activeClientId: server?.client || null,
-        isConnected: !!server && isConnected,
-    })
-    buildMenu()
+export function getModel() {
+    return ensureModel().getValue()
 }
 
 export function refresh() {
-    menuSettings = normalizeMenuSettings(settings.getAllSettings())
-    buildMenu()
+    ensureModel().refresh()
 }

--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -6,6 +6,7 @@ import type { AppSettings } from '@shared/ipc-contract'
 import * as electorrent from './electorrent'
 
 let data: any = null
+const changeListeners = new Set<() => void>()
 
 type MainAppSettings = AppSettings & {
     debugMode?: boolean
@@ -172,6 +173,7 @@ function mergeWithDefaults<T>(defaults: T, value: any): T {
 export function put(key: string, value: any, callback?: (err?: Error | null) => void) {
     load()
     data[key] = value
+    notifyChanged()
     if (callback !== undefined) {
         save(callback)
     }
@@ -193,6 +195,7 @@ export function write() {
 export function saveAll(settings: any, callback?: (err?: Error | null) => void) {
     load()
     data = mergeWithDefaults(defaultSettings, settings)
+    notifyChanged()
     if (callback !== undefined) {
         save(callback)
     }
@@ -205,4 +208,13 @@ export function get(key: string) {
         value = copy(data[key])
     }
     return value
+}
+
+export function subscribe(listener: () => void) {
+    changeListeners.add(listener)
+    return () => changeListeners.delete(listener)
+}
+
+function notifyChanged() {
+    changeListeners.forEach((listener) => listener())
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer, webUtils } from 'electron'
 
 import { IPC_CHANNELS } from '@shared/ipc'
 import type { ColorTheme, ElectorrentBridge, PendingTorrentUploadFile, PendingTorrentUploadLink } from '@shared/ipc-contract'
+import type { TitleMenuItem } from '@shared/title-menu'
 
 const INITIAL_THEME_ARGUMENT = '--theme='
 const initialThemeArgument = process.argv.find((argument) => argument.startsWith(INITIAL_THEME_ARGUMENT))
@@ -83,6 +84,8 @@ const electorrentBridge: ElectorrentBridge = {
         command: (command) => invoke(IPC_CHANNELS.window.command, { command }),
     },
     menu: {
+        getModel: () => invoke<TitleMenuItem[]>(IPC_CHANNELS.menu.getModel),
+        onChanged: (callback: (menu: TitleMenuItem[]) => void) => subscribe(IPC_CHANNELS.menu.changed, callback),
         onAction: (callback) => subscribe(IPC_CHANNELS.menu.action, callback),
     },
     clipboard: {

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.controller.ts
@@ -1,43 +1,21 @@
-import { IScope } from "angular";
-import { createMenuActionHandler } from "@renderer/app/lib/menu-action-handler";
-import { CLIENT_METADATA } from "@shared/client-metadata";
-import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
-import type { EditCommand, MenuAction, WindowCommand } from "@shared/ipc-contract";
-
-type TitleBarMenuAction =
-    | MenuAction
-    | { type: "quit" }
-    | { type: "edit-command"; command: EditCommand }
-    | { type: "window-command"; command: WindowCommand };
-
-interface TitleBarMenuItem {
-    label: string;
-    accelerator?: string;
-    separator?: boolean;
-    checked?: boolean;
-    enabled?: boolean;
-    visible?: () => boolean;
-    action?: TitleBarMenuAction;
-}
-
-interface TitleBarMenu {
-    label: string;
-    items: () => TitleBarMenuItem[];
-}
+import { IScope } from "angular"
+import { createMenuActionHandler } from "@renderer/app/lib/menu-action-handler"
+import type { ElectorrentRootScope } from "@renderer/app/types/root-scope"
+import type { TitleMenuAction, TitleMenuItem } from "@shared/title-menu"
 
 interface TitleBarMenuScope extends IScope {
-    currentPage: () => string | null;
-    activeTitleBarMenu: number | null;
-    titleBarMenus: TitleBarMenu[];
-    visibleTitleBarMenuItems: (menu: TitleBarMenu) => TitleBarMenuItem[];
-    toggleTitleBarMenu: (index: number, $event: Event) => void;
-    openTitleBarMenu: (index: number) => void;
-    closeTitleBarMenu: () => void;
-    runTitleBarMenuItem: (item: TitleBarMenuItem, $event: Event) => void;
+    currentPage: () => string | null
+    activeTitleBarMenu: number | null
+    titleBarMenus: TitleMenuItem[]
+    visibleTitleBarMenuItems: (menu: TitleMenuItem) => TitleMenuItem[]
+    toggleTitleBarMenu: (index: number, $event: Event) => void
+    openTitleBarMenu: (index: number) => void
+    closeTitleBarMenu: () => void
+    runTitleBarMenuItem: (item: TitleMenuItem, $event: Event) => void
 }
 
 export class TitleBarMenuController {
-    static $inject = ["$rootScope", "$scope", "$bittorrent", "settingsService"];
+    static $inject = ["$rootScope", "$scope", "$bittorrent", "settingsService"]
 
     constructor(
         $rootScope: ElectorrentRootScope,
@@ -45,242 +23,80 @@ export class TitleBarMenuController {
         $bittorrent: any,
         settingsService: any,
     ) {
-        const electorrent = window.electorrent;
-        let isDebug = false;
+        const electorrent = window.electorrent
         const handleMenuAction = createMenuActionHandler({
             $rootScope,
             $scope,
             $bittorrent,
             settingsService,
             currentPage: $scope.currentPage,
-        });
+        })
 
-        const activeServer = () => {
-            return ($rootScope as any).$activeServer || $rootScope.$server;
-        };
-
-        const supportsUploadOptions = () => {
-            const clientId = activeServer()?.client;
-            return !!clientId && !!CLIENT_METADATA[clientId]?.showAdvancedUploadMenu;
-        };
-
-        const hasActiveServer = () => {
-            return !!activeServer()?.id;
-        };
-
-        const hasConnectedServer = () => {
-            return hasActiveServer() && !!$rootScope.$server?.isConnected && !!$rootScope.$btclient;
-        };
-
-        const serverAccelerator = (index: number) => {
-            return index > 0 && index <= 10 ? `Ctrl+${index % 10}` : undefined;
-        };
-
-        const getServerLabel = (server: any) => {
-            if (typeof server?.getDisplayName === "function") {
-                return server.getDisplayName();
-            }
-
-            return server?.name || server?.ip || "Server";
-        };
-
-        const fileMenuItems = (): TitleBarMenuItem[] => [
-            {
-                label: "Add Torrent",
-                accelerator: "Ctrl+O",
-                enabled: hasConnectedServer(),
-                action: { type: "open-add-torrent", askUploadOptions: false },
-            },
-            {
-                label: "Add Torrent (Advanced)",
-                accelerator: "Ctrl+Shift+O",
-                visible: supportsUploadOptions,
-                enabled: hasConnectedServer(),
-                action: { type: "open-add-torrent", askUploadOptions: true },
-            },
-            {
-                label: "Paste Torrent URL",
-                accelerator: "Ctrl+I",
-                enabled: hasConnectedServer(),
-                action: { type: "paste-torrent-url", askUploadOptions: false },
-            },
-            {
-                label: "Paste Torrent URL (Advanced)",
-                accelerator: "Ctrl+Shift+I",
-                visible: supportsUploadOptions,
-                enabled: hasConnectedServer(),
-                action: { type: "paste-torrent-url", askUploadOptions: true },
-            },
-            { label: "", separator: true },
-            {
-                label: "Settings",
-                accelerator: "Ctrl+,",
-                action: { type: "show-settings" },
-            },
-            { label: "", separator: true },
-            {
-                label: "Exit",
-                action: { type: "quit" },
-            },
-        ];
-
-        const editMenuItems = (): TitleBarMenuItem[] => [
-            { label: "Undo", accelerator: "Ctrl+Z", action: { type: "edit-command", command: "undo" } },
-            { label: "Redo", accelerator: "Shift+Ctrl+Z", action: { type: "edit-command", command: "redo" } },
-            { label: "", separator: true },
-            { label: "Find", accelerator: "Ctrl+F", action: { type: "search-torrent" } },
-            { label: "Cut", accelerator: "Ctrl+X", action: { type: "edit-command", command: "cut" } },
-            { label: "Copy", accelerator: "Ctrl+C", action: { type: "edit-command", command: "copy" } },
-            { label: "Paste", accelerator: "Ctrl+V", action: { type: "edit-command", command: "paste" } },
-            { label: "Remove", accelerator: "Delete", action: { type: "remove-selected" } },
-            { label: "Remove and Delete", accelerator: "Ctrl+Delete", action: { type: "remove-and-delete-selected" } },
-            { label: "Select All", accelerator: "Ctrl+A", action: { type: "select-all" } },
-        ];
-
-        const viewMenuItems = (): TitleBarMenuItem[] => [
-            {
-                label: "Reload",
-                accelerator: "Ctrl+R",
-                visible: () => isDebug,
-                action: { type: "window-command", command: "reload" },
-            },
-            {
-                label: "Toggle Full Screen",
-                accelerator: "F11",
-                action: { type: "window-command", command: "toggle-full-screen" },
-            },
-            {
-                label: "Toggle Developer Tools",
-                accelerator: "Ctrl+Shift+I",
-                visible: () => isDebug,
-                action: { type: "window-command", command: "toggle-dev-tools" },
-            },
-        ];
-
-        const serverMenuItems = (): TitleBarMenuItem[] => {
-            const items: TitleBarMenuItem[] = [
-                { label: "Add new server...", accelerator: "Ctrl+N", action: { type: "add-server" } },
-                {
-                    label: "Set current as default",
-                    enabled: hasActiveServer(),
-                    action: { type: "set-current-default-server" },
-                },
-                { label: "", separator: true },
-            ];
-
-            const servers = settingsService.getServers();
-            if (!servers.length) {
-                items.push({ label: "No servers", enabled: false });
-                return items;
-            }
-
-            servers.forEach((server: any, index: number) => {
-                items.push({
-                    label: getServerLabel(server),
-                    accelerator: serverAccelerator(index + 1),
-                    checked: server.id === activeServer()?.id,
-                    action: { type: "connect-server", serverId: server.id },
-                });
-            });
-
-            return items;
-        };
-
-        const windowMenuItems = (): TitleBarMenuItem[] => [
-            {
-                label: "Minimize",
-                accelerator: "Ctrl+M",
-                action: { type: "window-command", command: "minimize" },
-            },
-            {
-                label: "Close",
-                accelerator: "Ctrl+W",
-                action: { type: "window-command", command: "close" },
-            },
-        ];
-
-        const helpMenuItems: TitleBarMenuItem[] = [
-            {
-                label: "Learn More",
-                action: { type: "open-external", url: "https://github.com/tympanix/Electorrent" },
-            },
-            {
-                label: "Check For Updates",
-                action: { type: "check-for-updates", verbose: true },
-            },
-        ];
-
-        const runTitleBarAction = (action: TitleBarMenuAction) => {
+        const runTitleBarAction = (action: TitleMenuAction) => {
             switch (action.type) {
                 case "quit":
-                    electorrent.app.quit();
-                    break;
+                    electorrent.app.quit()
+                    break
                 case "edit-command":
-                    electorrent.edit.command(action.command);
-                    break;
+                    electorrent.edit.command(action.command)
+                    break
                 case "window-command":
-                    electorrent.window.command(action.command);
-                    break;
+                    electorrent.window.command(action.command)
+                    break
                 default:
-                    handleMenuAction(action);
-                    break;
+                    handleMenuAction(action)
+                    break
             }
-        };
+        }
 
-        $scope.activeTitleBarMenu = null;
-        $scope.titleBarMenus = [
-            { label: "File", items: fileMenuItems },
-            { label: "Edit", items: editMenuItems },
-            { label: "View", items: viewMenuItems },
-            { label: "Servers", items: serverMenuItems },
-            { label: "Window", items: windowMenuItems },
-            { label: "Help", items: () => helpMenuItems },
-        ];
-        $scope.visibleTitleBarMenuItems = (menu: TitleBarMenu) => {
-            return menu.items().filter((item) => item.visible ? item.visible() : true);
-        };
+        $scope.activeTitleBarMenu = null
+        $scope.titleBarMenus = []
+        $scope.visibleTitleBarMenuItems = (menu: TitleMenuItem) => {
+            return (menu.submenu || []).filter((item) => item.visible !== false)
+        }
         $scope.toggleTitleBarMenu = (index: number, $event: Event) => {
-            $event.stopPropagation();
-            $scope.activeTitleBarMenu = $scope.activeTitleBarMenu === index ? null : index;
-        };
+            $event.stopPropagation()
+            $scope.activeTitleBarMenu = $scope.activeTitleBarMenu === index ? null : index
+        }
         $scope.openTitleBarMenu = (index: number) => {
             if ($scope.activeTitleBarMenu !== null) {
-                $scope.activeTitleBarMenu = index;
+                $scope.activeTitleBarMenu = index
             }
-        };
+        }
         $scope.closeTitleBarMenu = () => {
-            $scope.activeTitleBarMenu = null;
-        };
-        $scope.runTitleBarMenuItem = (item: TitleBarMenuItem, $event: Event) => {
-            $event.stopPropagation();
-            if (item.separator || item.enabled === false || !item.action) {
-                return;
-            }
+            $scope.activeTitleBarMenu = null
+        }
+        $scope.runTitleBarMenuItem = (item: TitleMenuItem, $event: Event) => {
+            $event.stopPropagation()
+            if (item.type === "separator" || item.enabled === false || !item.action) return
 
-            $scope.activeTitleBarMenu = null;
-            runTitleBarAction(item.action);
-        };
+            $scope.activeTitleBarMenu = null
+            runTitleBarAction(item.action)
+        }
 
-        electorrent.app.getMeta().then((meta) => {
-            isDebug = meta.isDebug;
-            $scope.$applyAsync();
-        });
+        const updateMenu = (menu: TitleMenuItem[]) => {
+            $scope.titleBarMenus = menu
+            $scope.$applyAsync()
+        }
+        const unsubscribeMenu = electorrent.menu.onChanged(updateMenu)
+        electorrent.menu.getModel().then(updateMenu)
 
         const onDocumentClick = () => {
-            $scope.closeTitleBarMenu();
-            $scope.$applyAsync();
-        };
+            $scope.closeTitleBarMenu()
+            $scope.$applyAsync()
+        }
         const onDocumentKeyDown = (event: KeyboardEvent) => {
             if (event.key === "Escape") {
-                $scope.closeTitleBarMenu();
-                $scope.$applyAsync();
+                $scope.closeTitleBarMenu()
+                $scope.$applyAsync()
             }
-        };
-        document.addEventListener("click", onDocumentClick);
-        document.addEventListener("keydown", onDocumentKeyDown);
+        }
+        document.addEventListener("click", onDocumentClick)
+        document.addEventListener("keydown", onDocumentKeyDown)
         $scope.$on("$destroy", () => {
-            document.removeEventListener("click", onDocumentClick);
-            document.removeEventListener("keydown", onDocumentKeyDown);
-        });
+            unsubscribeMenu()
+            document.removeEventListener("click", onDocumentClick)
+            document.removeEventListener("keydown", onDocumentKeyDown)
+        })
     }
 }

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.template.html
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.template.html
@@ -13,9 +13,9 @@
         </button>
         <div class="title-bar-menu-dropdown" ng-if="activeTitleBarMenu === $index" ng-click="$event.stopPropagation()" role="menu">
             <div ng-repeat="item in visibleTitleBarMenuItems(menu) track by $index">
-                <div ng-if="item.separator" class="title-bar-menu-divider" role="separator"></div>
+                <div ng-if="item.type === 'separator'" class="title-bar-menu-divider" role="separator"></div>
                 <button
-                    ng-if="!item.separator"
+                    ng-if="item.type !== 'separator'"
                     type="button"
                     class="title-bar-menu-item"
                     ng-class="{ disabled: item.enabled === false, checked: item.checked }"

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -411,6 +411,8 @@ export interface ElectorrentBridge {
         command(command: WindowCommand): Promise<void>
     }
     menu: {
+        getModel(): Promise<import("./title-menu").TitleMenuItem[]>
+        onChanged(callback: (menu: import("./title-menu").TitleMenuItem[]) => void): Unsubscribe
         onAction(callback: (action: MenuAction) => void): Unsubscribe
     }
     clipboard: {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -60,6 +60,8 @@ export const IPC_CHANNELS = {
     },
     menu: {
         action: 'menu:action',
+        getModel: 'menu:get-model',
+        changed: 'menu:changed',
     },
     clipboard: {
         readText: 'clipboard:read-text',

--- a/src/shared/title-menu.ts
+++ b/src/shared/title-menu.ts
@@ -1,0 +1,287 @@
+import { CLIENT_METADATA } from "./client-metadata"
+import type { AppSettings, EditCommand, MenuAction, StoredServerConfig, Unsubscribe, WindowCommand } from "./ipc-contract"
+
+export type TitleMenuPlatform = "darwin" | "linux" | "win32"
+
+export type TitleMenuAction =
+    | MenuAction
+    | { type: "quit" }
+    | { type: "edit-command"; command: EditCommand }
+    | { type: "window-command"; command: WindowCommand }
+
+export type TitleMenuNativeRole =
+    | "about"
+    | "close"
+    | "copy"
+    | "cut"
+    | "front"
+    | "help"
+    | "hide"
+    | "hideOthers"
+    | "minimize"
+    | "paste"
+    | "quit"
+    | "redo"
+    | "services"
+    | "undo"
+    | "unhide"
+    | "window"
+    | "zoom"
+
+export interface TitleMenuItem {
+    id?: string
+    label?: string
+    accelerator?: string
+    type?: "normal" | "radio" | "separator"
+    checked?: boolean
+    enabled?: boolean
+    visible?: boolean
+    nativeRole?: TitleMenuNativeRole
+    action?: TitleMenuAction
+    submenu?: TitleMenuItem[]
+}
+
+export interface TitleMenuState {
+    appName: string
+    platform: TitleMenuPlatform
+    isDebug: boolean
+    settings: Pick<AppSettings, "servers">
+    session: {
+        activeServerId: string | null
+        activeClientId: string | null
+        isConnected: boolean
+    }
+}
+
+export interface TitleMenuSources {
+    getSettings(): Pick<AppSettings, "servers">
+    subscribeSettings(listener: () => void): Unsubscribe
+    getSession(): TitleMenuState["session"]
+    subscribeSession(listener: () => void): Unsubscribe
+}
+
+const separator = (): TitleMenuItem => ({ type: "separator" })
+
+function serverAccelerator(index: number, platform: TitleMenuPlatform) {
+    if (index <= 0 || index > 10) return undefined
+    return `${platform === "darwin" ? "CmdOrCtrl" : "Ctrl"}+${index % 10}`
+}
+
+function getServerLabel(server: StoredServerConfig) {
+    const clientName = CLIENT_METADATA[server.client as keyof typeof CLIENT_METADATA]?.name || server.client || "Server"
+    return server.name || `${clientName} @ ${server.ip || "unknown host"}`
+}
+
+export function deriveTitleMenu(state: TitleMenuState): TitleMenuItem[] {
+    const { appName, isDebug, platform, session, settings } = state
+    const isDarwin = platform === "darwin"
+    const hasActiveServer = !!session.activeServerId
+    const hasConnectedServer = hasActiveServer && session.isConnected
+    const advancedUploadVisible = !!session.activeClientId
+        && !!CLIENT_METADATA[session.activeClientId as keyof typeof CLIENT_METADATA]?.showAdvancedUploadMenu
+
+    const fileItems: TitleMenuItem[] = [
+        {
+            label: "Add Torrent",
+            accelerator: "CmdOrCtrl+O",
+            enabled: hasConnectedServer,
+            action: { type: "open-add-torrent", askUploadOptions: false },
+        },
+        {
+            label: "Add Torrent (Advanced)",
+            accelerator: isDarwin ? "CmdOrCtrl+Alt+O" : "Ctrl+Shift+O",
+            visible: advancedUploadVisible,
+            enabled: hasConnectedServer && advancedUploadVisible,
+            action: { type: "open-add-torrent", askUploadOptions: true },
+        },
+        {
+            label: "Paste Torrent URL",
+            accelerator: "CmdOrCtrl+I",
+            enabled: hasConnectedServer,
+            action: { type: "paste-torrent-url", askUploadOptions: false },
+        },
+        {
+            label: "Paste Torrent URL (Advanced)",
+            accelerator: isDarwin ? "CmdOrCtrl+Alt+I" : "Ctrl+Shift+I",
+            visible: advancedUploadVisible,
+            enabled: hasConnectedServer && advancedUploadVisible,
+            action: { type: "paste-torrent-url", askUploadOptions: true },
+        },
+    ]
+
+    const editItems: TitleMenuItem[] = [
+        { label: "Undo", accelerator: "CmdOrCtrl+Z", nativeRole: "undo", action: { type: "edit-command", command: "undo" } },
+        { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", nativeRole: "redo", action: { type: "edit-command", command: "redo" } },
+        separator(),
+        { label: "Find", accelerator: "CmdOrCtrl+F", action: { type: "search-torrent" } },
+        { label: "Cut", accelerator: "CmdOrCtrl+X", nativeRole: "cut", action: { type: "edit-command", command: "cut" } },
+        { label: "Copy", accelerator: "CmdOrCtrl+C", nativeRole: "copy", action: { type: "edit-command", command: "copy" } },
+        { label: "Paste", accelerator: "CmdOrCtrl+V", nativeRole: "paste", action: { type: "edit-command", command: "paste" } },
+        { label: "Remove", accelerator: "Delete", action: { type: "remove-selected" } },
+        { label: "Remove and Delete", accelerator: "CmdOrCtrl+Delete", action: { type: "remove-and-delete-selected" } },
+        { label: "Select All", accelerator: "CmdOrCtrl+A", action: { type: "select-all" } },
+    ]
+
+    const viewItems: TitleMenuItem[] = [
+        {
+            label: "Reload",
+            accelerator: "CmdOrCtrl+R",
+            visible: isDebug,
+            action: { type: "window-command", command: "reload" },
+        },
+        {
+            label: "Toggle Full Screen",
+            accelerator: isDarwin ? "Ctrl+Command+F" : "F11",
+            action: { type: "window-command", command: "toggle-full-screen" },
+        },
+        {
+            label: "Toggle Developer Tools",
+            accelerator: isDarwin ? "Alt+Command+I" : "Ctrl+Shift+I",
+            visible: isDebug,
+            action: { type: "window-command", command: "toggle-dev-tools" },
+        },
+    ]
+
+    const serverItems: TitleMenuItem[] = [
+        { label: "Add new server...", accelerator: "CmdOrCtrl+N", action: { type: "add-server" } },
+        {
+            label: "Set current as default",
+            enabled: hasActiveServer,
+            action: { type: "set-current-default-server" },
+        },
+        separator(),
+    ]
+
+    if (settings.servers.length === 0) {
+        serverItems.push({ label: "No servers", enabled: false })
+    } else {
+        settings.servers.forEach((server, index) => {
+            serverItems.push({
+                label: getServerLabel(server),
+                accelerator: serverAccelerator(index + 1, platform),
+                type: "radio",
+                checked: server.id === session.activeServerId,
+                action: { type: "connect-server", serverId: server.id },
+            })
+        })
+    }
+
+    const helpItems: TitleMenuItem[] = [
+        {
+            label: "Learn More",
+            action: { type: "open-external", url: "https://github.com/tympanix/Electorrent" },
+        },
+        { label: "Check For Updates", action: { type: "check-for-updates", verbose: true } },
+    ]
+
+    if (isDarwin) {
+        return [
+            {
+                label: appName,
+                submenu: [
+                    { label: `About ${appName}`, nativeRole: "about" },
+                    separator(),
+                    { label: "Preferences", accelerator: "Command+,", action: { type: "show-settings" } },
+                    { label: "Services", nativeRole: "services", submenu: [] },
+                    separator(),
+                    { label: `Hide ${appName}`, accelerator: "Command+H", nativeRole: "hide" },
+                    { label: "Hide Others", accelerator: "Command+Alt+H", nativeRole: "hideOthers" },
+                    { label: "Show All", nativeRole: "unhide" },
+                    separator(),
+                    { label: "Quit", accelerator: "Command+Q", nativeRole: "quit", action: { type: "quit" } },
+                ],
+            },
+            { id: "file", label: "File", submenu: fileItems },
+            { id: "edit", label: "Edit", submenu: editItems },
+            { id: "view", label: "View", submenu: viewItems },
+            { id: "servers", label: "Servers", submenu: serverItems },
+            {
+                id: "window",
+                label: "Window",
+                nativeRole: "window",
+                submenu: [
+                    { label: "Close", accelerator: "CmdOrCtrl+W", nativeRole: "close", action: { type: "window-command", command: "close" } },
+                    { label: "Minimize", accelerator: "CmdOrCtrl+M", nativeRole: "minimize", action: { type: "window-command", command: "minimize" } },
+                    { label: "Zoom", nativeRole: "zoom" },
+                    separator(),
+                    { label: "Bring All to Front", nativeRole: "front" },
+                ],
+            },
+            { id: "help", label: "Help", nativeRole: "help", submenu: helpItems },
+        ]
+    }
+
+    return [
+        {
+            id: "file",
+            label: "File",
+            submenu: [
+                ...fileItems,
+                separator(),
+                { label: "Settings", accelerator: "Ctrl+,", action: { type: "show-settings" } },
+                separator(),
+                { label: "Exit", nativeRole: "quit", action: { type: "quit" } },
+            ],
+        },
+        { id: "edit", label: "Edit", submenu: editItems },
+        { id: "view", label: "View", submenu: viewItems },
+        { id: "servers", label: "Servers", submenu: serverItems },
+        {
+            id: "window",
+            label: "Window",
+            nativeRole: "window",
+            submenu: [
+                { label: "Minimize", accelerator: "CmdOrCtrl+M", nativeRole: "minimize", action: { type: "window-command", command: "minimize" } },
+                { label: "Close", accelerator: "CmdOrCtrl+W", nativeRole: "close", action: { type: "window-command", command: "close" } },
+            ],
+        },
+        { id: "help", label: "Help", nativeRole: "help", submenu: helpItems },
+    ]
+}
+
+export class TitleMenuModel {
+    private readonly listeners = new Set<(menu: TitleMenuItem[]) => void>()
+    private readonly unsubscribeSources: Unsubscribe[]
+    private menu: TitleMenuItem[]
+
+    constructor(private state: Omit<TitleMenuState, "settings" | "session">, private readonly sources: TitleMenuSources) {
+        this.menu = this.derive()
+        this.unsubscribeSources = [
+            sources.subscribeSettings(() => this.refresh()),
+            sources.subscribeSession(() => this.refresh()),
+        ]
+    }
+
+    getValue() {
+        return this.menu
+    }
+
+    setState(state: Partial<Omit<TitleMenuState, "settings" | "session">>) {
+        this.state = { ...this.state, ...state }
+        this.refresh()
+    }
+
+    refresh() {
+        this.menu = this.derive()
+        this.listeners.forEach((listener) => listener(this.menu))
+    }
+
+    subscribe(listener: (menu: TitleMenuItem[]) => void): Unsubscribe {
+        this.listeners.add(listener)
+        listener(this.menu)
+        return () => this.listeners.delete(listener)
+    }
+
+    dispose() {
+        this.unsubscribeSources.forEach((unsubscribe) => unsubscribe())
+        this.listeners.clear()
+    }
+
+    private derive() {
+        return deriveTitleMenu({
+            ...this.state,
+            settings: this.sources.getSettings(),
+            session: this.sources.getSession(),
+        })
+    }
+}


### PR DESCRIPTION
## What changed

- add a shared, serializable title-menu model derived as a pure function from application state
- subscribe the model to settings and BitTorrent session-manager changes
- adapt the same model to Electron's native application menu and the renderer title-bar menu
- expose model snapshots and updates through the preload bridge

## Why

The native and HTML title menus independently encoded the same items and state rules, which allowed labels, shortcuts, visibility, enabled state, and server selection to drift. A single state-derived structure now keeps both presentation layers aligned.

## Impact

Menu presentation remains platform-aware. Settings and connection changes automatically rebuild the native menu and update the renderer menu without either consumer deriving application state itself.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "mock" --spec "test/specs/mock/software-update.spec.ts"`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/keyboard-shortcuts.spec.ts"`
- `npm run test -- --client "mock" --spec "test/specs/mock/multiple-servers.spec.ts"`