### PR TITLE
refactor(ipc): type torrent actions

### DIFF
--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -5,6 +5,7 @@ import type {
     TorrentClientConnection,
 } from "@shared/ipc-contract"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
+import type { MockTorrentFileInput, MockTorrentInput } from "@shared/bittorrent-actions"
 import parseTorrent from "parse-torrent"
 
 const PRIORITY_SKIP = 0
@@ -35,25 +36,12 @@ interface MockTorrent {
     up_speed: number
 }
 
-interface MockTorrentFile {
-    index: number
-    name: string
-    size: number
-    progress: number
-    availability: number
-    priority: number
-    is_seed: boolean
-}
+type MockTorrentFile = MockTorrentFileInput
 
 interface MockRuntimeStore {
     torrents: Map<string, MockTorrent>
     files: Map<string, MockTorrentFile[]>
     removedHashes: string[]
-}
-
-type MockTorrentInput = Partial<MockTorrent> & {
-    hash?: string
-    files?: MockTorrentFile[]
 }
 
 export class MockBittorrentRuntime implements BittorrentRuntime {

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -3,17 +3,28 @@ import path from "path"
 import type { WebContents } from "electron"
 import type {
     BittorrentAddTorrentUrlRequest,
-    BittorrentInvokeActionRequest,
     BittorrentServerConfig,
     BittorrentSetTorrentFileSelectionRequest,
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
     BittorrentUploadTorrentRequest,
 } from "@shared/ipc-contract"
+import {
+    isBittorrentActionName,
+    type BittorrentActionName,
+    type BittorrentInvokeActionRequest,
+} from "@shared/bittorrent-actions"
 import logger from "../logger"
 import * as settings from "../settings"
 import { createRuntime } from "./registry"
-import type { BittorrentRuntime } from "./types"
+import type { BittorrentRuntime, BittorrentRuntimeAction } from "./types"
+
+function getRuntimeAction<Action extends BittorrentActionName>(
+    runtime: BittorrentRuntime,
+    action: Action,
+): BittorrentRuntimeAction<Action> | undefined {
+    return runtime[action] as BittorrentRuntimeAction<Action> | undefined
+}
 
 export interface BittorrentSessionState {
     activeServerId: string | null
@@ -161,13 +172,28 @@ class BittorrentManager {
         }
     }
 
-    async invokeAction(sender: WebContents, request: BittorrentInvokeActionRequest) {
-        const runtime = await this.getSession(sender)
-        const action = (runtime as unknown as Record<string, unknown>)[request.action]
-        if (typeof action !== "function") {
-            throw new Error(`Unsupported bittorrent action: ${request.action}`)
+    async invokeAction(sender: WebContents, request: BittorrentInvokeActionRequest | null | undefined) {
+        if (!request || typeof request !== "object") {
+            throw new Error("Invalid bittorrent action request")
         }
-        return action.call(runtime, request.hashes || [], ...(request.args || []))
+
+        const { action, hashes, args } = request
+        if (!isBittorrentActionName(action)) {
+            throw new Error(`Unsupported bittorrent action: ${action}`)
+        }
+        if (hashes !== undefined && !Array.isArray(hashes)) {
+            throw new Error("Invalid bittorrent action hashes")
+        }
+        if (args !== undefined && !Array.isArray(args)) {
+            throw new Error("Invalid bittorrent action arguments")
+        }
+
+        const runtime = await this.getSession(sender)
+        const runtimeAction = getRuntimeAction(runtime, action)
+        if (typeof runtimeAction !== "function") {
+            throw new Error(`Unsupported bittorrent action: ${action}`)
+        }
+        return runtimeAction.call(runtime, hashes || [], ...(args || []))
     }
 
     async getTorrentDetails(sender: WebContents, hash: string): Promise<BittorrentTorrentDetailsData> {

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -5,15 +5,24 @@ import type {
     BittorrentTorrentDetailsData,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
+import type { BittorrentActionArguments, BittorrentActionName } from "@shared/bittorrent-actions"
 
 export type CallbackFunc<T = unknown> = (err: unknown, val: T) => void
 
-export interface BittorrentRuntime {
+export type BittorrentRuntimeAction<Action extends BittorrentActionName> = (
+    hashes: string[],
+    ...args: BittorrentActionArguments[Action]
+) => Promise<unknown>
+
+export type BittorrentRuntimeActions = {
+    [Action in BittorrentActionName]?: BittorrentRuntimeAction<Action>
+}
+
+export interface BittorrentRuntime extends BittorrentRuntimeActions {
     connect(server: BittorrentServerConfig): Promise<TorrentClientConnection>
     getSnapshot(fullUpdate?: boolean): Promise<any>
     addTorrentUrl(uri: string, options?: TorrentUploadOptions): Promise<void>
     uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions): Promise<void>
-    setLocation?(hashes: string[], location: string): Promise<void>
     getTorrentDetails?(hash: string): Promise<BittorrentTorrentDetailsData>
     getTorrentFiles?(hash: string): Promise<BittorrentFileSelection[]>
     setTorrentFileSelection?(hash: string, files: BittorrentFileSelection[]): Promise<void>

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -6,6 +6,11 @@ import type {
     TorrentClientConnection,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
+import type {
+    BittorrentActionArguments,
+    BittorrentActionName,
+    BittorrentInvokeActionRequest,
+} from "@shared/bittorrent-actions"
 
 declare const window: Window & { electorrent: ElectorrentBridge }
 
@@ -50,8 +55,12 @@ export function uploadTorrent(data: Uint8Array, filename: string, options?: Torr
     return bridge().uploadTorrent({ data, filename, options, sourcePath })
 }
 
-export function invokeAction(action: string, hashes: string[] = [], ...args: unknown[]) {
-    return bridge().invokeAction({ action, hashes, args })
+export function invokeAction<Action extends BittorrentActionName>(
+    action: Action,
+    hashes: string[] = [],
+    ...args: BittorrentActionArguments[Action]
+) {
+    return bridge().invokeAction({ action, hashes, args } as BittorrentInvokeActionRequest)
 }
 
 export function getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -4,16 +4,13 @@ import type {
     BittorrentTorrentDetailsFile,
     ResolvedTorrentClientFeatures,
     TorrentClientFeatures,
+    TorrentRatioLimitOptions,
     TorrentSpeedLimitOptions,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
 import { connect } from "./ipc"
 
-export type { TorrentSpeedLimitOptions, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@shared/ipc-contract"
-
-export interface TorrentRatioLimitOptions {
-    ratioLimit: number
-}
+export type { TorrentRatioLimitOptions, TorrentSpeedLimitOptions, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@shared/ipc-contract"
 
 export type TorrentActionRole = "resume" | "stop" | "delete"
 

--- a/src/shared/bittorrent-actions.ts
+++ b/src/shared/bittorrent-actions.ts
@@ -1,0 +1,152 @@
+export interface TorrentSpeedLimitOptions {
+    downloadSpeedLimit?: number
+    uploadSpeedLimit?: number
+}
+
+export interface TorrentRatioLimitOptions {
+    ratioLimit: number
+}
+
+export interface MockTorrentFileInput {
+    index: number
+    name: string
+    size: number
+    progress: number
+    availability: number
+    priority: number
+    is_seed: boolean
+}
+
+export interface MockTorrentInput {
+    added_on?: number
+    category?: string
+    completion_on?: number
+    dl_speed?: number
+    eta?: number
+    hash?: string
+    name?: string
+    num_complete?: number
+    num_incomplete?: number
+    num_leechs?: number
+    num_seeds?: number
+    priority?: number
+    progress?: number
+    ratio?: number
+    ratio_limit?: number
+    save_path?: string
+    seq_dl?: boolean
+    size?: number
+    state?: string
+    total_downloaded?: number
+    total_size?: number
+    total_uploaded?: number
+    up_speed?: number
+    files?: MockTorrentFileInput[]
+}
+
+/** Arguments passed after the common torrent-hash array for each dispatchable action. */
+export interface BittorrentActionArguments {
+    addMockedTorrent: [input?: MockTorrentInput]
+    bottomPrio: []
+    clearMockedTorrents: []
+    decreasePrio: []
+    delete: []
+    deleteAndErase: []
+    deleteAndRemove: []
+    forcestart: []
+    getprops: []
+    increasePrio: []
+    label: [label: string]
+    pause: []
+    pauseAll: []
+    priorityHigh: []
+    priorityLow: []
+    priorityNormal: []
+    priorityOff: []
+    queueBottom: []
+    queueDown: []
+    queueTop: []
+    queueUp: []
+    queuedown: []
+    queueup: []
+    recheck: []
+    remove: []
+    removeAndDelete: []
+    removeAndLocal: []
+    removedata: []
+    removedatatorrent: []
+    removetorrent: []
+    resume: []
+    resumeAll: []
+    setAlternativeSpeedLimitsMode: [enabled: boolean]
+    setCategory: [category: string, create?: boolean]
+    setLabel: [label: string, create?: boolean]
+    setLocation: [location: string, resumeHashes?: string[]]
+    setRatioLimit: [options: TorrentRatioLimitOptions]
+    setSpeedLimits: [options: TorrentSpeedLimitOptions]
+    start: []
+    stop: []
+    toggleSequentialDownload: []
+    topPrio: []
+    verify: []
+}
+
+export type BittorrentActionName = keyof BittorrentActionArguments
+
+const BITTORRENT_ACTIONS = {
+    addMockedTorrent: true,
+    bottomPrio: true,
+    clearMockedTorrents: true,
+    decreasePrio: true,
+    delete: true,
+    deleteAndErase: true,
+    deleteAndRemove: true,
+    forcestart: true,
+    getprops: true,
+    increasePrio: true,
+    label: true,
+    pause: true,
+    pauseAll: true,
+    priorityHigh: true,
+    priorityLow: true,
+    priorityNormal: true,
+    priorityOff: true,
+    queueBottom: true,
+    queueDown: true,
+    queueTop: true,
+    queueUp: true,
+    queuedown: true,
+    queueup: true,
+    recheck: true,
+    remove: true,
+    removeAndDelete: true,
+    removeAndLocal: true,
+    removedata: true,
+    removedatatorrent: true,
+    removetorrent: true,
+    resume: true,
+    resumeAll: true,
+    setAlternativeSpeedLimitsMode: true,
+    setCategory: true,
+    setLabel: true,
+    setLocation: true,
+    setRatioLimit: true,
+    setSpeedLimits: true,
+    start: true,
+    stop: true,
+    toggleSequentialDownload: true,
+    topPrio: true,
+    verify: true,
+} as const satisfies Record<BittorrentActionName, true>
+
+export type BittorrentInvokeActionRequest<Action extends BittorrentActionName = BittorrentActionName> = {
+    [Name in Action]: {
+        action: Name
+        hashes?: string[]
+        args?: BittorrentActionArguments[Name]
+    }
+}[Action]
+
+export function isBittorrentActionName(action: unknown): action is BittorrentActionName {
+    return typeof action === "string" && Object.prototype.hasOwnProperty.call(BITTORRENT_ACTIONS, action)
+}

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,3 +1,7 @@
+import type { BittorrentInvokeActionRequest } from "./bittorrent-actions"
+
+export type { BittorrentInvokeActionRequest, TorrentRatioLimitOptions, TorrentSpeedLimitOptions } from "./bittorrent-actions"
+
 export type Unsubscribe = () => void
 
 export type ColorTheme = "light" | "dark"
@@ -89,12 +93,6 @@ export interface BittorrentUploadTorrentRequest {
     sourcePath?: string
 }
 
-export interface BittorrentInvokeActionRequest {
-    action: string
-    hashes?: string[]
-    args?: unknown[]
-}
-
 export interface BittorrentGetTorrentFilesRequest {
     hash: string
 }
@@ -183,11 +181,6 @@ export interface TorrentUploadOptions {
     downloadSpeedLimit?: number
     uploadSpeedLimit?: number
     fileSelection?: BittorrentFileSelection[]
-}
-
-export interface TorrentSpeedLimitOptions {
-    downloadSpeedLimit?: number
-    uploadSpeedLimit?: number
 }
 
 export type TorrentUploadOptionsEnable = Partial<Record<keyof TorrentUploadOptions, boolean>>

--- a/test/specs/mock/action-header-label-search.spec.ts
+++ b/test/specs/mock/action-header-label-search.spec.ts
@@ -2,6 +2,7 @@ import chai from "chai"
 import { $, $$, browser } from "@wdio/globals"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec } from "../../framework/fixture"
+import type { BittorrentActionArguments } from "@shared/bittorrent-actions"
 
 const assert: Chai.AssertStatic = chai.assert
 
@@ -53,7 +54,10 @@ describe("mock action header label search", function () {
   })
 })
 
-async function invokeMockAction(action: string, ...args: any[]) {
+async function invokeMockAction<Action extends "addMockedTorrent" | "clearMockedTorrents">(
+  action: Action,
+  ...args: BittorrentActionArguments[Action]
+) {
   await browser.execute(async (request) => {
     await (window as any).electorrent.bittorrent.invokeAction(request)
   }, { action, args })

--- a/test/specs/mock/multiple-servers.spec.ts
+++ b/test/specs/mock/multiple-servers.spec.ts
@@ -3,6 +3,7 @@ import { $, $$, browser } from "@wdio/globals"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec } from "../../framework/fixture"
 import { restartApplication } from "../../shared"
+import type { BittorrentActionArguments } from "@shared/bittorrent-actions"
 
 const assert: Chai.AssertStatic = chai.assert
 
@@ -114,7 +115,10 @@ function mockTorrent(index: number): MockTorrent {
   }
 }
 
-async function invokeMockAction(action: string, ...args: any[]) {
+async function invokeMockAction<Action extends "addMockedTorrent" | "clearMockedTorrents">(
+  action: Action,
+  ...args: BittorrentActionArguments[Action]
+) {
   await browser.execute(async (request) => {
     await (window as any).electorrent.bittorrent.invokeAction(request)
   }, { action, args })

--- a/test/specs/mock/sorting.spec.ts
+++ b/test/specs/mock/sorting.spec.ts
@@ -4,6 +4,7 @@ import { Key } from "webdriverio"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec } from "../../framework/fixture"
 import { restartApplication } from "../../shared"
+import type { BittorrentActionArguments } from "@shared/bittorrent-actions"
 
 const assert: Chai.AssertStatic = chai.assert
 
@@ -57,7 +58,10 @@ describe("mock torrent table sorting", function () {
     }
   }
 
-  async function invokeMockAction(action: string, ...args: any[]) {
+  async function invokeMockAction<Action extends "addMockedTorrent" | "clearMockedTorrents">(
+    action: Action,
+    ...args: BittorrentActionArguments[Action]
+  ) {
     await browser.execute(async (request) => {
       await (window as any).electorrent.bittorrent.invokeAction(request)
     }, { action, args })


### PR DESCRIPTION
## What changed

- add an exhaustive shared torrent-action argument map and runtime allowlist
- type renderer action calls and the main-process runtime action seam from the same interface
- reject unknown or malformed action requests before runtime property lookup
- share speed, ratio, and mock action input types across callers and adapters
- type the existing mock action helpers

## Why

Torrent actions crossed IPC as an arbitrary string plus an `unknown[]` argument list. The main process then used that string for dynamic runtime property access, so misspelled actions and invalid arguments escaped compilation and IPC could address unrelated runtime properties.

The shared action module concentrates valid names and argument invariants in one interface. Concrete runtime adapters and renderer callers are now checked against it, while the main process only looks up allowlisted actions.

## Impact

The wire shape and existing client-specific action behavior remain unchanged. Unsupported client actions keep the existing error, while unknown or malformed IPC requests are rejected before dispatch.

## Validation

- `npm run lint`
- `npm run build`
- qBittorrent action, speed-limit, and ratio-limit specs — 10 passing
- mock label-search, multiple-server, and sorting specs — 10 passing
