### PR TITLE
refactor: isolate torrent details tabs

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -214,6 +214,10 @@ import { TorrentFilesModalDirective } from "@renderer/app/directives/torrent-fil
 torrentApp.directive('torrentFilesModal', TorrentFilesModalDirective.getInstance())
 import { TorrentDetailsPanelDirective } from "@renderer/app/directives/torrent-details-panel/torrent-details-panel.directive";
 torrentApp.directive('torrentDetailsPanel', TorrentDetailsPanelDirective.getInstance())
+import { TorrentDetailsInfoTabDirective } from "@renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.directive";
+torrentApp.directive('torrentDetailsInfoTab', TorrentDetailsInfoTabDirective.getInstance())
+import { TorrentDetailsFilesTabDirective } from "@renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.directive";
+torrentApp.directive('torrentDetailsFilesTab', TorrentDetailsFilesTabDirective.getInstance())
 import { SetLocationModalDirective } from "@renderer/app/directives/set-location-modal/set-location-modal.directive";
 torrentApp.directive('setLocationModal', SetLocationModalDirective.getInstance())
 import { TorrentSpeedModalDirective } from "@renderer/app/directives/torrent-speed-modal/torrent-speed-modal.directive";

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
@@ -1,0 +1,331 @@
+import { IFilterService, IScope, IWindowService } from "angular";
+import {
+  TorrentDetailsFileColumn,
+  TorrentDetailsFileItem,
+  TorrentDetailsPanelData,
+} from "@renderer/app/bittorrent/torrentclient";
+import { loadSortingState, SortingOptions } from "@renderer/app/directives/sorting/sorting.controller";
+
+type TorrentDetailsFiles = TorrentDetailsPanelData["files"];
+
+interface TorrentDetailsFileRow {
+  key: string;
+  depth: number;
+  isDirectory: boolean;
+  file?: TorrentDetailsFileItem;
+  filesInSubtree: TorrentDetailsFileItem[];
+  data: TorrentDetailsFileItem;
+}
+
+interface TorrentDetailsFileNode {
+  name: string;
+  path: string;
+  children: Map<string, TorrentDetailsFileNode>;
+  file?: TorrentDetailsFileItem;
+  filesInSubtree: TorrentDetailsFileItem[];
+  data: TorrentDetailsFileItem;
+}
+
+interface UpdateSelectionLocals {
+  files: TorrentDetailsFileItem[];
+  wanted: boolean;
+}
+
+export interface TorrentDetailsFilesTabScope extends IScope {
+  files: TorrentDetailsFiles;
+  resizeMode: string;
+  resizeProfile: string;
+  canSelectFiles: boolean;
+  updateSelection: (locals: UpdateSelectionLocals) => Promise<void>;
+  sortedFiles: TorrentDetailsFileRow[];
+  selectionUpdating: boolean;
+  selectionError: string | null;
+}
+
+export class TorrentDetailsFilesTabController {
+  static $inject = ["$scope", "$filter", "$window"];
+
+  private readonly sortingOptions: SortingOptions = {
+    defaultSortKey: "name",
+    defaultSortOrder: false,
+    sortKeyPrefix: "torrent-details-files.sort-key",
+    sortOrderPrefix: "torrent-details-files.sort-desc",
+  };
+  private fileSortKey = "name";
+  private fileSortDescending = false;
+  private readonly collapsedFolders = new Set<string>();
+
+  constructor(
+    public scope: TorrentDetailsFilesTabScope,
+    private $filter: IFilterService,
+    private $window: IWindowService,
+  ) {
+    this.scope.sortedFiles = [];
+    this.scope.selectionUpdating = false;
+    this.scope.selectionError = null;
+    this.scope.$watch(
+      () => this.scope.files,
+      (files) => {
+        files?.items.forEach((file) => {
+          file.wanted = file.wanted !== false;
+        });
+        this.scope.selectionError = null;
+        this.loadSortingSettings();
+        this.sortFiles();
+      },
+    );
+  }
+
+  changeSorting = (columnId: string, descending: boolean) => {
+    this.fileSortKey = columnId;
+    this.fileSortDescending = descending;
+    this.sortFiles();
+  };
+
+  isFolderExpanded(row: TorrentDetailsFileRow) {
+    return row.isDirectory && !this.collapsedFolders.has(row.data.path);
+  }
+
+  toggleFolder(row: TorrentDetailsFileRow, event?: Event) {
+    event?.stopPropagation();
+    if (!row.isDirectory) {
+      return;
+    }
+
+    if (this.collapsedFolders.has(row.data.path)) {
+      this.collapsedFolders.delete(row.data.path);
+    } else {
+      this.collapsedFolders.add(row.data.path);
+    }
+    this.sortFiles();
+  }
+
+  rowWanted(row: TorrentDetailsFileRow) {
+    return row.filesInSubtree.length > 0 && row.filesInSubtree.every((file) => file.wanted !== false);
+  }
+
+  rowSelectionIndeterminate(row: TorrentDetailsFileRow) {
+    const wanted = row.filesInSubtree.filter((file) => file.wanted !== false).length;
+    return wanted > 0 && wanted < row.filesInSubtree.length;
+  }
+
+  allFilesWanted() {
+    const files = this.scope.files.items;
+    return files.length > 0 && files.every((file) => file.wanted !== false);
+  }
+
+  allFilesSelectionIndeterminate() {
+    const files = this.scope.files.items;
+    const wanted = files.filter((file) => file.wanted !== false).length;
+    return wanted > 0 && wanted < files.length;
+  }
+
+  toggleAllFiles(event: Event) {
+    event.stopPropagation();
+    return this.updateFileSelection(this.scope.files.items, !this.allFilesWanted());
+  }
+
+  toggleRowSelection(row: TorrentDetailsFileRow, event: Event) {
+    event.stopPropagation();
+    return this.updateFileSelection(row.filesInSubtree, !this.rowWanted(row));
+  }
+
+  formatFileCell(column: TorrentDetailsFileColumn, file: TorrentDetailsFileItem) {
+    const value = file[column.id];
+
+    switch (column.format) {
+      case "bytes":
+        return this.applyFilter("bytes", value);
+      case "percent":
+        return this.formatPercent(typeof value === "number" ? value : Number(value));
+      case "number":
+        return value == null ? "" : String(value);
+      case "text":
+      default:
+        return value == null ? "" : String(value);
+    }
+  }
+
+  fileProgressPercent(file: TorrentDetailsFileItem) {
+    const progress = typeof file.progress === "number" ? file.progress : Number(file.progress);
+    if (!Number.isFinite(progress) || progress < 0) {
+      return 0;
+    }
+
+    return Math.max(0, Math.min(100, progress * 100));
+  }
+
+  private sortFiles() {
+    const columns = this.scope.files?.columns || [];
+    const column = columns.find((entry) => entry.id === this.fileSortKey) || columns[0];
+    const sortKey = column?.id || "name";
+    const sortType = column?.sortType || (sortKey === "name" || sortKey === "path" ? "alphabetical" : "numeric");
+    const root = this.buildFileTree(this.scope.files?.items || []);
+    const rows: TorrentDetailsFileRow[] = [];
+
+    const compareNodes = (left: TorrentDetailsFileNode, right: TorrentDetailsFileNode) => {
+      const leftIsDirectory = left.children.size > 0 && !left.file;
+      const rightIsDirectory = right.children.size > 0 && !right.file;
+      if (leftIsDirectory !== rightIsDirectory) {
+        return leftIsDirectory ? -1 : 1;
+      }
+
+      const leftValue = left.data[sortKey];
+      const rightValue = right.data[sortKey];
+      const compared = sortType === "alphabetical"
+        ? String(leftValue ?? "").toLowerCase().localeCompare(String(rightValue ?? "").toLowerCase())
+        : Number(leftValue ?? 0) - Number(rightValue ?? 0);
+      const ordered = this.fileSortDescending ? -compared : compared;
+      return ordered || left.name.localeCompare(right.name);
+    };
+
+    const visit = (node: TorrentDetailsFileNode, depth: number, visible: boolean) => {
+      const isDirectory = node.children.size > 0 && !node.file;
+      if (visible) {
+        rows.push({
+          key: isDirectory ? `folder:${node.path}` : `file:${node.file?.index}`,
+          depth,
+          isDirectory,
+          file: node.file,
+          filesInSubtree: node.filesInSubtree,
+          data: node.data,
+        });
+      }
+
+      const childrenVisible = visible && (!isDirectory || !this.collapsedFolders.has(node.path));
+      Array.from(node.children.values()).sort(compareNodes).forEach((child) => visit(child, depth + 1, childrenVisible));
+    };
+
+    Array.from(root.children.values()).sort(compareNodes).forEach((node) => visit(node, 0, true));
+    this.scope.sortedFiles = rows;
+  }
+
+  private buildFileTree(files: TorrentDetailsFileItem[]) {
+    const emptyData = (name = "", path = ""): TorrentDetailsFileItem => ({
+      index: -1,
+      name,
+      path,
+      size: 0,
+      progress: 0,
+      wanted: false,
+    });
+    const root: TorrentDetailsFileNode = {
+      name: "",
+      path: "",
+      children: new Map(),
+      filesInSubtree: [],
+      data: emptyData(),
+    };
+
+    files.forEach((file) => {
+      const normalizedPath = (file.path || file.name || "").replace(/\\/g, "/");
+      const parts = normalizedPath.split("/").filter(Boolean);
+      if (!parts.length) {
+        return;
+      }
+
+      let node = root;
+      let currentPath = "";
+      parts.forEach((part, index) => {
+        currentPath = currentPath ? `${currentPath}/${part}` : part;
+        let child = node.children.get(part);
+        if (!child) {
+          child = {
+            name: part,
+            path: currentPath,
+            children: new Map(),
+            filesInSubtree: [],
+            data: emptyData(part, currentPath),
+          };
+          node.children.set(part, child);
+        }
+        if (index === parts.length - 1) {
+          child.file = file;
+          child.data = file;
+        }
+        node = child;
+      });
+    });
+
+    const aggregate = (node: TorrentDetailsFileNode): TorrentDetailsFileItem[] => {
+      if (node.file) {
+        node.filesInSubtree = [node.file];
+        return node.filesInSubtree;
+      }
+
+      node.filesInSubtree = Array.from(node.children.values()).flatMap(aggregate);
+      const totalSize = node.filesInSubtree.reduce((sum, file) => sum + (Number(file.size) || 0), 0);
+      const weightedValue = (key: "progress" | "availability") => {
+        const values = node.filesInSubtree.filter((file) => Number.isFinite(Number(file[key])));
+        if (!values.length) {
+          return undefined;
+        }
+        if (totalSize > 0) {
+          return values.reduce((sum, file) => sum + Number(file[key]) * (Number(file.size) || 0), 0) / totalSize;
+        }
+        return values.reduce((sum, file) => sum + Number(file[key]), 0) / values.length;
+      };
+      const priorities = new Set(node.filesInSubtree.map((file) => file.priority).filter((value) => value != null));
+      node.data = {
+        ...node.data,
+        size: totalSize,
+        progress: weightedValue("progress") || 0,
+        availability: weightedValue("availability"),
+        wanted: node.filesInSubtree.every((file) => file.wanted !== false),
+        priority: priorities.size === 1 ? priorities.values().next().value : undefined,
+      };
+      return node.filesInSubtree;
+    };
+
+    aggregate(root);
+    return root;
+  }
+
+  private async updateFileSelection(files: TorrentDetailsFileItem[], wanted: boolean) {
+    if (!this.scope.canSelectFiles || this.scope.selectionUpdating || !files.length) {
+      return;
+    }
+
+    const previous = files.map((file) => ({ file, wanted: file.wanted }));
+    files.forEach((file) => { file.wanted = wanted; });
+    this.scope.selectionUpdating = true;
+    this.scope.selectionError = null;
+    this.sortFiles();
+
+    try {
+      await this.scope.updateSelection({ files, wanted });
+    } catch (err) {
+      previous.forEach((entry) => { entry.file.wanted = entry.wanted; });
+      this.scope.selectionError = err && err.message ? err.message : "Failed to update file selection";
+      this.sortFiles();
+    } finally {
+      this.scope.selectionUpdating = false;
+      this.scope.$evalAsync();
+    }
+  }
+
+  private loadSortingSettings() {
+    const columns = this.scope.files?.columns || [];
+    const defaultColumn = columns[0]?.id || "name";
+    const { sortKey, sortOrder } = loadSortingState(this.$window, this.scope.resizeProfile, this.sortingOptions);
+
+    this.fileSortKey = columns.some((column) => column.id === sortKey)
+      ? sortKey
+      : defaultColumn;
+    this.fileSortDescending = sortOrder;
+  }
+
+  private formatPercent(value: unknown) {
+    const numeric = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(numeric) || numeric < 0) {
+      return "";
+    }
+
+    return `${(numeric * 100).toFixed(1)}%`;
+  }
+
+  private applyFilter(name: string, ...args: any[]) {
+    const filter = this.$filter(name) as (...filterArgs: any[]) => string;
+    return typeof filter === "function" ? filter(...args) : "";
+  }
+}

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.directive.ts
@@ -1,0 +1,21 @@
+import { IDirective, IDirectiveFactory } from "angular";
+import { TorrentDetailsFilesTabController } from "./torrent-details-files-tab.controller";
+import html from "./torrent-details-files-tab.template.html";
+
+export class TorrentDetailsFilesTabDirective implements IDirective {
+  template = html;
+  restrict = "E";
+  scope = {
+    files: "<",
+    resizeMode: "<",
+    resizeProfile: "<",
+    canSelectFiles: "<",
+    updateSelection: "&",
+  };
+  controller = TorrentDetailsFilesTabController;
+  controllerAs = "ctl";
+
+  static getInstance(): IDirectiveFactory {
+    return () => new TorrentDetailsFilesTabDirective();
+  }
+}

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
@@ -1,0 +1,108 @@
+<div class="torrent-details-files" data-role="torrent-details-files">
+  <div class="torrent-details-files-content">
+    <div class="ui tiny negative message torrent-details-files-error" ng-if="ctl.scope.selectionError">
+      {{ ctl.scope.selectionError }}
+    </div>
+    <table
+      id="torrentDetailsFilesTable"
+      data-role="torrent-details-files-table"
+      rz-table
+      rz-profile="ctl.scope.resizeProfile"
+      rz-mode="ctl.scope.resizeMode"
+      rz-container=".torrent-details-files-content"
+      columns="ctl.scope.files.columns"
+      class="ui compact single line unstackable fixed torrent resize table"
+    >
+      <thead>
+        <tr
+          sorting="ctl.changeSorting"
+          mode="ctl.scope.resizeProfile"
+          default-sort-key="name"
+          default-sort-order="false"
+          sort-key-prefix="torrent-details-files.sort-key"
+          sort-order-prefix="torrent-details-files.sort-desc"
+        >
+          <th
+            ng-repeat="column in ctl.scope.files.columns track by column.id"
+            rz-col="column.id"
+            sort="column.id"
+            sort-disabled="column.sortable === false"
+            ng-class="{ 'torrent-details-file-selection-column': column.id === 'wanted' }"
+          >
+            <div ng-if="column.id === 'wanted'" class="ui checkbox torrent-details-file-checkbox">
+              <input
+                type="checkbox"
+                aria-label="Select all files"
+                data-role="torrent-details-files-select-all"
+                ng-checked="ctl.allFilesWanted()"
+                indeterminate-value="ctl.allFilesSelectionIndeterminate()"
+                ng-disabled="!ctl.scope.canSelectFiles || ctl.scope.selectionUpdating"
+                ng-click="ctl.toggleAllFiles($event)"
+              />
+              <label></label>
+            </div>
+            <span ng-if="column.id !== 'wanted'" class="torrent-details-files-header-label">{{ column.label }}</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          ng-repeat="row in ctl.scope.sortedFiles track by row.key"
+          ng-class="{ 'torrent-details-folder-row': row.isDirectory }"
+          data-file-index="{{ row.file.index }}"
+          data-file-path="{{ row.data.path }}"
+        >
+          <td ng-repeat="column in ctl.scope.files.columns track by column.id" data-col="{{ column.id }}">
+            <div ng-if="column.id === 'wanted'" class="torrent-details-file-cell">
+              <div class="ui checkbox torrent-details-file-checkbox">
+                <input
+                  type="checkbox"
+                  aria-label="{{ row.isDirectory ? 'Select folder ' : 'Select file ' }}{{ row.data.name }}"
+                  data-role="torrent-details-file-checkbox"
+                  ng-checked="ctl.rowWanted(row)"
+                  indeterminate-value="ctl.rowSelectionIndeterminate(row)"
+                  ng-disabled="!ctl.scope.canSelectFiles || ctl.scope.selectionUpdating"
+                  ng-click="ctl.toggleRowSelection(row, $event)"
+                />
+                <label></label>
+              </div>
+            </div>
+            <div ng-if="column.id !== 'wanted'" ng-switch="column.format" class="torrent-details-file-cell">
+              <div ng-switch-when="progress" class="torrent-details-file-progress">
+                <div class="ui tiny indicating progress">
+                  <div class="bar" ng-style="{ width: ctl.fileProgressPercent(row.data) + '%' }"></div>
+                </div>
+                <span>{{ ctl.fileProgressPercent(row.data) | number:1 }}%</span>
+              </div>
+              <div
+                ng-switch-default
+                ng-if="column.id === 'name'"
+                class="torrent-details-file-name"
+                ng-style="{ 'padding-left': (row.depth * 18) + 'px' }"
+                title="{{ row.data.path }}"
+                ng-click="row.isDirectory && ctl.toggleFolder(row, $event)"
+              >
+                <button
+                  ng-if="row.isDirectory"
+                  type="button"
+                  class="ui icon basic button torrent-details-folder-toggle"
+                  aria-label="{{ ctl.isFolderExpanded(row) ? 'Collapse' : 'Expand' }} {{ row.data.name }}"
+                  aria-expanded="{{ ctl.isFolderExpanded(row) }}"
+                  ng-click="ctl.toggleFolder(row, $event)"
+                >
+                  <i class="icon" ng-class="ctl.isFolderExpanded(row) ? 'caret down' : 'caret right'"></i>
+                </button>
+                <i ng-if="!row.isDirectory" class="file outline icon torrent-details-file-icon"></i>
+                <span>{{ row.data.name }}</span>
+              </div>
+              <span ng-switch-default ng-if="column.id !== 'name'">{{ ctl.formatFileCell(column, row.data) }}</span>
+            </div>
+          </td>
+        </tr>
+        <tr ng-if="!ctl.scope.sortedFiles.length">
+          <td colspan="{{ ctl.scope.files.columns.length || 1 }}">No files available.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.controller.ts
@@ -1,0 +1,58 @@
+import { IFilterService, IScope } from "angular";
+import { TorrentDetailsInfoField, TorrentDetailsInfoSection } from "@renderer/app/bittorrent/torrentclient";
+
+export interface TorrentDetailsInfoTabScope extends IScope {
+  sections: TorrentDetailsInfoSection[];
+}
+
+export class TorrentDetailsInfoTabController {
+  static $inject = ["$scope", "$filter"];
+
+  constructor(
+    public scope: TorrentDetailsInfoTabScope,
+    private $filter: IFilterService,
+  ) {}
+
+  formatFieldValue(field: TorrentDetailsInfoField) {
+    switch (field.format) {
+      case "bytes":
+        return this.applyFilter("bytes", field.value);
+      case "speed":
+        return this.applyFilter("speed", field.value);
+      case "speedLimit":
+        return this.applyFilter("speedLimit", field.value);
+      case "ratio": {
+        const value = Number(field.value);
+        return Number.isFinite(value) ? value.toFixed(2) : "";
+      }
+      case "eta":
+        return this.applyFilter("eta", field.value);
+      case "epoch":
+        return this.applyFilter("epoch", field.value);
+      case "boolean":
+        return field.value ? "Yes" : "No";
+      case "number":
+        return String(field.value);
+      case "percent":
+        return this.formatPercent(field.value);
+      case "path":
+      case "text":
+      default:
+        return field.value == null ? "" : String(field.value);
+    }
+  }
+
+  private formatPercent(value: unknown) {
+    const numeric = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(numeric) || numeric < 0) {
+      return "";
+    }
+
+    return `${(numeric * 100).toFixed(1)}%`;
+  }
+
+  private applyFilter(name: string, ...args: any[]) {
+    const filter = this.$filter(name) as (...filterArgs: any[]) => string;
+    return typeof filter === "function" ? filter(...args) : "";
+  }
+}

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.directive.ts
@@ -1,0 +1,17 @@
+import { IDirective, IDirectiveFactory } from "angular";
+import { TorrentDetailsInfoTabController } from "./torrent-details-info-tab.controller";
+import html from "./torrent-details-info-tab.template.html";
+
+export class TorrentDetailsInfoTabDirective implements IDirective {
+  template = html;
+  restrict = "E";
+  scope = {
+    sections: "<",
+  };
+  controller = TorrentDetailsInfoTabController;
+  controllerAs = "ctl";
+
+  static getInstance(): IDirectiveFactory {
+    return () => new TorrentDetailsInfoTabDirective();
+  }
+}

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
@@ -1,0 +1,17 @@
+<div class="torrent-details-info" data-role="torrent-details-info">
+  <div class="torrent-details-section" ng-repeat="section in ctl.scope.sections track by section.id">
+    <div class="ui tiny header">{{ section.title }}</div>
+    <table class="ui very basic compact table">
+      <tbody>
+        <tr
+          ng-repeat="field in section.fields track by field.id"
+          data-role="torrent-details-field"
+          data-field-id="{{ field.id }}"
+        >
+          <td class="label">{{ field.label }}</td>
+          <td class="value" ng-class="{ multiline: field.multiline }">{{ ctl.formatFieldValue(field) }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -1,11 +1,5 @@
-import { IDocumentService, IFilterService, IScope, IWindowService } from "angular";
-import {
-  TorrentDetailsFileColumn,
-  TorrentDetailsFileItem,
-  TorrentDetailsInfoField,
-  TorrentDetailsPanelData,
-} from "@renderer/app/bittorrent/torrentclient";
-import { loadSortingState, SortingOptions } from "@renderer/app/directives/sorting/sorting.controller";
+import { IDocumentService, IScope, IWindowService } from "angular";
+import { TorrentDetailsFileItem, TorrentDetailsPanelData } from "@renderer/app/bittorrent/torrentclient";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 
 export interface TorrentDetailsPanelScope extends IScope {
@@ -16,53 +10,22 @@ export interface TorrentDetailsPanelScope extends IScope {
   torrent: any;
   panel: TorrentDetailsPanelData;
   activeTab: "info" | "files";
-  sortedFiles: TorrentDetailsFileRow[];
-  selectionUpdating: boolean;
-  selectionError: string | null;
   resizeMode: string;
   resizeProfile: string;
 }
 
-interface TorrentDetailsFileRow {
-  key: string;
-  depth: number;
-  isDirectory: boolean;
-  file?: TorrentDetailsFileItem;
-  filesInSubtree: TorrentDetailsFileItem[];
-  data: TorrentDetailsFileItem;
-}
-
-interface TorrentDetailsFileNode {
-  name: string;
-  path: string;
-  children: Map<string, TorrentDetailsFileNode>;
-  file?: TorrentDetailsFileItem;
-  filesInSubtree: TorrentDetailsFileItem[];
-  data: TorrentDetailsFileItem;
-}
-
 export class TorrentDetailsPanelController {
-  static $inject = ["$scope", "$rootScope", "$filter", "$window", "$document"];
+  static $inject = ["$scope", "$rootScope", "$window", "$document"];
 
   private readonly defaultPanelHeight = 320;
   private readonly minPanelHeight = 220;
-  private readonly sortingOptions: SortingOptions = {
-    defaultSortKey: "name",
-    defaultSortOrder: false,
-    sortKeyPrefix: "torrent-details-files.sort-key",
-    sortOrderPrefix: "torrent-details-files.sort-desc",
-  };
-  private fileSortKey = "name";
-  private fileSortDescending = false;
   private panelHeight = this.defaultPanelHeight;
   private loadRequestId = 0;
   private stopResizeListeners?: () => void;
-  private readonly collapsedFolders = new Set<string>();
 
   constructor(
     public scope: TorrentDetailsPanelScope,
     private rootScope: ElectorrentRootScope,
-    private $filter: IFilterService,
     private $window: IWindowService,
     private $document: IDocumentService,
   ) {
@@ -71,9 +34,6 @@ export class TorrentDetailsPanelController {
     this.scope.error = null;
     this.scope.torrent = null;
     this.scope.activeTab = "info";
-    this.scope.sortedFiles = [];
-    this.scope.selectionUpdating = false;
-    this.scope.selectionError = null;
     this.scope.resizeMode = "OverflowResizer";
     this.scope.resizeProfile = this.getResizeProfile();
     this.scope.panel = {
@@ -161,10 +121,20 @@ export class TorrentDetailsPanelController {
     };
   }
 
-  private getResizeProfile() {
-    const serverId = this.rootScope.$server?.id || this.rootScope.$btclient?.id || "default";
-    return `torrent-details-files.${serverId}`;
+  canSelectFiles() {
+    return !!this.rootScope.$btclient?.features.fileSelection;
   }
+
+  updateFileSelection = async (files: TorrentDetailsFileItem[], wanted: boolean) => {
+    const client = this.rootScope.$btclient;
+    const torrent = this.scope.torrent;
+    if (!this.canSelectFiles() || !client || !torrent || !files.length) {
+      return;
+    }
+
+    await client.setTorrentFileSelection(torrent, files.map((file) => ({ ...file, wanted })));
+    this.scheduleDetailsFilesUpdate(torrent);
+  };
 
   startResizing(event: MouseEvent) {
     event.preventDefault();
@@ -197,130 +167,9 @@ export class TorrentDetailsPanelController {
     this.stopResizeListeners = onMouseUp;
   }
 
-  changeSorting = (columnId: string, descending: boolean) => {
-    this.fileSortKey = columnId;
-    this.fileSortDescending = descending;
-    this.sortFiles();
-  };
-
-  canSelectFiles() {
-    return !!this.rootScope.$btclient?.features.fileSelection;
-  }
-
-  isFolderExpanded(row: TorrentDetailsFileRow) {
-    return row.isDirectory && !this.collapsedFolders.has(row.data.path);
-  }
-
-  toggleFolder(row: TorrentDetailsFileRow, event?: Event) {
-    event?.stopPropagation();
-    if (!row.isDirectory) {
-      return;
-    }
-
-    if (this.collapsedFolders.has(row.data.path)) {
-      this.collapsedFolders.delete(row.data.path);
-    } else {
-      this.collapsedFolders.add(row.data.path);
-    }
-    this.sortFiles();
-  }
-
-  rowWanted(row: TorrentDetailsFileRow) {
-    return row.filesInSubtree.length > 0 && row.filesInSubtree.every((file) => file.wanted !== false);
-  }
-
-  rowSelectionIndeterminate(row: TorrentDetailsFileRow) {
-    const wanted = row.filesInSubtree.filter((file) => file.wanted !== false).length;
-    return wanted > 0 && wanted < row.filesInSubtree.length;
-  }
-
-  allFilesWanted() {
-    const files = this.scope.panel.files.items;
-    return files.length > 0 && files.every((file) => file.wanted !== false);
-  }
-
-  allFilesSelectionIndeterminate() {
-    const files = this.scope.panel.files.items;
-    const wanted = files.filter((file) => file.wanted !== false).length;
-    return wanted > 0 && wanted < files.length;
-  }
-
-  toggleAllFiles(event: Event) {
-    event.stopPropagation();
-    return this.updateFileSelection(this.scope.panel.files.items, !this.allFilesWanted());
-  }
-
-  toggleRowSelection(row: TorrentDetailsFileRow, event: Event) {
-    event.stopPropagation();
-    return this.updateFileSelection(row.filesInSubtree, !this.rowWanted(row));
-  }
-
-  formatFieldValue(field: TorrentDetailsInfoField) {
-    switch (field.format) {
-      case "bytes":
-        return this.applyFilter("bytes", field.value);
-      case "speed":
-        return this.applyFilter("speed", field.value);
-      case "speedLimit":
-        return this.applyFilter("speedLimit", field.value);
-      case "ratio": {
-        const value = Number(field.value);
-        return Number.isFinite(value) ? value.toFixed(2) : "";
-      }
-      case "eta":
-        return this.applyFilter("eta", field.value);
-      case "epoch":
-        return this.applyFilter("epoch", field.value);
-      case "boolean":
-        return field.value ? "Yes" : "No";
-      case "number":
-        return String(field.value);
-      case "percent":
-        return this.formatPercent(field.value);
-      case "path":
-      case "text":
-      default:
-        return field.value == null ? "" : String(field.value);
-    }
-  }
-
-  formatFileCell(column: TorrentDetailsFileColumn, file: TorrentDetailsFileItem) {
-    const value = file[column.id];
-
-    switch (column.format) {
-      case "bytes":
-        return this.applyFilter("bytes", value);
-      case "percent":
-        return this.formatPercent(typeof value === "number" ? value : Number(value));
-      case "number":
-        return value == null ? "" : String(value);
-      case "text":
-      default:
-        return value == null ? "" : String(value);
-    }
-  }
-
-  fileProgressPercent(file: TorrentDetailsFileItem) {
-    const progress = typeof file.progress === "number" ? file.progress : Number(file.progress);
-    if (!Number.isFinite(progress) || progress < 0) {
-      return 0;
-    }
-
-    return Math.max(0, Math.min(100, progress * 100));
-  }
-
-  private formatPercent(value: unknown) {
-    const numeric = typeof value === "number" ? value : Number(value);
-    if (!Number.isFinite(numeric) || numeric < 0) {
-      return "";
-    }
-
-    return `${(numeric * 100).toFixed(1)}%`;
-  }
-
-  private applyFilter(name: string, ...args: any[]) {
-    const filter = this.$filter(name) as (...filterArgs: any[]) => string;
-    return typeof filter === "function" ? filter(...args) : "";
+  private getResizeProfile() {
+    const serverId = this.rootScope.$server?.id || this.rootScope.$btclient?.id || "default";
+    return `torrent-details-files.${serverId}`;
   }
 
   private async loadDetails(torrent: any) {
@@ -338,12 +187,6 @@ export class TorrentDetailsPanelController {
       }
 
       this.scope.panel = panel || this.scope.panel;
-      this.scope.panel.files.items.forEach((file) => {
-        file.wanted = file.wanted !== false;
-      });
-      this.scope.selectionError = null;
-      this.loadSortingSettings();
-      this.sortFiles();
     } catch (err) {
       if (requestId !== this.loadRequestId) {
         return;
@@ -355,157 +198,6 @@ export class TorrentDetailsPanelController {
         this.scope.loading = false;
         this.scope.$evalAsync();
       }
-    }
-  }
-
-  private sortFiles() {
-    const columns = this.scope.panel?.files?.columns || [];
-    const column = columns.find((entry) => entry.id === this.fileSortKey) || columns[0];
-    const sortKey = column?.id || "name";
-    const sortType = column?.sortType || (sortKey === "name" || sortKey === "path" ? "alphabetical" : "numeric");
-    const root = this.buildFileTree(this.scope.panel?.files?.items || []);
-    const rows: TorrentDetailsFileRow[] = [];
-
-    const compareNodes = (left: TorrentDetailsFileNode, right: TorrentDetailsFileNode) => {
-      const leftIsDirectory = left.children.size > 0 && !left.file;
-      const rightIsDirectory = right.children.size > 0 && !right.file;
-      if (leftIsDirectory !== rightIsDirectory) {
-        return leftIsDirectory ? -1 : 1;
-      }
-
-      const leftValue = left.data[sortKey];
-      const rightValue = right.data[sortKey];
-      const compared = sortType === "alphabetical"
-        ? String(leftValue ?? "").toLowerCase().localeCompare(String(rightValue ?? "").toLowerCase())
-        : Number(leftValue ?? 0) - Number(rightValue ?? 0);
-      const ordered = this.fileSortDescending ? -compared : compared;
-      return ordered || left.name.localeCompare(right.name);
-    };
-
-    const visit = (node: TorrentDetailsFileNode, depth: number, visible: boolean) => {
-      const isDirectory = node.children.size > 0 && !node.file;
-      if (visible) {
-        rows.push({
-          key: isDirectory ? `folder:${node.path}` : `file:${node.file?.index}`,
-          depth,
-          isDirectory,
-          file: node.file,
-          filesInSubtree: node.filesInSubtree,
-          data: node.data,
-        });
-      }
-
-      const childrenVisible = visible && (!isDirectory || !this.collapsedFolders.has(node.path));
-      Array.from(node.children.values()).sort(compareNodes).forEach((child) => visit(child, depth + 1, childrenVisible));
-    };
-
-    Array.from(root.children.values()).sort(compareNodes).forEach((node) => visit(node, 0, true));
-    this.scope.sortedFiles = rows;
-  }
-
-  private buildFileTree(files: TorrentDetailsFileItem[]) {
-    const emptyData = (name = "", path = ""): TorrentDetailsFileItem => ({
-      index: -1,
-      name,
-      path,
-      size: 0,
-      progress: 0,
-      wanted: false,
-    });
-    const root: TorrentDetailsFileNode = {
-      name: "",
-      path: "",
-      children: new Map(),
-      filesInSubtree: [],
-      data: emptyData(),
-    };
-
-    files.forEach((file) => {
-      const normalizedPath = (file.path || file.name || "").replace(/\\/g, "/");
-      const parts = normalizedPath.split("/").filter(Boolean);
-      if (!parts.length) {
-        return;
-      }
-
-      let node = root;
-      let currentPath = "";
-      parts.forEach((part, index) => {
-        currentPath = currentPath ? `${currentPath}/${part}` : part;
-        let child = node.children.get(part);
-        if (!child) {
-          child = {
-            name: part,
-            path: currentPath,
-            children: new Map(),
-            filesInSubtree: [],
-            data: emptyData(part, currentPath),
-          };
-          node.children.set(part, child);
-        }
-        if (index === parts.length - 1) {
-          child.file = file;
-          child.data = file;
-        }
-        node = child;
-      });
-    });
-
-    const aggregate = (node: TorrentDetailsFileNode): TorrentDetailsFileItem[] => {
-      if (node.file) {
-        node.filesInSubtree = [node.file];
-        return node.filesInSubtree;
-      }
-
-      node.filesInSubtree = Array.from(node.children.values()).flatMap(aggregate);
-      const totalSize = node.filesInSubtree.reduce((sum, file) => sum + (Number(file.size) || 0), 0);
-      const weightedValue = (key: "progress" | "availability") => {
-        const values = node.filesInSubtree.filter((file) => Number.isFinite(Number(file[key])));
-        if (!values.length) {
-          return undefined;
-        }
-        if (totalSize > 0) {
-          return values.reduce((sum, file) => sum + Number(file[key]) * (Number(file.size) || 0), 0) / totalSize;
-        }
-        return values.reduce((sum, file) => sum + Number(file[key]), 0) / values.length;
-      };
-      const priorities = new Set(node.filesInSubtree.map((file) => file.priority).filter((value) => value != null));
-      node.data = {
-        ...node.data,
-        size: totalSize,
-        progress: weightedValue("progress") || 0,
-        availability: weightedValue("availability"),
-        wanted: node.filesInSubtree.every((file) => file.wanted !== false),
-        priority: priorities.size === 1 ? priorities.values().next().value : undefined,
-      };
-      return node.filesInSubtree;
-    };
-
-    aggregate(root);
-    return root;
-  }
-
-  private async updateFileSelection(files: TorrentDetailsFileItem[], wanted: boolean) {
-    const client = this.rootScope.$btclient;
-    if (!this.canSelectFiles() || !client || !this.scope.torrent || this.scope.selectionUpdating || !files.length) {
-      return;
-    }
-
-    const previous = files.map((file) => ({ file, wanted: file.wanted }));
-    files.forEach((file) => { file.wanted = wanted; });
-    this.scope.selectionUpdating = true;
-    this.scope.selectionError = null;
-    this.sortFiles();
-
-    try {
-      await client.setTorrentFileSelection(this.scope.torrent, files);
-      this.scheduleDetailsFilesUpdate(this.scope.torrent);
-    } catch (err) {
-      previous.forEach((entry) => { entry.file.wanted = entry.wanted; });
-      this.scope.selectionError = err && err.message ? err.message : "Failed to update file selection";
-      this.sortFiles();
-    } finally {
-      this.scope.selectionUpdating = false;
-      this.scope.$evalAsync();
     }
   }
 
@@ -522,17 +214,6 @@ export class TorrentDetailsPanelController {
     this.scope.resizeProfile = this.getResizeProfile();
   }
 
-  private loadSortingSettings() {
-    const columns = this.scope.panel?.files?.columns || [];
-    const defaultColumn = columns[0]?.id || "name";
-    const { sortKey, sortOrder } = loadSortingState(this.$window, this.scope.resizeProfile, this.sortingOptions);
-
-    this.fileSortKey = columns.some((column) => column.id === sortKey)
-      ? sortKey
-      : defaultColumn;
-    this.fileSortDescending = sortOrder;
-  }
-
   private clearSelection() {
     this.loadRequestId += 1;
     this.resetPanelState();
@@ -541,14 +222,10 @@ export class TorrentDetailsPanelController {
   private resetPanelState() {
     this.scope.loading = false;
     this.scope.error = null;
-    this.scope.selectionError = null;
-    this.scope.selectionUpdating = false;
     this.scope.torrent = null;
     this.scope.panel = {
       info: { sections: [] },
       files: { columns: [], items: [] },
     };
-    this.scope.sortedFiles = [];
-    this.collapsedFolders.clear();
   }
 }

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -41,139 +41,18 @@
       </div>
     </div>
 
-    <div
-      class="torrent-details-info"
-      data-role="torrent-details-info"
+    <torrent-details-info-tab
       ng-if="!ctl.showStateMessage() && ctl.isActiveTab('info')"
-    >
-      <div class="torrent-details-section" ng-repeat="section in ctl.scope.panel.info.sections track by section.id">
-        <div class="ui tiny header">{{ section.title }}</div>
-        <table class="ui very basic compact table">
-          <tbody>
-            <tr
-              ng-repeat="field in section.fields track by field.id"
-              data-role="torrent-details-field"
-              data-field-id="{{ field.id }}"
-            >
-              <td class="label">{{ field.label }}</td>
-              <td class="value" ng-class="{ multiline: field.multiline }">{{ ctl.formatFieldValue(field) }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
+      sections="ctl.scope.panel.info.sections"
+    ></torrent-details-info-tab>
 
-    <div
-      class="torrent-details-files"
-      data-role="torrent-details-files"
+    <torrent-details-files-tab
       ng-if="!ctl.showStateMessage() && ctl.isActiveTab('files')"
-    >
-      <div class="torrent-details-files-content">
-        <div class="ui tiny negative message torrent-details-files-error" ng-if="ctl.scope.selectionError">
-          {{ ctl.scope.selectionError }}
-        </div>
-        <table
-          id="torrentDetailsFilesTable"
-          data-role="torrent-details-files-table"
-          rz-table
-          rz-profile="ctl.scope.resizeProfile"
-          rz-mode="ctl.scope.resizeMode"
-          rz-container=".torrent-details-files-content"
-          columns="ctl.scope.panel.files.columns"
-          class="ui compact single line unstackable fixed torrent resize table"
-        >
-          <thead>
-            <tr
-              sorting="ctl.changeSorting"
-              mode="ctl.scope.resizeProfile"
-              default-sort-key="name"
-              default-sort-order="false"
-              sort-key-prefix="torrent-details-files.sort-key"
-              sort-order-prefix="torrent-details-files.sort-desc"
-            >
-              <th
-                ng-repeat="column in ctl.scope.panel.files.columns track by column.id"
-                rz-col="column.id"
-                sort="column.id"
-                sort-disabled="column.sortable === false"
-                ng-class="{ 'torrent-details-file-selection-column': column.id === 'wanted' }"
-              >
-                <div ng-if="column.id === 'wanted'" class="ui checkbox torrent-details-file-checkbox">
-                  <input
-                    type="checkbox"
-                    aria-label="Select all files"
-                    data-role="torrent-details-files-select-all"
-                    ng-checked="ctl.allFilesWanted()"
-                    indeterminate-value="ctl.allFilesSelectionIndeterminate()"
-                    ng-disabled="!ctl.canSelectFiles() || ctl.scope.selectionUpdating"
-                    ng-click="ctl.toggleAllFiles($event)"
-                  />
-                  <label></label>
-                </div>
-                <span ng-if="column.id !== 'wanted'" class="torrent-details-files-header-label">{{ column.label }}</span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              ng-repeat="row in ctl.scope.sortedFiles track by row.key"
-              ng-class="{ 'torrent-details-folder-row': row.isDirectory }"
-              data-file-index="{{ row.file.index }}"
-              data-file-path="{{ row.data.path }}"
-            >
-              <td ng-repeat="column in ctl.scope.panel.files.columns track by column.id" data-col="{{ column.id }}">
-                <div ng-if="column.id === 'wanted'" class="torrent-details-file-cell">
-                  <div class="ui checkbox torrent-details-file-checkbox">
-                    <input
-                      type="checkbox"
-                      aria-label="{{ row.isDirectory ? 'Select folder ' : 'Select file ' }}{{ row.data.name }}"
-                      data-role="torrent-details-file-checkbox"
-                      ng-checked="ctl.rowWanted(row)"
-                      indeterminate-value="ctl.rowSelectionIndeterminate(row)"
-                      ng-disabled="!ctl.canSelectFiles() || ctl.scope.selectionUpdating"
-                      ng-click="ctl.toggleRowSelection(row, $event)"
-                    />
-                    <label></label>
-                  </div>
-                </div>
-                <div ng-if="column.id !== 'wanted'" ng-switch="column.format" class="torrent-details-file-cell">
-                  <div ng-switch-when="progress" class="torrent-details-file-progress">
-                    <div class="ui tiny indicating progress">
-                      <div class="bar" ng-style="{ width: ctl.fileProgressPercent(row.data) + '%' }"></div>
-                    </div>
-                    <span>{{ ctl.fileProgressPercent(row.data) | number:1 }}%</span>
-                  </div>
-                  <div
-                    ng-switch-default
-                    ng-if="column.id === 'name'"
-                    class="torrent-details-file-name"
-                    ng-style="{ 'padding-left': (row.depth * 18) + 'px' }"
-                    title="{{ row.data.path }}"
-                    ng-click="row.isDirectory && ctl.toggleFolder(row, $event)"
-                  >
-                    <button
-                      ng-if="row.isDirectory"
-                      type="button"
-                      class="ui icon basic button torrent-details-folder-toggle"
-                      aria-label="{{ ctl.isFolderExpanded(row) ? 'Collapse' : 'Expand' }} {{ row.data.name }}"
-                      aria-expanded="{{ ctl.isFolderExpanded(row) }}"
-                      ng-click="ctl.toggleFolder(row, $event)"
-                    >
-                      <i class="icon" ng-class="ctl.isFolderExpanded(row) ? 'caret down' : 'caret right'"></i>
-                    </button>
-                    <i ng-if="!row.isDirectory" class="file outline icon torrent-details-file-icon"></i>
-                    <span>{{ row.data.name }}</span>
-                  </div>
-                  <span ng-switch-default ng-if="column.id !== 'name'">{{ ctl.formatFileCell(column, row.data) }}</span>
-                </div>
-              </td>
-            </tr>
-            <tr ng-if="!ctl.scope.sortedFiles.length">
-              <td colspan="{{ ctl.scope.panel.files.columns.length || 1 }}">No files available.</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
+      files="ctl.scope.panel.files"
+      resize-mode="ctl.scope.resizeMode"
+      resize-profile="ctl.scope.resizeProfile"
+      can-select-files="ctl.canSelectFiles()"
+      update-selection="ctl.updateFileSelection(files, wanted)"
+    ></torrent-details-files-tab>
   </div>
 </div>

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -713,6 +713,13 @@ torrent-sidebar + .main-panel {
             padding: 0;
         }
 
+        torrent-details-info-tab,
+        torrent-details-files-tab {
+            display: flex;
+            flex: 1 1 auto;
+            min-height: 0;
+        }
+
         .torrent-details-state {
             display: flex;
             flex: 1 1 auto;


### PR DESCRIPTION
## What changed

- split the torrent details Info and Files tabs into isolated element directives
- keep panel orchestration, loading, tab selection, and panel resizing in the parent directive
- move Info value formatting into the Info tab
- move file-tree rendering, sorting, formatting, and optimistic selection UI into the Files tab
- expose file-selection capability and persistence through a narrow parent callback

## Why

The panel directive previously owned every tab's rendering and behavior. Separate tab directives provide a clear extension seam and keep tab-specific state and presentation isolated without exposing torrent-client or event-bus concerns to child directives.

## Impact

The existing panel DOM roles and behavior are preserved, including hierarchical file rows, file selection, sorting, and column resizing.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts"`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-file-selection.spec.ts"`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/upload-file-selection.spec.ts"`