### PR TITLE
refactor(ipc): split torrent detail requests

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,7 @@
 import request from "request"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, TorrentClientConnection } from "@shared/ipc-contract"
 import {
     defer,
     HTTP_LOGIN_TIMEOUT,
@@ -43,9 +43,6 @@ const DELUGE_TORRENT_FIELDS = [
 
 const DELUGE_TORRENT_DETAIL_FIELDS = [
     ...DELUGE_TORRENT_FIELDS,
-    "files",
-    "file_progress",
-    "file_priorities",
     "message",
     "active_time",
     "seeding_time",
@@ -59,6 +56,8 @@ const DELUGE_TORRENT_DETAIL_FIELDS = [
     "seed_rank",
     "time_since_transfer",
 ]
+
+const DELUGE_TORRENT_FILES_FIELDS = ["files", "file_progress", "file_priorities"]
 
 export class DelugeRuntime implements BittorrentRuntime {
     private url(server: BittorrentServerConfig, endpoint?: string) {
@@ -305,10 +304,6 @@ export class DelugeRuntime implements BittorrentRuntime {
 
     async getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {
         const details = await defer<Record<string, any>>((done) => this.rpc("web.get_torrent_status", [hash, DELUGE_TORRENT_DETAIL_FIELDS], done))
-        const files = Array.isArray(details.files) ? details.files : []
-        const fileProgress = Array.isArray(details.file_progress) ? details.file_progress : []
-        const filePriorities = Array.isArray(details.file_priorities) ? details.file_priorities : []
-
         return {
             info: {
                 hash,
@@ -343,7 +338,16 @@ export class DelugeRuntime implements BittorrentRuntime {
                 message: details.message ?? null,
                 timeSinceTransfer: details.time_since_transfer ?? null,
             },
-            files: files.map((file: any, index: number) => {
+        }
+    }
+
+    async getTorrentFiles(hash: string): Promise<BittorrentTorrentDetailsFile[]> {
+        const details = await defer<Record<string, any>>((done) => this.rpc("web.get_torrent_status", [hash, DELUGE_TORRENT_FILES_FIELDS], done))
+        const files = Array.isArray(details.files) ? details.files : []
+        const fileProgress = Array.isArray(details.file_progress) ? details.file_progress : []
+        const filePriorities = Array.isArray(details.file_priorities) ? details.file_priorities : []
+
+        return files.map((file: any, index: number) => {
                 const priority = filePriorities[index] != null ? Number(filePriorities[index]) : undefined
                 const progressValue = typeof fileProgress[index] === "number"
                     ? fileProgress[index]
@@ -358,8 +362,7 @@ export class DelugeRuntime implements BittorrentRuntime {
                     priority,
                     wanted: priority !== 0,
                 }
-            }),
-        }
+            })
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -2,6 +2,7 @@ import type {
     BittorrentFileSelection,
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
+    BittorrentTorrentDetailsFile,
     TorrentClientConnection,
 } from "@shared/ipc-contract"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
@@ -275,15 +276,18 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         })
     }
 
-    async getTorrentFiles(hash: string): Promise<BittorrentFileSelection[]> {
+    async getTorrentFiles(hash: string): Promise<BittorrentTorrentDetailsFile[]> {
         this.assertConnected()
         return (this.files.get(hash) || []).map((file) => ({
             index: file.index,
             path: file.name,
             name: file.name.split(/[/\\]/).pop() || "",
             size: file.size,
+            progress: file.progress,
+            availability: file.availability,
             wanted: file.priority !== PRIORITY_SKIP,
             priority: file.priority,
+            isSeed: file.is_seed,
         }))
     }
 
@@ -354,17 +358,6 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
                 uploadSpeed: torrent.up_speed,
                 isPrivate: false,
             },
-            files: (this.files.get(hash) || []).map((file) => ({
-                index: file.index,
-                path: file.name,
-                name: file.name.split(/[/\\]/).pop() || file.name,
-                size: file.size,
-                progress: file.progress,
-                availability: file.availability,
-                priority: file.priority,
-                wanted: file.priority !== PRIORITY_SKIP,
-                isSeed: file.is_seed,
-            })),
         }
     }
 

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -22,31 +22,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null
 }
 
-function normalizeTorrentFiles(body: unknown): BittorrentFileSelection[] {
-    if (!Array.isArray(body)) {
-        throw new Error("Invalid torrent files response")
-    }
-
-    return body.map((value, index) => {
-        if (!isRecord(value)) {
-            throw new Error("Invalid torrent file response")
-        }
-
-        const path = typeof value.name === "string" ? value.name : ""
-        const size = typeof value.size === "number" ? value.size : Number.parseInt(String(value.size), 10) || 0
-        const priority = typeof value.priority === "number" ? value.priority : QBITTORRENT_PRIORITY_NORMAL
-
-        return {
-            index: typeof value.index === "number" ? value.index : index,
-            path,
-            name: path.split(/[/\\]/).pop() || "",
-            size,
-            wanted: priority !== QBITTORRENT_PRIORITY_SKIP,
-            priority,
-        }
-    })
-}
-
 function normalizeTorrentDetailsFiles(body: unknown): BittorrentTorrentDetailsFile[] {
     if (!Array.isArray(body)) {
         throw new Error("Invalid torrent files response")
@@ -521,19 +496,16 @@ export class QBittorrentRuntime implements BittorrentRuntime {
 
     async getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {
         const api = this.getApi()
-        const [properties, files] = await Promise.all([
-            new Promise<Record<string, any>>((resolve, reject) => {
-                api.getJson("torrents/properties", { qs: { hash } }, (err: any, _res: any, body: any) => {
-                    if (err) {
-                        reject(err)
-                        return
-                    }
+        const properties = await new Promise<Record<string, any>>((resolve, reject) => {
+            api.getJson("torrents/properties", { qs: { hash } }, (err: any, _res: any, body: any) => {
+                if (err) {
+                    reject(err)
+                    return
+                }
 
-                    resolve(body || {})
-                })
-            }),
-            this.fetchTorrentFiles(hash),
-        ])
+                resolve(body || {})
+            })
+        })
 
         return {
             info: {
@@ -575,7 +547,6 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 uploadSpeed: properties.up_speed ?? null,
                 isPrivate: properties.is_private ?? properties.isPrivate ?? null,
             },
-            files: normalizeTorrentDetailsFiles(files),
         }
     }
 
@@ -593,8 +564,8 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         })
     }
 
-    async getTorrentFiles(hash: string): Promise<BittorrentFileSelection[]> {
-        return normalizeTorrentFiles(await this.fetchTorrentFiles(hash))
+    async getTorrentFiles(hash: string): Promise<BittorrentTorrentDetailsFile[]> {
+        return normalizeTorrentDetailsFiles(await this.fetchTorrentFiles(hash))
     }
 
     async setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]): Promise<void> {

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -3,7 +3,7 @@ import { URL } from "node:url"
 import xmlrpc from "@electorrent/xmlrpc"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, TorrentClientConnection } from "@shared/ipc-contract"
 import { defer, HTTP_LOGIN_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { doubleArrayToHash, postfix, rtorrentFields, stringsToBooleans, stringsToNumbers, urlHostname } from "./helpers"
@@ -322,24 +322,12 @@ export class RtorrentRuntime implements BittorrentRuntime {
             "additionDate",
             "loadDate",
         ] as const
-        const fileCommands = {
-            path: "f.path",
-            size: "f.size_bytes",
-            completedChunks: "f.completed_chunks",
-            totalChunks: "f.size_chunks",
-            priority: "f.priority",
-        }
-
-        const [detailFields, files] = await Promise.all([
-            this.getTorrentFields(hash, detailCommands),
-            this.getMulticall("f.multicall", [hash, ""], fileCommands),
-        ])
+        const detailFields = await this.getTorrentFields(hash, detailCommands)
 
         numericDetailFields.forEach((field) => {
             const numeric = Number(detailFields[field])
             detailFields[field] = Number.isFinite(numeric) ? numeric : null
         })
-        files.forEach((file) => stringsToNumbers(file))
 
         const savePath = typeof detailFields.savePath === "string" ? detailFields.savePath : null
         const name = typeof detailFields.name === "string" ? detailFields.name : null
@@ -384,7 +372,20 @@ export class RtorrentRuntime implements BittorrentRuntime {
                 chunksComplete: chunksComplete ?? null,
                 message: message ?? null,
             },
-            files: files.map((file: Record<string, any>, index: number) => {
+        }
+    }
+
+    async getTorrentFiles(hash: string): Promise<BittorrentTorrentDetailsFile[]> {
+        const files = await this.getMulticall("f.multicall", [hash, ""], {
+            path: "f.path",
+            size: "f.size_bytes",
+            completedChunks: "f.completed_chunks",
+            totalChunks: "f.size_chunks",
+            priority: "f.priority",
+        })
+        files.forEach((file) => stringsToNumbers(file))
+
+        return files.map((file: Record<string, any>, index: number) => {
                 const size = typeof file.size === "number" ? file.size : 0
                 const totalChunks = typeof file.totalChunks === "number" ? file.totalChunks : 0
                 const completedChunks = typeof file.completedChunks === "number" ? file.completedChunks : 0
@@ -399,8 +400,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
                     priority,
                     wanted: priority !== 0,
                 }
-            }),
-        }
+            })
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import https from 'https'
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, TorrentClientConnection } from '@shared/ipc-contract'
+import type { BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -87,6 +87,15 @@ const TRANSMISSION_FIELDS = [
     'webseeds',
     'webseedsSendingToUs',
 ]
+
+const TRANSMISSION_TORRENT_DETAILS_FIELDS = TRANSMISSION_FIELDS.filter((field) => ![
+    'files',
+    'fileStats',
+    'priorities',
+    'wanted',
+].includes(field))
+
+const TRANSMISSION_TORRENT_FILES_FIELDS = ['files', 'fileStats', 'priorities', 'wanted']
 
 export class TransmissionRuntime implements BittorrentRuntime {
     private server!: BittorrentServerConfig
@@ -242,7 +251,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
         const response = await this.getHttpClient().post(this.url(), {
             arguments: {
                 ids: [hash],
-                fields: TRANSMISSION_FIELDS,
+                fields: TRANSMISSION_TORRENT_DETAILS_FIELDS,
             },
             method: 'torrent-get',
         })
@@ -251,11 +260,6 @@ export class TransmissionRuntime implements BittorrentRuntime {
         if (!torrent) {
             throw new Error('Transmission did not return torrent details')
         }
-
-        const files = Array.isArray(torrent.files) ? torrent.files : []
-        const fileStats = Array.isArray(torrent.fileStats) ? torrent.fileStats : []
-        const wanted = Array.isArray(torrent.wanted) ? torrent.wanted : []
-        const priorities = Array.isArray(torrent.priorities) ? torrent.priorities : []
 
         return {
             info: {
@@ -289,7 +293,28 @@ export class TransmissionRuntime implements BittorrentRuntime {
                 queuePosition: torrent.queuePosition ?? null,
                 sequentialDownload: torrent.sequentialDownload ?? torrent.sequential_download ?? null,
             },
-            files: files.map((file: any, index: number) => {
+        }
+    }
+
+    async getTorrentFiles(hash: string): Promise<BittorrentTorrentDetailsFile[]> {
+        const response = await this.getHttpClient().post(this.url(), {
+            arguments: {
+                ids: [hash],
+                fields: TRANSMISSION_TORRENT_FILES_FIELDS,
+            },
+            method: 'torrent-get',
+        })
+        const torrent = response?.data?.arguments?.torrents?.[0]
+        if (!torrent) {
+            throw new Error('Transmission did not return torrent files')
+        }
+
+        const files = Array.isArray(torrent.files) ? torrent.files : []
+        const fileStats = Array.isArray(torrent.fileStats) ? torrent.fileStats : []
+        const wanted = Array.isArray(torrent.wanted) ? torrent.wanted : []
+        const priorities = Array.isArray(torrent.priorities) ? torrent.priorities : []
+
+        return files.map((file: any, index: number) => {
                 const stats = fileStats[index] || {}
                 const size = typeof file.length === 'number' ? file.length : (parseInt(String(file.length), 10) || 0)
                 const completed = typeof stats.bytesCompleted === 'number'
@@ -308,8 +333,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
                     priority,
                     wanted: Boolean(stats.wanted ?? wanted[index] ?? true),
                 }
-            }),
-        }
+            })
     }
 
     private removeEmpty(obj: Record<string, any>) {

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -8,6 +8,7 @@ import type {
     BittorrentSetTorrentFileSelectionRequest,
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
+    BittorrentTorrentDetailsFile,
     BittorrentUploadTorrentRequest,
 } from "@shared/ipc-contract"
 import logger from "../logger"
@@ -178,10 +179,10 @@ class BittorrentManager {
         return runtime.getTorrentDetails(hash)
     }
 
-    async getTorrentFiles(sender: WebContents, hash: string) {
+    async getTorrentFiles(sender: WebContents, hash: string): Promise<BittorrentTorrentDetailsFile[]> {
         const runtime = await this.getSession(sender)
         if (typeof runtime.getTorrentFiles !== "function") {
-            throw new Error("Torrent file selection not supported for this client")
+            throw new Error("Torrent files not supported for this client")
         }
         return runtime.getTorrentFiles(hash)
     }

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -3,6 +3,7 @@ import type {
     BittorrentServerConfig,
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
+    BittorrentTorrentDetailsFile,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
 
@@ -15,7 +16,7 @@ export interface BittorrentRuntime {
     uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions): Promise<void>
     setLocation?(hashes: string[], location: string): Promise<void>
     getTorrentDetails?(hash: string): Promise<BittorrentTorrentDetailsData>
-    getTorrentFiles?(hash: string): Promise<BittorrentFileSelection[]>
+    getTorrentFiles?(hash: string): Promise<BittorrentTorrentDetailsFile[]>
     setTorrentFileSelection?(hash: string, files: BittorrentFileSelection[]): Promise<void>
     disconnect?(): Promise<void>
 }

--- a/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/qbittorrentservice.ts
@@ -11,7 +11,7 @@ import {
 } from "@renderer/app/bittorrent/torrentclient";
 import { TorrentFile } from "@renderer/app/bittorrent/abstracttorrent";
 import { QBittorrentTorrent } from "./torrentq";
-import { addTorrentUrl, getSnapshot, getTorrentDetails, getTorrentFiles, invokeAction, setTorrentFileSelection, uploadTorrent } from "@renderer/app/bittorrent/ipc";
+import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, setTorrentFileSelection, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
 import { applyFreeDiskSpace } from "@renderer/app/bittorrent/free-disk-space";
 
@@ -164,10 +164,6 @@ export class QBittorrentClient extends TorrentClient<QBittorrentTorrent> {
 
     deleteTorrents(torrents: QBittorrentTorrent[]): Promise<void> {
       return this.delete(torrents)
-    }
-
-    async getTorrentFiles(torrent: QBittorrentTorrent): Promise<TorrentFile[]> {
-      return getTorrentFiles(torrent.hash);
     }
 
     setTorrentFileSelection(torrent: QBittorrentTorrent, files: TorrentFile[]): Promise<void> {

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -7,7 +7,7 @@ import type {
     TorrentSpeedLimitOptions,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
-import { connect } from "./ipc"
+import { connect, getTorrentFiles as getTorrentFilesData } from "./ipc"
 
 export type { TorrentSpeedLimitOptions, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@shared/ipc-contract"
 
@@ -182,6 +182,9 @@ export interface TorrentDetailsPanelData {
     }
 }
 
+export type TorrentDetailsInfoData = TorrentDetailsPanelData["info"]
+export type TorrentDetailsFilesData = TorrentDetailsPanelData["files"]
+
 export abstract class TorrentClient<T extends Torrent = Torrent> {
     private resolvedFeatures = DEFAULT_FEATURES
     private clientVersion = ""
@@ -276,18 +279,14 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
     /**
      * Get the list of files for a torrent.
      *
-     * Default implementation always throws:
-     * - when {@link features.fileSelection} is false: Error("File selection not supported for this client")
-     * - when {@link features.fileSelection} is true but the client did not override this method:
-     *   Error("File selection not implemented for this client")
-     *
-     * Concrete clients that support file selection must override this method.
+     * The shared implementation uses the torrent-files IPC for both the details panel and
+     * file-selection UI. Clients advertise at least one of those features when files are available.
      */
-    async getTorrentFiles(torrent: T): Promise<TorrentFile[]> {
-        if (!this.features.fileSelection) {
-            throw new Error("File selection not supported for this client")
+    async getTorrentFiles(torrent: T): Promise<TorrentDetailsFileItem[]> {
+        if (!this.features.fileSelection && !this.features.torrentDetails) {
+            throw new Error("Torrent files not supported for this client")
         }
-        return Promise.reject(new Error("File selection not implemented for this client"))
+        return getTorrentFilesData(torrent.hash)
     }
 
     /**
@@ -343,7 +342,7 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
         return Promise.reject(new Error("Ratio limits not implemented for this client"))
     }
 
-    async getTorrentDetails(torrent: T): Promise<TorrentDetailsPanelData> {
+    async getTorrentDetails(torrent: T): Promise<TorrentDetailsInfoData> {
         if (!this.features.torrentDetails) {
             throw new Error("Torrent details not supported for this client")
         }
@@ -351,13 +350,19 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
         const details = await this.getTorrentDetailsData(torrent)
 
         return {
-            info: {
-                sections: this.getTorrentDetailsInfoSections(torrent, details),
-            },
-            files: {
-                columns: this.getTorrentDetailsFilesColumns(torrent, details),
-                items: details.files.map((file) => this.mapTorrentDetailsFile(torrent, details, file)),
-            },
+            sections: this.getTorrentDetailsInfoSections(torrent, details),
+        }
+    }
+
+    async getTorrentDetailsFiles(torrent: T): Promise<TorrentDetailsFilesData> {
+        if (!this.features.torrentDetails) {
+            throw new Error("Torrent details not supported for this client")
+        }
+
+        const files = await this.getTorrentFiles(torrent)
+        return {
+            columns: this.getTorrentDetailsFilesColumns(torrent),
+            items: files.map((file) => this.mapTorrentDetailsFile(torrent, file)),
         }
     }
 
@@ -373,7 +378,7 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
         return []
     }
 
-    protected getTorrentDetailsFilesColumns(_torrent: T, _details: BittorrentTorrentDetailsData): TorrentDetailsFileColumn[] {
+    protected getTorrentDetailsFilesColumns(_torrent: T): TorrentDetailsFileColumn[] {
         return [
             { id: "wanted", label: "", format: "text", sortType: "alphabetical", sortable: false },
             { id: "name", label: "Name", format: "text", sortType: "alphabetical" },
@@ -387,7 +392,6 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
 
     protected mapTorrentDetailsFile(
         _torrent: T,
-        _details: BittorrentTorrentDetailsData,
         file: BittorrentTorrentDetailsFile,
     ): TorrentDetailsFileItem {
         return { ...file, wanted: file.wanted !== false }

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -20,7 +20,10 @@ export class TorrentDetailsPanelController {
   private readonly defaultPanelHeight = 320;
   private readonly minPanelHeight = 220;
   private panelHeight = this.defaultPanelHeight;
-  private loadRequestId = 0;
+  private loadRequestIds = { info: 0, files: 0 };
+  private loadedTabs = { info: false, files: false };
+  private loadingTabs = { info: false, files: false };
+  private tabErrors: Record<"info" | "files", string | null> = { info: null, files: null };
   private stopResizeListeners?: () => void;
 
   constructor(
@@ -61,7 +64,8 @@ export class TorrentDetailsPanelController {
         return;
       }
 
-      this.loadDetails(torrent);
+      this.prepareTorrent(torrent);
+      this.loadTab(this.scope.activeTab, torrent, true);
     });
     const resetListener = this.rootScope.$on("wipe:torrents", () => {
       this.close();
@@ -84,11 +88,11 @@ export class TorrentDetailsPanelController {
     this.panelHeight = this.defaultPanelHeight;
     this.scope.activeTab = "info";
     this.syncResizeBindings();
-    await this.loadDetails(torrent);
+    this.prepareTorrent(torrent);
+    await this.loadTab(this.scope.activeTab, torrent);
   }
 
   close() {
-    this.loadRequestId += 1;
     this.stopResizeListeners?.();
     this.scope.isOpen = false;
     this.scope.activeTab = "info";
@@ -97,6 +101,10 @@ export class TorrentDetailsPanelController {
 
   showTab(tab: "info" | "files") {
     this.scope.activeTab = tab;
+    this.syncActiveTabState();
+    if (this.scope.torrent && !this.loadedTabs[tab]) {
+      void this.loadTab(tab, this.scope.torrent);
+    }
   }
 
   isActiveTab(tab: "info" | "files") {
@@ -105,6 +113,12 @@ export class TorrentDetailsPanelController {
 
   showStateMessage() {
     return !this.scope.loading && (!!this.scope.error || !this.scope.torrent);
+  }
+
+  hasActiveTabData() {
+    return this.scope.activeTab === "info"
+      ? this.scope.panel.info.sections.length > 0
+      : this.scope.panel.files.items.length > 0;
   }
 
   stateMessageIcon() {
@@ -172,30 +186,43 @@ export class TorrentDetailsPanelController {
     return `torrent-details-files.${serverId}`;
   }
 
-  private async loadDetails(torrent: any) {
-    const requestId = ++this.loadRequestId;
-
+  private async loadTab(tab: "info" | "files", torrent: any, force = false) {
+    if (!force && this.loadedTabs[tab]) {
+      return;
+    }
+    const requestId = ++this.loadRequestIds[tab];
     this.syncResizeBindings();
-    this.scope.loading = true;
-    this.scope.error = null;
-    this.scope.torrent = torrent;
+    this.loadingTabs[tab] = true;
+    this.tabErrors[tab] = null;
+    this.syncActiveTabState();
 
     try {
-      const panel = await this.rootScope.$btclient?.getTorrentDetails(torrent);
-      if (requestId !== this.loadRequestId) {
+      const client = this.rootScope.$btclient;
+      const data = tab === "info"
+        ? await client?.getTorrentDetails(torrent)
+        : await client?.getTorrentDetailsFiles(torrent);
+      if (requestId !== this.loadRequestIds[tab] || this.scope.torrent !== torrent) {
         return;
       }
 
-      this.scope.panel = panel || this.scope.panel;
+      if (data) {
+        if (tab === "info") {
+          this.scope.panel.info = data as TorrentDetailsPanelData["info"];
+        } else {
+          this.scope.panel.files = data as TorrentDetailsPanelData["files"];
+        }
+      }
+      this.loadedTabs[tab] = true;
     } catch (err) {
-      if (requestId !== this.loadRequestId) {
+      if (requestId !== this.loadRequestIds[tab] || this.scope.torrent !== torrent) {
         return;
       }
 
-      this.scope.error = err && err.message ? err.message : "Failed to load torrent details";
+      this.tabErrors[tab] = err && err.message ? err.message : `Failed to load torrent ${tab}`;
     } finally {
-      if (requestId === this.loadRequestId) {
-        this.scope.loading = false;
+      if (requestId === this.loadRequestIds[tab] && this.scope.torrent === torrent) {
+        this.loadingTabs[tab] = false;
+        this.syncActiveTabState();
         this.scope.$evalAsync();
       }
     }
@@ -204,7 +231,7 @@ export class TorrentDetailsPanelController {
   private scheduleDetailsFilesUpdate(torrent: any) {
     this.scope.$evalAsync(() => {
       if (this.scope.isOpen && this.scope.torrent === torrent) {
-        void this.loadDetails(torrent);
+        void this.loadTab("files", torrent, true);
       }
     });
   }
@@ -215,11 +242,28 @@ export class TorrentDetailsPanelController {
   }
 
   private clearSelection() {
-    this.loadRequestId += 1;
     this.resetPanelState();
   }
 
+  private prepareTorrent(torrent: any) {
+    if (this.scope.torrent !== torrent) {
+      this.resetPanelState();
+      this.scope.torrent = torrent;
+    }
+  }
+
+  private syncActiveTabState() {
+    const tab = this.scope.activeTab;
+    this.scope.loading = this.loadingTabs[tab];
+    this.scope.error = this.tabErrors[tab];
+  }
+
   private resetPanelState() {
+    this.loadRequestIds.info += 1;
+    this.loadRequestIds.files += 1;
+    this.loadedTabs = { info: false, files: false };
+    this.loadingTabs = { info: false, files: false };
+    this.tabErrors = { info: null, files: null };
     this.scope.loading = false;
     this.scope.error = null;
     this.scope.torrent = null;

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -30,7 +30,7 @@
   </div>
 
   <div class="torrent-details-panel-body">
-    <div ng-if="ctl.scope.loading && !ctl.scope.panel.info.sections.length && !ctl.scope.panel.files.items.length" class="torrent-details-state torrent-details-panel-loader">
+    <div ng-if="ctl.scope.loading && !ctl.hasActiveTabData()" class="torrent-details-state torrent-details-panel-loader">
       <div class="ui active inline loader"></div>
     </div>
 

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -113,13 +113,12 @@ export interface BittorrentTorrentDetailsFile {
     progress: number
     availability?: number
     priority?: number
-    wanted?: boolean
+    wanted: boolean
     isSeed?: boolean
 }
 
 export interface BittorrentTorrentDetailsData {
     info: Record<string, BittorrentTorrentDetailsPrimitive>
-    files: BittorrentTorrentDetailsFile[]
 }
 
 export interface BittorrentFileSelection {
@@ -386,7 +385,7 @@ export interface ElectorrentBridge {
         uploadTorrent(request: BittorrentUploadTorrentRequest): Promise<void>
         invokeAction(request: BittorrentInvokeActionRequest): Promise<void>
         getTorrentDetails(request: BittorrentGetTorrentDetailsRequest): Promise<BittorrentTorrentDetailsData>
-        getTorrentFiles(request: BittorrentGetTorrentFilesRequest): Promise<BittorrentFileSelection[]>
+        getTorrentFiles(request: BittorrentGetTorrentFilesRequest): Promise<BittorrentTorrentDetailsFile[]>
         setTorrentFileSelection(request: BittorrentSetTorrentFileSelectionRequest): Promise<void>
     }
     updates: {


### PR DESCRIPTION
## Summary

- split torrent detail info and file data into dedicated IPC requests
- update qBittorrent, Transmission, Deluge, rTorrent, and mock runtimes to fetch only the requested data
- load and refresh only the active details-panel tab in the renderer

## Why

The combined details request coupled unrelated tab data and fetched file payloads even when only torrent information was visible. Dedicated contracts keep the IPC boundary focused and avoid unnecessary client requests.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "torrent-details.spec.ts"`
- Codex review subagent (no implementation defects found)