### PR TITLE
fix(ui): align torrent files headers

### DIFF
--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -883,6 +883,7 @@ torrent-sidebar + .main-panel {
                 top: 50%;
                 margin: 0;
                 transform: translateY(-50%);
+                pointer-events: none;
             }
         }
 

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -873,6 +873,19 @@ torrent-sidebar + .main-panel {
             text-align: center;
         }
 
+        .torrent-details-file-selection-column .torrent-details-file-checkbox {
+            margin-right: auto;
+            margin-left: auto;
+        }
+
+        .torrent-details-files-content .torrent.table thead th {
+            .sorting.icon {
+                top: 50%;
+                margin: 0;
+                transform: translateY(-50%);
+            }
+        }
+
         .torrent-details-file-selection-column .rz-handle {
             display: none;
         }

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -380,13 +380,15 @@ export class Torrent {
     const contextMeny = $("#contextmenu")
     for (let attempt = 0; attempt < 3; attempt++) {
       await elem.click(options)
-      if (await contextMeny.isDisplayed()) {
+      try {
+        await contextMeny.waitForDisplayed({ timeout: attempt === 2 ? this.timeout : 1000 })
         return
+      } catch (error) {
+        if (attempt === 2) {
+          throw error
+        }
       }
-      await browser.pause(100)
     }
-
-    await contextMeny.waitForDisplayed()
   }
 
   async clickContextMenu(roleName: string) {


### PR DESCRIPTION
## Summary

- horizontally center the files-table header selection checkbox
- vertically center sorting arrows beside their column labels
- keep sorting indicators within the table header without blocking column resize handles
- stabilize the shared E2E context-menu helper by waiting for the menu after each organic right-click

## Root cause

The fixed-width header checkbox lacked automatic horizontal margins, unlike the row checkbox wrapper. Sorting icons were absolutely positioned without an explicit vertical anchor, so their static position could fall below the label and clip outside the header. Applying a transform to align the icon also created a stacking context over the resize handle, so the decorative icon now ignores pointer events.

During CI monitoring, Deluge 2 consistently exposed a separate race in the context-menu helper: it checked visibility immediately after right-clicking and could issue another click while the menu was opening, toggling it away. The helper now waits briefly after each attempt and retains the existing full timeout on the final attempt.

## Impact

The torrent details Files tab now presents consistent checkbox alignment and readable, unclipped sorting indicators while preserving column resizing. E2E context-menu interaction is more reliable under slower clients.

## Validation

- `npm run lint`
- `npm run build`
- qBittorrent latest torrent-details file information test
- qBittorrent latest torrent-details column resize test
- Deluge 2 upload-queue spec
- GitHub Actions: all 13 checks green