### PR TITLE
feat(ui): default to overflow resizing

### DIFF
--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -27,7 +27,7 @@ const defaultSettings: MainAppSettings = {
     alwaysPromptUploadOptions: false,
     watchDirectory: '',
     ui: {
-        resizeMode: 'FixedResizer',
+        resizeMode: 'OverflowResizer',
         notifications: true,
         displaySize: 'normal',
         displayCompact: false,

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -51,7 +51,7 @@ export class TorrentDetailsPanelController {
     this.scope.torrent = null;
     this.scope.activeTab = "info";
     this.scope.sortedFiles = [];
-    this.scope.resizeMode = "FixedResizer";
+    this.scope.resizeMode = "OverflowResizer";
     this.scope.resizeProfile = this.getResizeProfile();
     this.scope.panel = {
       info: { sections: [] },
@@ -61,7 +61,7 @@ export class TorrentDetailsPanelController {
     this.scope.$watch(
       () => this.scope.settings?.ui?.resizeMode,
       (resizeMode?: string) => {
-        this.scope.resizeMode = resizeMode || "FixedResizer";
+        this.scope.resizeMode = resizeMode || "OverflowResizer";
       },
     );
 
@@ -305,7 +305,7 @@ export class TorrentDetailsPanelController {
   }
 
   private syncResizeBindings() {
-    this.scope.resizeMode = this.scope.settings?.ui?.resizeMode || "FixedResizer";
+    this.scope.resizeMode = this.scope.settings?.ui?.resizeMode || "OverflowResizer";
     this.scope.resizeProfile = this.getResizeProfile();
   }
 


### PR DESCRIPTION
## What changed

- Default new configurations to `OverflowResizer` for torrent tables.
- Use the same overflow fallback in the torrent details table while settings load or are absent.
- Preserve existing users’ explicitly saved resize mode.

## Why

Overflow resizing keeps table columns usable by allowing the table to extend horizontally instead of forcing the static resize behavior by default.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts"`