### PR TITLE
refactor(types): tighten IPC boundaries

### DIFF
--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -275,9 +275,16 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         })
     }
 
-    async getTorrentFiles(hash: string): Promise<MockTorrentFile[]> {
+    async getTorrentFiles(hash: string): Promise<BittorrentFileSelection[]> {
         this.assertConnected()
-        return this.files.get(hash) || []
+        return (this.files.get(hash) || []).map((file) => ({
+            index: file.index,
+            path: file.name,
+            name: file.name.split(/[/\\]/).pop() || "",
+            size: file.size,
+            wanted: file.priority !== PRIORITY_SKIP,
+            priority: file.priority,
+        }))
     }
 
     async setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]): Promise<void> {

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -6,6 +6,7 @@ import type {
     BittorrentFileSelection,
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
+    BittorrentTorrentDetailsFile,
     TorrentClientConnection,
 } from "@shared/ipc-contract"
 import { defer, HTTP_LOGIN_TIMEOUT, HTTP_REQUEST_TIMEOUT, serverOriginUrl, serverUrl, urlPath } from "@main/lib/bittorrent/helpers"
@@ -16,6 +17,62 @@ import type { QBittorrentBaseApi } from "./base-api"
 
 const QBITTORRENT_PRIORITY_SKIP = 0
 const QBITTORRENT_PRIORITY_NORMAL = 1
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null
+}
+
+function normalizeTorrentFiles(body: unknown): BittorrentFileSelection[] {
+    if (!Array.isArray(body)) {
+        throw new Error("Invalid torrent files response")
+    }
+
+    return body.map((value, index) => {
+        if (!isRecord(value)) {
+            throw new Error("Invalid torrent file response")
+        }
+
+        const path = typeof value.name === "string" ? value.name : ""
+        const size = typeof value.size === "number" ? value.size : Number.parseInt(String(value.size), 10) || 0
+        const priority = typeof value.priority === "number" ? value.priority : QBITTORRENT_PRIORITY_NORMAL
+
+        return {
+            index: typeof value.index === "number" ? value.index : index,
+            path,
+            name: path.split(/[/\\]/).pop() || "",
+            size,
+            wanted: priority !== QBITTORRENT_PRIORITY_SKIP,
+            priority,
+        }
+    })
+}
+
+function normalizeTorrentDetailsFiles(body: unknown): BittorrentTorrentDetailsFile[] {
+    if (!Array.isArray(body)) {
+        throw new Error("Invalid torrent files response")
+    }
+
+    return body.map((value, index) => {
+        if (!isRecord(value)) {
+            throw new Error("Invalid torrent file response")
+        }
+
+        const path = typeof value.name === "string" ? value.name : ""
+        const priority = typeof value.priority === "number" ? value.priority : QBITTORRENT_PRIORITY_NORMAL
+
+        return {
+            index: typeof value.index === "number" ? value.index : index,
+            path,
+            name: path.split(/[/\\]/).pop() || "",
+            size: typeof value.size === "number" ? value.size : Number.parseInt(String(value.size), 10) || 0,
+            progress: typeof value.progress === "number" ? value.progress : Number(value.progress) || 0,
+            availability: typeof value.availability === "number" ? value.availability : Number(value.availability) || 0,
+            priority,
+            wanted: priority !== QBITTORRENT_PRIORITY_SKIP,
+            isSeed: Boolean(value.is_seed),
+        }
+    })
+}
 
 export class QBittorrentRuntime implements BittorrentRuntime {
     private url(server: BittorrentServerConfig, endpoint?: string) {
@@ -475,12 +532,8 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                     resolve(body || {})
                 })
             }),
-            this.getTorrentFiles(hash),
+            this.fetchTorrentFiles(hash),
         ])
-
-        if (!Array.isArray(files)) {
-            throw new Error("Invalid torrent files response")
-        }
 
         return {
             info: {
@@ -522,27 +575,14 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 uploadSpeed: properties.up_speed ?? null,
                 isPrivate: properties.is_private ?? properties.isPrivate ?? null,
             },
-            files: files.map((file: any, idx: number) => {
-                const priority = file.priority != null ? Number(file.priority) : undefined
-                return {
-                    index: file.index != null ? Number(file.index) : idx,
-                    path: file.name || "",
-                    name: (file.name || "").split(/[/\\]/).pop() || "",
-                    size: typeof file.size === "number" ? file.size : (parseInt(String(file.size), 10) || 0),
-                    progress: typeof file.progress === "number" ? file.progress : Number(file.progress) || 0,
-                    availability: typeof file.availability === "number" ? file.availability : Number(file.availability) || 0,
-                    priority,
-                    wanted: priority !== QBITTORRENT_PRIORITY_SKIP,
-                    isSeed: Boolean(file.is_seed),
-                }
-            }),
+            files: normalizeTorrentDetailsFiles(files),
         }
     }
 
-    getTorrentFiles(hash: string): Promise<any> {
+    private fetchTorrentFiles(hash: string): Promise<unknown> {
         const api = this.getApi()
         return new Promise((resolve, reject) => {
-            api.getJson("torrents/files", { qs: { hash } }, (err: any, _res: any, body: any) => {
+            api.getJson("torrents/files", { qs: { hash } }, (err: unknown, _res: unknown, body: unknown) => {
                 if (err) {
                     reject(err)
                     return
@@ -551,6 +591,10 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 resolve(body)
             })
         })
+    }
+
+    async getTorrentFiles(hash: string): Promise<BittorrentFileSelection[]> {
+        return normalizeTorrentFiles(await this.fetchTorrentFiles(hash))
     }
 
     async setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]): Promise<void> {

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -137,7 +137,7 @@ class BittorrentManager {
 
     async invokeAction(sender: WebContents, request: BittorrentInvokeActionRequest) {
         const runtime = await this.getSession(sender)
-        const action = runtime[request.action]
+        const action = (runtime as unknown as Record<string, unknown>)[request.action]
         if (typeof action !== "function") {
             throw new Error(`Unsupported bittorrent action: ${request.action}`)
         }

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -3,19 +3,19 @@ import type {
     BittorrentServerConfig,
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
+    TorrentUploadOptions,
 } from "@shared/ipc-contract"
 
-export type CallbackFunc<T = any> = (err: any, val: T) => void
+export type CallbackFunc<T = unknown> = (err: unknown, val: T) => void
 
 export interface BittorrentRuntime {
     connect(server: BittorrentServerConfig): Promise<TorrentClientConnection>
     getSnapshot(fullUpdate?: boolean): Promise<any>
-    addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void>
-    uploadTorrent(buffer: Uint8Array, filename: string, options?: Record<string, any>): Promise<void>
+    addTorrentUrl(uri: string, options?: TorrentUploadOptions): Promise<void>
+    uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions): Promise<void>
     setLocation?(hashes: string[], location: string): Promise<void>
     getTorrentDetails?(hash: string): Promise<BittorrentTorrentDetailsData>
-    getTorrentFiles?(hash: string): Promise<any>
+    getTorrentFiles?(hash: string): Promise<BittorrentFileSelection[]>
     setTorrentFileSelection?(hash: string, files: BittorrentFileSelection[]): Promise<void>
     disconnect?(): Promise<void>
-    [key: string]: any
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,7 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 
 import { IPC_CHANNELS } from '@shared/ipc'
-import type { ColorTheme, EditCommand, PendingTorrentUploadFile, PendingTorrentUploadLink, WindowCommand } from '@shared/ipc-contract'
+import type { ColorTheme, ElectorrentBridge, PendingTorrentUploadFile, PendingTorrentUploadLink } from '@shared/ipc-contract'
 
 const INITIAL_THEME_ARGUMENT = '--theme='
 const initialThemeArgument = process.argv.find((argument) => argument.startsWith(INITIAL_THEME_ARGUMENT))
@@ -9,7 +9,7 @@ const initialThemeValue = initialThemeArgument?.slice(INITIAL_THEME_ARGUMENT.len
 const initialTheme: ColorTheme = initialThemeValue === 'dark' ? 'dark' : 'light'
 const nodeEnvironment = process.env["NODE" + "_ENV"]
 
-function invoke<T = unknown>(channel: string, payload?: any): Promise<T> {
+function invoke<T = unknown>(channel: string, payload?: unknown): Promise<T> {
     return ipcRenderer.invoke(channel, payload)
 }
 
@@ -19,7 +19,7 @@ function subscribe<T = unknown>(channel: string, callback: (payload: T) => void)
     return () => ipcRenderer.removeListener(channel, listener)
 }
 
-contextBridge.exposeInMainWorld('electorrent', {
+const electorrentBridge: ElectorrentBridge = {
     app: {
         initialTheme,
         isTestEnvironment: nodeEnvironment === 'test',
@@ -34,7 +34,7 @@ contextBridge.exposeInMainWorld('electorrent', {
     },
     settings: {
         getAll: () => invoke(IPC_CHANNELS.settings.getAll),
-        saveAll: (settings: unknown) => invoke(IPC_CHANNELS.settings.saveAll, { settings }),
+        saveAll: (settings) => invoke(IPC_CHANNELS.settings.saveAll, { settings }),
         listThemes: () => invoke(IPC_CHANNELS.settings.listThemes),
         getSystemTheme: () => invoke(IPC_CHANNELS.settings.getSystemTheme),
         onSystemThemeChanged: (callback: (theme: ColorTheme) => void) => subscribe(IPC_CHANNELS.settings.systemThemeChanged, callback),
@@ -47,45 +47,47 @@ contextBridge.exposeInMainWorld('electorrent', {
     },
     torrents: {
         openFiles: (askUploadOptions: boolean) => invoke(IPC_CHANNELS.torrents.openFiles, { askUploadOptions }),
-        parse: (request: unknown) => invoke(IPC_CHANNELS.torrents.parse, request),
-        getPathForFile: (file: any) => webUtils.getPathForFile(file),
+        parse: (request) => invoke(IPC_CHANNELS.torrents.parse, request),
+        getPathForFile: (file) => webUtils.getPathForFile(file),
     },
     bittorrent: {
-        connect: (server: unknown) => invoke(IPC_CHANNELS.bittorrent.connect, { server }),
+        connect: (server) => invoke(IPC_CHANNELS.bittorrent.connect, { server }),
         disconnect: () => invoke(IPC_CHANNELS.bittorrent.disconnect),
-        getSnapshot: (request?: unknown) => invoke(IPC_CHANNELS.bittorrent.getSnapshot, request || {}),
-        addTorrentUrl: (request: unknown) => invoke(IPC_CHANNELS.bittorrent.addTorrentUrl, request),
-        uploadTorrent: (request: unknown) => invoke(IPC_CHANNELS.bittorrent.uploadTorrent, request),
-        invokeAction: (request: unknown) => invoke(IPC_CHANNELS.bittorrent.invokeAction, request),
-        getTorrentDetails: (request: unknown) => invoke(IPC_CHANNELS.bittorrent.getTorrentDetails, request),
-        getTorrentFiles: (request: unknown) => invoke(IPC_CHANNELS.bittorrent.getTorrentFiles, request),
-        setTorrentFileSelection: (request: unknown) => invoke(IPC_CHANNELS.bittorrent.setTorrentFileSelection, request),
+        getSnapshot: (request) => invoke(IPC_CHANNELS.bittorrent.getSnapshot, request || {}),
+        addTorrentUrl: (request) => invoke(IPC_CHANNELS.bittorrent.addTorrentUrl, request),
+        uploadTorrent: (request) => invoke(IPC_CHANNELS.bittorrent.uploadTorrent, request),
+        invokeAction: (request) => invoke(IPC_CHANNELS.bittorrent.invokeAction, request),
+        getTorrentDetails: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentDetails, request),
+        getTorrentFiles: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentFiles, request),
+        setTorrentFileSelection: (request) => invoke(IPC_CHANNELS.bittorrent.setTorrentFileSelection, request),
     },
     updates: {
         check: (verbose?: boolean) => invoke(IPC_CHANNELS.updates.check, { verbose }),
         installDownloaded: () => invoke(IPC_CHANNELS.updates.installDownloaded),
         installAuto: () => invoke(IPC_CHANNELS.updates.installAuto),
-        onStatus: (callback: (event: unknown) => void) => subscribe(IPC_CHANNELS.updates.status, callback),
+        onStatus: (callback) => subscribe(IPC_CHANNELS.updates.status, callback),
     },
     certificates: {
-        fetch: (request: unknown) => invoke(IPC_CHANNELS.certificates.fetch, request),
-        install: (request: unknown) => invoke(IPC_CHANNELS.certificates.install, request),
+        fetch: (request) => invoke(IPC_CHANNELS.certificates.fetch, request),
+        install: (request) => invoke(IPC_CHANNELS.certificates.install, request),
         load: (fingerprint: string) => invoke(IPC_CHANNELS.certificates.load, { fingerprint }),
-        onChallenge: (callback: (prompt: unknown) => void) => subscribe(IPC_CHANNELS.certificates.challenge, callback),
+        onChallenge: (callback) => subscribe(IPC_CHANNELS.certificates.challenge, callback),
     },
     notifications: {
-        onPush: (callback: (notification: unknown) => void) => subscribe(IPC_CHANNELS.notifications.push, callback),
+        onPush: (callback) => subscribe(IPC_CHANNELS.notifications.push, callback),
     },
     edit: {
-        command: (command: EditCommand) => invoke(IPC_CHANNELS.edit.command, { command }),
+        command: (command) => invoke(IPC_CHANNELS.edit.command, { command }),
     },
     window: {
-        command: (command: WindowCommand) => invoke(IPC_CHANNELS.window.command, { command }),
+        command: (command) => invoke(IPC_CHANNELS.window.command, { command }),
     },
     menu: {
-        onAction: (callback: (action: unknown) => void) => subscribe(IPC_CHANNELS.menu.action, callback),
+        onAction: (callback) => subscribe(IPC_CHANNELS.menu.action, callback),
     },
     clipboard: {
         readText: () => invoke(IPC_CHANNELS.clipboard.readText),
     },
-})
+}
+
+contextBridge.exposeInMainWorld('electorrent', electorrentBridge)

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -50,7 +50,7 @@ export function uploadTorrent(data: Uint8Array, filename: string, options?: Torr
     return bridge().uploadTorrent({ data, filename, options, sourcePath })
 }
 
-export function invokeAction(action: string, hashes: string[] = [], ...args: any[]) {
+export function invokeAction(action: string, hashes: string[] = [], ...args: unknown[]) {
     return bridge().invokeAction({ action, hashes, args })
 }
 

--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -32,8 +32,6 @@ export interface QBittorrentUploadOptions {
   firstLastPiecePrio?: boolean
 }
 
-const QBITTORRENT_PRIORITY_SKIP = 0;
-
 export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
     public name = "qBittorrent"
     public id = "qbittorrent"
@@ -169,19 +167,7 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
     }
 
     async getTorrentFiles(torrent: QBittorrentTorrent): Promise<TorrentFile[]> {
-      const body = await getTorrentFiles(torrent.hash);
-      if (!Array.isArray(body)) {
-        throw new Error("Invalid response");
-      }
-
-      return body.map((file: any, idx: number) => ({
-        index: file.index != null ? file.index : idx,
-        path: file.name || "",
-        name: (file.name || "").split(/[/\\]/).pop() || "",
-        size: typeof file.size === "number" ? file.size : (parseInt(String(file.size), 10) || 0),
-        wanted: (file.priority != null ? file.priority : 1) !== QBITTORRENT_PRIORITY_SKIP,
-        priority: file.priority,
-      }));
+      return getTorrentFiles(torrent.hash);
     }
 
     setTorrentFileSelection(torrent: QBittorrentTorrent, files: TorrentFile[]): Promise<void> {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -79,20 +79,20 @@ export interface BittorrentSnapshotRequest {
 
 export interface BittorrentAddTorrentUrlRequest {
     uri: string
-    options?: Record<string, any>
+    options?: TorrentUploadOptions
 }
 
 export interface BittorrentUploadTorrentRequest {
     data: Uint8Array
     filename: string
-    options?: Record<string, any>
+    options?: TorrentUploadOptions
     sourcePath?: string
 }
 
 export interface BittorrentInvokeActionRequest {
     action: string
     hashes?: string[]
-    args?: any[]
+    args?: unknown[]
 }
 
 export interface BittorrentGetTorrentFilesRequest {
@@ -376,7 +376,7 @@ export interface ElectorrentBridge {
     torrents: {
         openFiles(askUploadOptions: boolean): Promise<PendingTorrentUploadFile[]>
         parse(request: ParseTorrentRequest): Promise<TorrentMetadata>
-        getPathForFile(file: unknown): string
+        getPathForFile(file: File): string
     }
     bittorrent: {
         connect(server: BittorrentServerConfig): Promise<BittorrentConnectResult>
@@ -386,7 +386,7 @@ export interface ElectorrentBridge {
         uploadTorrent(request: BittorrentUploadTorrentRequest): Promise<void>
         invokeAction(request: BittorrentInvokeActionRequest): Promise<void>
         getTorrentDetails(request: BittorrentGetTorrentDetailsRequest): Promise<BittorrentTorrentDetailsData>
-        getTorrentFiles(request: BittorrentGetTorrentFilesRequest): Promise<any>
+        getTorrentFiles(request: BittorrentGetTorrentFilesRequest): Promise<BittorrentFileSelection[]>
         setTorrentFileSelection(request: BittorrentSetTorrentFileSelectionRequest): Promise<void>
     }
     updates: {


### PR DESCRIPTION
## What changed

- enforce the shared `ElectorrentBridge` contract on the preload implementation
- replace generic upload option bags and action arguments with existing domain types and `unknown`
- remove the permissive runtime string index signature and isolate dynamic action lookup
- normalize qBittorrent and mock file responses into `BittorrentFileSelection` before crossing IPC

## Why

The preload and bittorrent runtime boundaries were high-impact type escape hatches. Their `any` and `unknown` annotations allowed contract drift and client-native response shapes to propagate into renderer code without compiler checks.

Raw client snapshots remain intentionally out of scope because each backend has a distinct protocol shape; typing those safely is best handled client by client.

## Impact

Bridge drift is now caught during typechecking, upload options use the established domain model, and torrent file consumers receive one stable shared shape.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-file-selection.spec.ts"`