### PR TITLE
refactor(clients): make registries exhaustive

### DIFF
--- a/src/main/lib/bittorrent/registry.ts
+++ b/src/main/lib/bittorrent/registry.ts
@@ -5,25 +5,23 @@ import { MockBittorrentRuntime } from "@main/lib/bittorrent/clients/mock"
 import { SynologyRuntime } from "@main/lib/bittorrent/clients/synology"
 import { TransmissionRuntime } from "@main/lib/bittorrent/clients/transmission"
 import { UtorrentRuntime } from "@main/lib/bittorrent/clients/utorrent"
+import { isClientId, type ClientId } from "@shared/client-metadata"
 import type { BittorrentRuntime } from "./types"
 
+const runtimeFactories = {
+    qbittorrent: () => new QBittorrentRuntime(),
+    rtorrent: () => new RtorrentRuntime(),
+    deluge: () => new DelugeRuntime(),
+    mock: () => new MockBittorrentRuntime(),
+    transmission: () => new TransmissionRuntime(),
+    utorrent: () => new UtorrentRuntime(),
+    synology: () => new SynologyRuntime(),
+} satisfies Record<ClientId, () => BittorrentRuntime>
+
 export function createRuntime(clientId: string): BittorrentRuntime {
-    switch (clientId) {
-        case "qbittorrent":
-            return new QBittorrentRuntime()
-        case "rtorrent":
-            return new RtorrentRuntime()
-        case "deluge":
-            return new DelugeRuntime()
-        case "mock":
-            return new MockBittorrentRuntime()
-        case "transmission":
-            return new TransmissionRuntime()
-        case "utorrent":
-            return new UtorrentRuntime()
-        case "synology":
-            return new SynologyRuntime()
-        default:
-            throw new Error(`Unsupported bittorrent client: ${clientId}`)
+    if (!isClientId(clientId)) {
+        throw new Error(`Unsupported bittorrent client: ${clientId}`)
     }
+
+    return runtimeFactories[clientId]()
 }

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -12,7 +12,7 @@ import {
     DelugeClient,
     MockBittorrentClient
 } from "@renderer/app/bittorrent"
-import { CLIENT_METADATA } from "@shared/client-metadata"
+import { CLIENT_METADATA, type ClientId } from "@shared/client-metadata"
 
 const torrentApp = angular.module("torrentApp", ["ngResource", "ngAnimate", "rzTable", "infinite-scroll", "hc.marked", "ui.sortable"]);
 
@@ -22,45 +22,34 @@ torrentApp.config(['$animateProvider', function($animateProvider) {
     }
 ]);
 
-const btclients: Record<string, { name: string; service: unknown; icon: string }> = {
-    'utorrent': {
-        name: CLIENT_METADATA.utorrent.name,
-        service: new UtorrentClient(),
-        icon: CLIENT_METADATA.utorrent.icon
-    },
-    'qbittorrent': {
-        name: CLIENT_METADATA.qbittorrent.name,
-        service: new QBittorrentClient(),
-        icon: CLIENT_METADATA.qbittorrent.icon
-    },
-    'transmission': {
-        name: CLIENT_METADATA.transmission.name,
-        service: new TransmissionClient(),
-        icon: CLIENT_METADATA.transmission.icon
-    },
-    'rtorrent': {
-        name: CLIENT_METADATA.rtorrent.name,
-        service: new RtorrentClient(),
-        icon: CLIENT_METADATA.rtorrent.icon
-    },
-    'synology': {
-        name: CLIENT_METADATA.synology.name,
-        service: new SynologyClient(),
-        icon: CLIENT_METADATA.synology.icon
-    },
-    'deluge': {
-        name: CLIENT_METADATA.deluge.name,
-        service: new DelugeClient(),
-        icon: CLIENT_METADATA.deluge.icon,
-    }
-};
+interface ClientRegistration {
+    name: string
+    service: unknown
+    icon: string
+}
 
-if (window.electorrent.app.isTestEnvironment) {
-    btclients.mock = {
-        name: CLIENT_METADATA.mock.name,
-        service: new MockBittorrentClient(),
-        icon: CLIENT_METADATA.mock.icon,
-    };
+const clientFactories = {
+    utorrent: () => new UtorrentClient(),
+    qbittorrent: () => new QBittorrentClient(),
+    transmission: () => new TransmissionClient(),
+    rtorrent: () => new RtorrentClient(),
+    synology: () => new SynologyClient(),
+    deluge: () => new DelugeClient(),
+    mock: () => new MockBittorrentClient(),
+} satisfies Record<ClientId, () => unknown>
+
+const btclients: Record<string, ClientRegistration> = {}
+
+for (const clientId of Object.keys(clientFactories) as ClientId[]) {
+    if (clientId === "mock" && !window.electorrent.app.isTestEnvironment) {
+        continue
+    }
+
+    btclients[clientId] = {
+        name: CLIENT_METADATA[clientId].name,
+        service: clientFactories[clientId](),
+        icon: CLIENT_METADATA[clientId].icon,
+    }
 }
 
 // Register torrent clients

--- a/src/shared/client-metadata.ts
+++ b/src/shared/client-metadata.ts
@@ -43,3 +43,7 @@ export const CLIENT_METADATA = {
 } as const satisfies Record<string, ClientMetadata>
 
 export type ClientId = keyof typeof CLIENT_METADATA
+
+export function isClientId(value: string): value is ClientId {
+    return Object.prototype.hasOwnProperty.call(CLIENT_METADATA, value)
+}


### PR DESCRIPTION
## What changed

- add a shared runtime guard for narrowing persisted client strings to `ClientId`
- replace main-process client dispatch with an exhaustive runtime factory map
- replace renderer registration duplication with an exhaustive adapter factory map
- preserve test-only mock adapter visibility and fresh adapter instances

## Why

Client metadata already defined the canonical client IDs, but the main registry used a string switch and the renderer used an unconstrained string record. Adding or renaming an adapter could therefore compile while one process registry remained incomplete.

Both construction implementations now satisfy `Record<ClientId, ...>`, so metadata changes require corresponding adapters at compile time. Persisted configuration remains runtime-safe: unknown strings still produce the existing unsupported-client error.

## Impact

There is no persistence or user-facing behavior change. Production exposes the same six renderer adapters, tests additionally expose mock, and each connection receives a fresh main-process runtime.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/application.spec.ts"` — 4 passing
- `npm run test -- --client "mock" --spec "test/specs/mock/multiple-servers.spec.ts"` — 2 passing
