### PR TITLE
feat(ui): improve torrent info layout

### DIFF
--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.controller.ts
@@ -42,6 +42,22 @@ export class TorrentDetailsInfoTabController {
     }
   }
 
+  fieldTitle(field: TorrentDetailsInfoField) {
+    return field.multiline || field.format === "path" ? this.formatFieldValue(field) : "";
+  }
+
+  sectionIcon(sectionId: string) {
+    const icons: Record<string, string> = {
+      overview: "info circle",
+      transfer: "exchange",
+      swarm: "users",
+      content: "file alternate outline",
+      dates: "calendar alternate outline",
+    };
+
+    return icons[sectionId] || "list alternate outline";
+  }
+
   private formatPercent(value: unknown) {
     const numeric = typeof value === "number" ? value : Number(value);
     if (!Number.isFinite(numeric) || numeric < 0) {

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
@@ -1,17 +1,28 @@
 <div class="torrent-details-info" data-role="torrent-details-info">
-  <div class="torrent-details-section" ng-repeat="section in ctl.scope.sections track by section.id">
-    <div class="ui tiny header">{{ section.title }}</div>
-    <table class="ui very basic compact table">
-      <tbody>
-        <tr
-          ng-repeat="field in section.fields track by field.id"
-          data-role="torrent-details-field"
-          data-field-id="{{ field.id }}"
-        >
-          <td class="label">{{ field.label }}</td>
-          <td class="value" ng-class="{ multiline: field.multiline }">{{ ctl.formatFieldValue(field) }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+  <section
+    class="torrent-details-section"
+    ng-repeat="section in ctl.scope.sections track by section.id"
+    aria-labelledby="torrent-details-section-{{ section.id }}"
+  >
+    <header class="torrent-details-section-header">
+      <i class="icon {{ ctl.sectionIcon(section.id) }}" aria-hidden="true"></i>
+      <h3 id="torrent-details-section-{{ section.id }}">{{ section.title }}</h3>
+    </header>
+
+    <dl class="torrent-details-field-list">
+      <div
+        class="torrent-details-field"
+        ng-repeat="field in section.fields track by field.id"
+        data-role="torrent-details-field"
+        data-field-id="{{ field.id }}"
+      >
+        <dt>{{ field.label }}</dt>
+        <dd
+          class="torrent-details-field-value torrent-details-field-value-{{ field.format || 'text' }}"
+          ng-class="{ multiline: field.multiline }"
+          title="{{ ctl.fieldTitle(field) }}"
+        >{{ ctl.formatFieldValue(field) }}</dd>
+      </div>
+    </dl>
+  </section>
 </div>

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
@@ -18,7 +18,7 @@
       >
         <dt>{{ field.label }}</dt>
         <dd
-          class="torrent-details-field-value torrent-details-field-value-{{ field.format || 'text' }}"
+          class="value torrent-details-field-value torrent-details-field-value-{{ field.format || 'text' }}"
           ng-class="{ multiline: field.multiline }"
           title="{{ ctl.fieldTitle(field) }}"
         >{{ ctl.formatFieldValue(field) }}</dd>

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -757,36 +757,116 @@ torrent-sidebar + .main-panel {
 
         .torrent-details-info {
             display: grid;
-            gap: 1rem;
-            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-            padding: 0.75rem 1rem;
-            overflow-y: hidden;
+            align-content: start;
+            gap: 0.75rem;
+            grid-auto-rows: max-content;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            padding: 1rem;
+            overflow-x: hidden;
+            overflow-y: auto;
+            background: fade(@pageMiddleground, 45%);
         }
 
         .torrent-details-section {
             min-width: 0;
+            border: 1px solid @borderColor;
+            border-radius: 4px;
+            background: @pageForeground;
+            box-shadow: 0 1px 2px fade(#000, 5%);
 
-            .table {
+            .torrent-details-section-header {
+                display: flex;
+                align-items: center;
+                gap: 0.5rem;
+                min-height: 2.5rem;
+                padding: 0.6rem 0.85rem;
+                border-bottom: 1px solid fade(@borderColor, 75%);
+                background: fade(@pageMiddleground, 55%);
+
+                .icon {
+                    width: 1.15rem;
+                    margin: 0;
+                    color: @primaryColor;
+                    text-align: center;
+                }
+
+                h3 {
+                    margin: 0;
+                    color: @textColor;
+                    font-size: 0.85rem;
+                    font-weight: 700;
+                    letter-spacing: 0.035em;
+                    line-height: 1.2;
+                    text-transform: uppercase;
+                }
+            }
+
+            .torrent-details-field-list {
                 margin: 0;
             }
 
-            td {
-                vertical-align: top;
+            .torrent-details-field {
+                display: grid;
+                grid-template-columns: minmax(110px, 38%) minmax(0, 1fr);
+                gap: 0.75rem;
+                padding: 0.55rem 0.85rem;
+                border-bottom: 1px solid fade(@borderColor, 42%);
+
+                &:last-child {
+                    border-bottom: 0;
+                }
+
+                &:hover {
+                    background: fade(@pageMiddleground, 32%);
+                }
             }
 
-            td.label {
-                width: 120px;
+            dt {
+                min-width: 0;
+                color: fade(@textColor, 62%);
+                font-size: 0.82rem;
                 font-weight: 600;
-                padding-left: 0;
-                white-space: nowrap;
+                line-height: 1.45;
             }
 
-            td.value {
-                padding-right: 0;
-                word-break: break-word;
+            dd {
+                min-width: 0;
+                margin: 0;
+                color: @textColor;
+                font-size: 0.9rem;
+                font-variant-numeric: tabular-nums;
+                font-weight: 600;
+                line-height: 1.35;
+                overflow-wrap: anywhere;
+                text-align: right;
 
                 &.multiline {
                     white-space: pre-wrap;
+                }
+            }
+
+            .torrent-details-field-value-path,
+            .torrent-details-field-value-text.multiline {
+                font-family: monospace;
+                font-size: 0.82rem;
+                font-weight: 400;
+                text-align: left;
+            }
+        }
+
+        @media (max-width: 720px) {
+            .torrent-details-info {
+                grid-template-columns: minmax(0, 1fr);
+            }
+        }
+
+        @media (max-width: 460px) {
+            .torrent-details-section .torrent-details-field {
+                grid-template-columns: minmax(0, 1fr);
+                gap: 0.2rem;
+
+                dd {
+                    text-align: left;
                 }
             }
         }


### PR DESCRIPTION
## What changed

- replace the dense info table with responsive, scannable section cards
- add section icons and stronger label/value hierarchy
- improve long path and multiline content readability
- make dense metadata vertically scrollable without clipping fields
- use semantic definition-list markup and section labels

## Why

Torrent metadata was presented as several compact tables with limited visual separation, making it difficult to scan and compare values. The fixed-height panel could also leave dense content hard to reach.

## Impact

The Info tab is easier to scan across light and dark themes, adapts down to narrow layouts, and preserves access to all client-provided metadata.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts"` (3 passing)