### PR TITLE
refactor(settings): centralize defaults

### DIFF
--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -3,41 +3,11 @@ import fs from 'fs'
 import path from 'path'
 
 import type { AppSettings } from '@shared/ipc-contract'
+import { createDefaultSettings, normalizeSettings } from '@shared/settings-defaults'
 import * as electorrent from './electorrent'
 
 let data: any = null
 const changeListeners = new Set<() => void>()
-
-type MainAppSettings = AppSettings & {
-    debugMode?: boolean
-    autoRemoveTorrents?: boolean
-    alwaysPromptUploadOptions?: boolean
-    watchDirectory?: string
-}
-
-const defaultSettings: MainAppSettings = {
-    startup: 'default',
-    systemStartup: 'disabled',
-    refreshRate: 2000,
-    servers: [],
-    certificates: [],
-    automaticUpdates: true,
-    closeToTray: true,
-    debugMode: false,
-    autoRemoveTorrents: false,
-    alwaysPromptUploadOptions: false,
-    watchDirectory: '',
-    ui: {
-        resizeMode: 'OverflowResizer',
-        notifications: true,
-        displaySize: 'normal',
-        displayCompact: false,
-        cleanNames: true,
-        fixedHeader: false,
-        theme: 'system',
-        sidebarCollapsed: false,
-    },
-}
 
 const CONF_PATH = path.join(app.getPath('userData'), 'config.json')
 
@@ -80,19 +50,19 @@ function load() {
     }
 
     if (!fs.existsSync(CONF_PATH)) {
-        data = copy(defaultSettings)
+        data = createDefaultSettings()
         return
     }
 
     const file = fs.readFileSync(CONF_PATH, 'utf-8')
 
     if (!file) {
-        data = copy(defaultSettings)
+        data = createDefaultSettings()
         return
     }
 
     try {
-        data = mergeWithDefaults(defaultSettings, JSON.parse(file))
+        data = normalizeSettings(JSON.parse(file))
     } catch (_e) {
         if (app.isReady()) {
             showCorruptDialog()
@@ -144,32 +114,6 @@ function copyArray(_obj: any[]) {
     return copiedArray
 }
 
-function mergeWithDefaults<T>(defaults: T, value: any): T {
-    if (value === undefined) {
-        return copy(defaults)
-    }
-
-    if (defaults === null || typeof defaults !== 'object') {
-        return copy(value)
-    }
-
-    if (Array.isArray(defaults)) {
-        return (Array.isArray(value) ? copy(value) : copy(defaults)) as T
-    }
-
-    const mergedValue = value && typeof value === 'object' && !Array.isArray(value)
-        ? copyObject(value)
-        : {}
-
-    for (const key in defaults as Record<string, any>) {
-        if (Object.prototype.hasOwnProperty.call(defaults, key)) {
-            mergedValue[key] = mergeWithDefaults((defaults as Record<string, any>)[key], mergedValue[key])
-        }
-    }
-
-    return mergedValue as T
-}
-
 export function put(key: string, value: any, callback?: (err?: Error | null) => void) {
     load()
     data[key] = value
@@ -179,13 +123,13 @@ export function put(key: string, value: any, callback?: (err?: Error | null) => 
     }
 }
 
-export function getAllSettings(): MainAppSettings {
+export function getAllSettings(): AppSettings {
     load()
-    return copy(data)
+    return normalizeSettings(data)
 }
 
-export function getDefaultSettings() {
-    return copy(defaultSettings)
+export function getDefaultSettings(): AppSettings {
+    return createDefaultSettings()
 }
 
 export function write() {
@@ -194,7 +138,7 @@ export function write() {
 
 export function saveAll(settings: any, callback?: (err?: Error | null) => void) {
     load()
-    data = mergeWithDefaults(defaultSettings, settings)
+    data = normalizeSettings(settings)
     notifyChanged()
     if (callback !== undefined) {
         save(callback)

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -1,5 +1,6 @@
 import { IRootScopeService } from "angular";
 import type { AppSettings, StoredServerConfig } from "@shared/ipc-contract";
+import { createDefaultSettings } from "@shared/settings-defaults";
 import type { Server } from "@renderer/app/services/server";
 
 export interface SettingsService {
@@ -27,29 +28,7 @@ export interface SettingsService {
 export let settingsService = ['$rootScope', '$bittorrent', 'notificationService', '$q', 'Server', function($rootScope: IRootScopeService, $bittorrent, $notify, $q, Server) {
     const electorrent = window.electorrent
 
-    var settings: AppSettings<any> = {
-        startup: 'default',
-        systemStartup: 'disabled',
-        refreshRate: 2000,
-        automaticUpdates: true,
-        closeToTray: true,
-        debugMode: false,
-        autoRemoveTorrents: false,
-        alwaysPromptUploadOptions: false,
-        watchDirectory: '',
-        ui: {
-            resizeMode: '',
-            notifications: true,
-            displaySize: 'normal',
-            displayCompact: false,
-            cleanNames: true,
-            fixedHeader: false,
-            theme: 'system',
-            sidebarCollapsed: false,
-        },
-        servers: [],
-        certificates: []
-    };
+    var settings: AppSettings<any> = createDefaultSettings();
 
     function loadServerCertificate(server: any) {
         if (server?.tlsSecurity === "insecure") {

--- a/src/shared/settings-defaults.ts
+++ b/src/shared/settings-defaults.ts
@@ -1,0 +1,76 @@
+import type { AppSettings } from '@shared/ipc-contract'
+
+const DEFAULT_SETTINGS: AppSettings = {
+    startup: 'default',
+    systemStartup: 'disabled',
+    refreshRate: 2000,
+    servers: [],
+    certificates: [],
+    automaticUpdates: true,
+    closeToTray: true,
+    debugMode: false,
+    autoRemoveTorrents: false,
+    alwaysPromptUploadOptions: false,
+    watchDirectory: '',
+    ui: {
+        resizeMode: 'OverflowResizer',
+        notifications: true,
+        displaySize: 'normal',
+        displayCompact: false,
+        cleanNames: true,
+        fixedHeader: false,
+        theme: 'system',
+        sidebarCollapsed: false,
+    },
+}
+
+function clone<T>(value: T): T {
+    if (value === null || typeof value !== 'object') {
+        return value
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((item) => clone(item)) as T
+    }
+
+    const clonedValue: Record<string, unknown> = {}
+    for (const key of Object.keys(value)) {
+        clonedValue[key] = clone((value as Record<string, unknown>)[key])
+    }
+    return clonedValue as T
+}
+
+function mergeWithDefaults<T>(defaults: T, value: unknown): T {
+    if (value === undefined) {
+        return clone(defaults)
+    }
+
+    if (defaults === null || typeof defaults !== 'object') {
+        return clone(value) as T
+    }
+
+    if (Array.isArray(defaults)) {
+        return (Array.isArray(value) ? clone(value) : clone(defaults)) as T
+    }
+
+    const mergedValue: Record<string, unknown> = value !== null && typeof value === 'object' && !Array.isArray(value)
+        ? clone(value as Record<string, unknown>)
+        : {}
+
+    for (const key of Object.keys(defaults)) {
+        mergedValue[key] = mergeWithDefaults(
+            (defaults as Record<string, unknown>)[key],
+            mergedValue[key],
+        )
+    }
+
+    return mergedValue as T
+}
+
+export function createDefaultSettings(): AppSettings {
+    return clone(DEFAULT_SETTINGS)
+}
+
+export function normalizeSettings(value: unknown): AppSettings {
+    return mergeWithDefaults(DEFAULT_SETTINGS, value)
+}


### PR DESCRIPTION
## What changed

- add a shared settings defaults and normalization module
- use one canonical settings definition in the main and renderer processes
- preserve recursive default filling, unknown persisted keys, array replacement, and fresh returned values
- align the renderer default resize mode with the persisted canonical default

## Why

Main and renderer independently encoded the same settings defaults. The copies had already drifted on `ui.resizeMode`, and settings schema changes required coordinated edits across process seams. Centralizing normalization improves locality while keeping persistence and renderer hydration behavior unchanged.

## Impact

Settings continue using the existing persistence format and renderer object identity. Missing nested fields are normalized consistently in both processes, while unknown persisted fields remain intact.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/settings.spec.ts"` — 15 passing
