### PR TITLE
feat: add torrent trackers details tab

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,7 @@
 import request from "request"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
 import {
     defer,
     HTTP_LOGIN_TIMEOUT,
@@ -377,6 +377,21 @@ export class DelugeRuntime implements BittorrentRuntime {
             uploadSpeed: Number(peer.up_speed) || 0,
             country: typeof peer.country === "string" ? peer.country : undefined,
         }))
+    }
+
+    async getTorrentTrackers(hash: string): Promise<BittorrentTorrentDetailsTracker[]> {
+        const details = await defer<Record<string, any>>((done) => this.rpc("web.get_torrent_status", [hash, ["trackers", "tracker_status"]], done))
+        const status = typeof details.tracker_status === "string" ? details.tracker_status : undefined
+        return (Array.isArray(details.trackers) ? details.trackers : []).flatMap((tracker: any) => {
+            if (typeof tracker?.url !== "string") {
+                return []
+            }
+            return [{
+                url: tracker.url,
+                tier: typeof tracker.tier === "number" ? tracker.tier : Number(tracker.tier) || undefined,
+                status,
+            }]
+        })
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -4,6 +4,7 @@ import type {
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
+    BittorrentTorrentDetailsTracker,
     TorrentClientConnection,
 } from "@shared/ipc-contract"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
@@ -50,12 +51,14 @@ interface MockTorrentFile {
 interface MockRuntimeStore {
     torrents: Map<string, MockTorrent>
     files: Map<string, MockTorrentFile[]>
+    trackers: Map<string, BittorrentTorrentDetailsTracker[]>
     removedHashes: string[]
 }
 
 type MockTorrentInput = Partial<MockTorrent> & {
     hash?: string
     files?: MockTorrentFile[]
+    trackers?: BittorrentTorrentDetailsTracker[]
 }
 
 export class MockBittorrentRuntime implements BittorrentRuntime {
@@ -71,6 +74,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
             store = {
                 torrents: new Map<string, MockTorrent>(),
                 files: new Map<string, MockTorrentFile[]>(),
+                trackers: new Map<string, BittorrentTorrentDetailsTracker[]>(),
                 removedHashes: [],
             }
             MockBittorrentRuntime.stores.set(key, store)
@@ -133,6 +137,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
             await this.addTorrent(options?.renameTorrent || parsed.name || uri.replace(/^magnet:\?xt=urn:btih:/, "Mock Magnet "), {
                 hash: parsed.infoHash,
                 files: this.createFilesFromUploadSelection(options?.fileSelection),
+                trackers: this.createTrackersFromTorrentMetadata(parsed),
             })
         } catch {
             await this.addTorrent(options?.renameTorrent || uri.replace(/^magnet:\?xt=urn:btih:/, "Mock Magnet "), {
@@ -149,6 +154,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
             hash: parsed.infoHash,
             files: this.createFilesFromUploadSelection(options?.fileSelection)
                 || this.createFilesFromTorrentMetadata(parsedFiles),
+            trackers: this.createTrackersFromTorrentMetadata(parsed),
         })
     }
 
@@ -187,6 +193,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
             up_speed: input.up_speed ?? (index * 256),
         })
         this.files.set(hash, input.files || this.createFiles(name, size, progress))
+        this.trackers.set(hash, input.trackers || [])
         return hash
     }
 
@@ -195,6 +202,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         this.removedHashes.push(...this.torrents.keys())
         this.torrents.clear()
         this.files.clear()
+        this.trackers.clear()
     }
 
     async resume(hashes: string[]): Promise<void> {
@@ -249,6 +257,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         hashes.forEach((hash) => {
             if (this.torrents.delete(hash)) {
                 this.files.delete(hash)
+                this.trackers.delete(hash)
                 this.removedHashes.push(hash)
             }
         })
@@ -311,6 +320,11 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
             connection: "Outgoing",
             flags: "Interested, encrypted",
         }]
+    }
+
+    async getTorrentTrackers(hash: string): Promise<BittorrentTorrentDetailsTracker[]> {
+        this.assertConnected()
+        return (this.trackers.get(hash) || []).map((tracker) => ({ ...tracker }))
     }
 
     async setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]): Promise<void> {
@@ -442,6 +456,16 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         }))
     }
 
+    private createTrackersFromTorrentMetadata(metadata: unknown): BittorrentTorrentDetailsTracker[] {
+        const announce = (metadata as { announce?: unknown })?.announce
+        const urls = Array.isArray(announce) ? announce : (typeof announce === "string" ? [announce] : [])
+        return urls.filter((url): url is string => typeof url === "string").map((url, tier) => ({
+            url,
+            tier,
+            status: "Working",
+        }))
+    }
+
     private getCategories() {
         return Object.fromEntries(
             Array.from(new Set(Array.from(this.torrents.values()).map((torrent) => torrent.category)))
@@ -518,6 +542,11 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
     private get files() {
         this.assertConnected()
         return this.store!.files
+    }
+
+    private get trackers() {
+        this.assertConnected()
+        return this.store!.trackers
     }
 
     private get removedHashes() {

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -8,6 +8,7 @@ import type {
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
+    BittorrentTorrentDetailsTracker,
     TorrentClientConnection,
 } from "@shared/ipc-contract"
 import { defer, HTTP_LOGIN_TIMEOUT, HTTP_REQUEST_TIMEOUT, serverOriginUrl, serverUrl, urlPath } from "@main/lib/bittorrent/helpers"
@@ -76,6 +77,41 @@ function normalizeTorrentPeers(body: unknown): BittorrentTorrentPeer[] {
                 ? value.country_code.toUpperCase()
                 : undefined,
         }
+    })
+}
+
+function normalizeTorrentTrackers(body: unknown): BittorrentTorrentDetailsTracker[] {
+    if (!Array.isArray(body)) {
+        throw new Error("Invalid torrent trackers response")
+    }
+
+    const statuses: Record<number, string> = {
+        0: "Disabled",
+        1: "Not contacted",
+        2: "Working",
+        3: "Updating",
+        4: "Not working",
+    }
+    const optionalNumber = (value: unknown) => {
+        const numeric = typeof value === "number" ? value : Number(value)
+        return Number.isFinite(numeric) && numeric >= 0 ? numeric : undefined
+    }
+
+    return body.flatMap((value) => {
+        if (!isRecord(value) || typeof value.url !== "string") {
+            return []
+        }
+        const statusCode = optionalNumber(value.status)
+        return [{
+            url: value.url,
+            status: statusCode == null ? undefined : (statuses[statusCode] || String(statusCode)),
+            tier: optionalNumber(value.tier),
+            peers: optionalNumber(value.num_peers),
+            seeds: optionalNumber(value.num_seeds),
+            leeches: optionalNumber(value.num_leeches),
+            downloaded: optionalNumber(value.num_downloaded),
+            message: typeof value.msg === "string" ? value.msg : undefined,
+        }]
     })
 }
 
@@ -611,6 +647,19 @@ export class QBittorrentRuntime implements BittorrentRuntime {
             })
         })
         return normalizeTorrentPeers(peers)
+    }
+
+    async getTorrentTrackers(hash: string): Promise<BittorrentTorrentDetailsTracker[]> {
+        const body = await new Promise<unknown>((resolve, reject) => {
+            this.getApi().getTorrentTrackers(hash, (err: unknown, response: unknown) => {
+                if (err) {
+                    reject(err)
+                    return
+                }
+                resolve(response)
+            })
+        })
+        return normalizeTorrentTrackers(body)
     }
 
     async setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]): Promise<void> {

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -3,7 +3,7 @@ import { URL } from "node:url"
 import xmlrpc from "@electorrent/xmlrpc"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
 import { defer, HTTP_LOGIN_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { doubleArrayToHash, postfix, rtorrentFields, stringsToBooleans, stringsToNumbers, urlHostname } from "./helpers"
@@ -427,6 +427,25 @@ export class RtorrentRuntime implements BittorrentRuntime {
             uploaded: Number(peer.uploaded) || 0,
             flags: typeof peer.flags === "string" ? peer.flags : undefined,
         }))
+    }
+
+    async getTorrentTrackers(hash: string): Promise<BittorrentTorrentDetailsTracker[]> {
+        const trackers = await this.getMulticall("t.multicall", [hash, ""], rtorrentFields.trackers)
+        return trackers.flatMap((tracker) => {
+            if (typeof tracker.url !== "string") {
+                return []
+            }
+            stringsToNumbers(tracker)
+            return [{
+                url: tracker.url,
+                status: Number(tracker.enabled) === 0 ? "Disabled" : (Number(tracker.open) !== 0 ? "Working" : undefined),
+                tier: typeof tracker.group === "number" ? tracker.group : undefined,
+                seeds: typeof tracker.scrape_complete === "number" && tracker.scrape_complete >= 0 ? tracker.scrape_complete : undefined,
+                leeches: typeof tracker.scrape_incomplete === "number" && tracker.scrape_incomplete >= 0 ? tracker.scrape_incomplete : undefined,
+                downloaded: typeof tracker.scrape_downloaded === "number" && tracker.scrape_downloaded >= 0 ? tracker.scrape_downloaded : undefined,
+                lastAnnounce: typeof tracker.scrape_time_last === "number" && tracker.scrape_time_last > 0 ? tracker.scrape_time_last : undefined,
+            }]
+        })
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import https from 'https'
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentPeer, TorrentClientConnection } from '@shared/ipc-contract'
+import type { BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -357,6 +357,33 @@ export class TransmissionRuntime implements BittorrentRuntime {
             connection: peer.isIncoming ? 'Incoming' : 'Outgoing',
             flags: typeof peer.flagStr === 'string' ? peer.flagStr : undefined,
         }))
+    }
+
+    async getTorrentTrackers(hash: string): Promise<BittorrentTorrentDetailsTracker[]> {
+        const response = await this.getHttpClient().post(this.url(), {
+            arguments: {
+                ids: [hash],
+                fields: ['trackerStats'],
+            },
+            method: 'torrent-get',
+        })
+        const torrent = response?.data?.arguments?.torrents?.[0]
+        if (!torrent) {
+            throw new Error('Transmission did not return torrent trackers')
+        }
+
+        const optionalNumber = (value: unknown) => typeof value === 'number' && value >= 0 ? value : undefined
+        return (Array.isArray(torrent.trackerStats) ? torrent.trackerStats : []).map((tracker: any) => ({
+            url: tracker.announce || tracker.host || '',
+            status: tracker.lastAnnounceResult || tracker.lastScrapeResult || undefined,
+            tier: optionalNumber(tracker.tier),
+            peers: optionalNumber(tracker.lastAnnouncePeerCount),
+            seeds: optionalNumber(tracker.seederCount),
+            leeches: optionalNumber(tracker.leecherCount),
+            downloaded: optionalNumber(tracker.downloadCount),
+            lastAnnounce: optionalNumber(tracker.lastAnnounceTime),
+            nextAnnounce: optionalNumber(tracker.nextAnnounceTime),
+        })).filter((tracker: BittorrentTorrentDetailsTracker) => tracker.url)
     }
 
     private removeEmpty(obj: Record<string, any>) {

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -11,6 +11,7 @@ import type {
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
+    BittorrentTorrentDetailsTracker,
     BittorrentUploadTorrentRequest,
 } from "@shared/ipc-contract"
 import logger from "../logger"
@@ -204,6 +205,14 @@ class BittorrentManager {
             const geo = lookupCountry(peer.ip)
             return geo ? { ...peer, countryCode: geo.country, country: geo.name } : peer
         })
+    }
+
+    async getTorrentTrackers(sender: WebContents, hash: string): Promise<BittorrentTorrentDetailsTracker[]> {
+        const runtime = await this.getSession(sender)
+        if (typeof runtime.getTorrentTrackers !== "function") {
+            throw new Error("Torrent trackers not supported for this client")
+        }
+        return runtime.getTorrentTrackers(hash)
     }
 
     async setTorrentFileSelection(sender: WebContents, request: BittorrentSetTorrentFileSelectionRequest) {

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -5,6 +5,7 @@ import type {
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
+    BittorrentTorrentDetailsTracker,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
 
@@ -19,6 +20,7 @@ export interface BittorrentRuntime {
     getTorrentDetails?(hash: string): Promise<BittorrentTorrentDetailsData>
     getTorrentFiles?(hash: string): Promise<BittorrentTorrentDetailsFile[]>
     getTorrentPeers?(hash: string): Promise<BittorrentTorrentPeer[]>
+    getTorrentTrackers?(hash: string): Promise<BittorrentTorrentDetailsTracker[]>
     setTorrentFileSelection?(hash: string, files: BittorrentFileSelection[]): Promise<void>
     disconnect?(): Promise<void>
 }

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -259,6 +259,10 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
         return bittorrentManager.getTorrentPeers(event.sender, hash)
     })
 
+    ipcMain.handle(IPC_CHANNELS.bittorrent.getTorrentTrackers, async function(event: IpcMainInvokeEvent, { hash }) {
+        return bittorrentManager.getTorrentTrackers(event.sender, hash)
+    })
+
     ipcMain.handle(IPC_CHANNELS.bittorrent.setTorrentFileSelection, async function(event: IpcMainInvokeEvent, request) {
         return bittorrentManager.setTorrentFileSelection(event.sender, request)
     })

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -61,6 +61,7 @@ const electorrentBridge: ElectorrentBridge = {
         getTorrentDetails: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentDetails, request),
         getTorrentFiles: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentFiles, request),
         getTorrentPeers: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentPeers, request),
+        getTorrentTrackers: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentTrackers, request),
         setTorrentFileSelection: (request) => invoke(IPC_CHANNELS.bittorrent.setTorrentFileSelection, request),
     },
     updates: {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -209,6 +209,8 @@ import { TorrentDetailsFilesTabDirective } from "@renderer/app/directives/torren
 torrentApp.directive('torrentDetailsFilesTab', TorrentDetailsFilesTabDirective.getInstance())
 import { TorrentDetailsPeersTabDirective } from "@renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.directive";
 torrentApp.directive('torrentDetailsPeersTab', TorrentDetailsPeersTabDirective.getInstance())
+import { TorrentDetailsTrackersTabDirective } from "@renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.directive";
+torrentApp.directive('torrentDetailsTrackersTab', TorrentDetailsTrackersTabDirective.getInstance())
 import { SetLocationModalDirective } from "@renderer/app/directives/set-location-modal/set-location-modal.directive";
 torrentApp.directive('setLocationModal', SetLocationModalDirective.getInstance())
 import { TorrentSpeedModalDirective } from "@renderer/app/directives/torrent-speed-modal/torrent-speed-modal.directive";

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -67,6 +67,10 @@ export function getTorrentPeers(hash: string): Promise<BittorrentTorrentPeer[]> 
     return bridge().getTorrentPeers({ hash })
 }
 
+export function getTorrentTrackers(hash: string) {
+    return bridge().getTorrentTrackers({ hash })
+}
+
 export function setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]) {
     return bridge().setTorrentFileSelection({ hash, files })
 }

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -3,12 +3,13 @@ import type {
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
+    BittorrentTorrentDetailsTracker,
     ResolvedTorrentClientFeatures,
     TorrentClientFeatures,
     TorrentSpeedLimitOptions,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
-import { connect, getTorrentFiles as getTorrentFilesData, getTorrentPeers as getTorrentPeersData } from "./ipc"
+import { connect, getTorrentFiles as getTorrentFilesData, getTorrentPeers as getTorrentPeersData, getTorrentTrackers as getTorrentTrackersData } from "./ipc"
 
 export type { TorrentSpeedLimitOptions, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@shared/ipc-contract"
 
@@ -185,11 +186,15 @@ export interface TorrentDetailsPanelData {
     peers: {
         items: BittorrentTorrentPeer[]
     }
+    trackers: {
+        items: BittorrentTorrentDetailsTracker[]
+    }
 }
 
 export type TorrentDetailsInfoData = TorrentDetailsPanelData["info"]
 export type TorrentDetailsFilesData = TorrentDetailsPanelData["files"]
 export type TorrentDetailsPeersData = TorrentDetailsPanelData["peers"]
+export type TorrentDetailsTrackersData = TorrentDetailsPanelData["trackers"]
 
 export abstract class TorrentClient<T extends Torrent = Torrent> {
     private resolvedFeatures = DEFAULT_FEATURES
@@ -378,6 +383,16 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
         }
 
         return { items: await getTorrentPeersData(torrent.hash) }
+    }
+
+    async getTorrentDetailsTrackers(torrent: T): Promise<TorrentDetailsTrackersData> {
+        if (!this.features.torrentDetails) {
+            throw new Error("Torrent details not supported for this client")
+        }
+
+        return {
+            items: await getTorrentTrackersData(torrent.hash),
+        }
     }
 
     protected async getTorrentDetailsData(_torrent: T): Promise<BittorrentTorrentDetailsData> {

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -2,7 +2,7 @@ import { IDocumentService, IScope, IWindowService } from "angular";
 import { TorrentDetailsFileItem, TorrentDetailsPanelData } from "@renderer/app/bittorrent/torrentclient";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 
-type TorrentDetailsTab = "info" | "files" | "peers";
+type TorrentDetailsTab = "info" | "files" | "peers" | "trackers";
 
 export interface TorrentDetailsPanelScope extends IScope {
   settings: any;
@@ -22,10 +22,10 @@ export class TorrentDetailsPanelController {
   private readonly defaultPanelHeight = 320;
   private readonly minPanelHeight = 220;
   private panelHeight = this.defaultPanelHeight;
-  private loadRequestIds: Record<TorrentDetailsTab, number> = { info: 0, files: 0, peers: 0 };
-  private loadedTabs: Record<TorrentDetailsTab, boolean> = { info: false, files: false, peers: false };
-  private loadingTabs: Record<TorrentDetailsTab, boolean> = { info: false, files: false, peers: false };
-  private tabErrors: Record<TorrentDetailsTab, string | null> = { info: null, files: null, peers: null };
+  private loadRequestIds: Record<TorrentDetailsTab, number> = { info: 0, files: 0, peers: 0, trackers: 0 };
+  private loadedTabs: Record<TorrentDetailsTab, boolean> = { info: false, files: false, peers: false, trackers: false };
+  private loadingTabs: Record<TorrentDetailsTab, boolean> = { info: false, files: false, peers: false, trackers: false };
+  private tabErrors: Record<TorrentDetailsTab, string | null> = { info: null, files: null, peers: null, trackers: null };
   private stopResizeListeners?: () => void;
 
   constructor(
@@ -45,6 +45,7 @@ export class TorrentDetailsPanelController {
       info: { sections: [] },
       files: { columns: [], items: [] },
       peers: { items: [] },
+      trackers: { items: [] },
     };
 
     this.scope.$watch(
@@ -124,7 +125,9 @@ export class TorrentDetailsPanelController {
     }
     return this.scope.activeTab === "files"
       ? this.scope.panel.files.items.length > 0
-      : this.scope.panel.peers.items.length > 0;
+      : this.scope.activeTab === "peers"
+        ? this.scope.panel.peers.items.length > 0
+        : this.scope.panel.trackers.items.length > 0;
   }
 
   stateMessageIcon() {
@@ -212,7 +215,9 @@ export class TorrentDetailsPanelController {
         ? await client?.getTorrentDetails(torrent)
         : tab === "files"
           ? await client?.getTorrentDetailsFiles(torrent)
-          : await client?.getTorrentDetailsPeers(torrent);
+          : tab === "peers"
+            ? await client?.getTorrentDetailsPeers(torrent)
+            : await client?.getTorrentDetailsTrackers(torrent);
       if (requestId !== this.loadRequestIds[tab] || this.scope.torrent !== torrent) {
         return;
       }
@@ -222,8 +227,10 @@ export class TorrentDetailsPanelController {
           this.scope.panel.info = data as TorrentDetailsPanelData["info"];
         } else if (tab === "files") {
           this.scope.panel.files = data as TorrentDetailsPanelData["files"];
-        } else {
+        } else if (tab === "peers") {
           this.scope.panel.peers = data as TorrentDetailsPanelData["peers"];
+        } else {
+          this.scope.panel.trackers = data as TorrentDetailsPanelData["trackers"];
         }
       }
       this.loadedTabs[tab] = true;
@@ -276,9 +283,10 @@ export class TorrentDetailsPanelController {
     this.loadRequestIds.info += 1;
     this.loadRequestIds.files += 1;
     this.loadRequestIds.peers += 1;
-    this.loadedTabs = { info: false, files: false, peers: false };
-    this.loadingTabs = { info: false, files: false, peers: false };
-    this.tabErrors = { info: null, files: null, peers: null };
+    this.loadRequestIds.trackers += 1;
+    this.loadedTabs = { info: false, files: false, peers: false, trackers: false };
+    this.loadingTabs = { info: false, files: false, peers: false, trackers: false };
+    this.tabErrors = { info: null, files: null, peers: null, trackers: null };
     this.scope.loading = false;
     this.scope.error = null;
     this.scope.torrent = null;
@@ -286,6 +294,7 @@ export class TorrentDetailsPanelController {
       info: { sections: [] },
       files: { columns: [], items: [] },
       peers: { items: [] },
+      trackers: { items: [] },
     };
   }
 }

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -26,6 +26,14 @@
     >
       Peers
     </a>
+    <a
+      class="item"
+      data-role="torrent-details-tab-trackers"
+      ng-class="{ active: ctl.isActiveTab('trackers') }"
+      ng-click="ctl.showTab('trackers')"
+    >
+      Trackers
+    </a>
     <div class="right menu">
       <a
         class="item"
@@ -68,5 +76,9 @@
       ng-if="!ctl.showStateMessage() && ctl.isActiveTab('peers')"
       peers="ctl.scope.panel.peers"
     ></torrent-details-peers-tab>
+    <torrent-details-trackers-tab
+      ng-if="!ctl.showStateMessage() && ctl.isActiveTab('trackers')"
+      trackers="ctl.scope.panel.trackers.items"
+    ></torrent-details-trackers-tab>
   </div>
 </div>

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.directive.ts
@@ -1,0 +1,14 @@
+import { IDirective, IDirectiveFactory } from "angular";
+import html from "./torrent-details-trackers-tab.template.html";
+
+export class TorrentDetailsTrackersTabDirective implements IDirective {
+  template = html;
+  restrict = "E";
+  scope = {
+    trackers: "<",
+  };
+
+  static getInstance(): IDirectiveFactory {
+    return () => new TorrentDetailsTrackersTabDirective();
+  }
+}

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
@@ -1,0 +1,35 @@
+<div class="torrent-details-trackers" data-role="torrent-details-trackers">
+  <table class="ui compact single line unstackable table" data-role="torrent-details-trackers-table">
+    <thead>
+      <tr>
+        <th>URL</th>
+        <th>Status</th>
+        <th>Tier</th>
+        <th>Peers</th>
+        <th>Seeds</th>
+        <th>Leeches</th>
+        <th>Downloaded</th>
+        <th>Last announce</th>
+        <th>Next announce</th>
+        <th>Message</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="tracker in trackers track by $index" data-tracker-url="{{ tracker.url }}">
+        <td class="torrent-details-tracker-url" title="{{ tracker.url }}">{{ tracker.url }}</td>
+        <td>{{ tracker.status }}</td>
+        <td>{{ tracker.tier }}</td>
+        <td>{{ tracker.peers }}</td>
+        <td>{{ tracker.seeds }}</td>
+        <td>{{ tracker.leeches }}</td>
+        <td>{{ tracker.downloaded }}</td>
+        <td>{{ tracker.lastAnnounce ? (tracker.lastAnnounce | epoch) : '' }}</td>
+        <td>{{ tracker.nextAnnounce ? (tracker.nextAnnounce | epoch) : '' }}</td>
+        <td title="{{ tracker.message }}">{{ tracker.message }}</td>
+      </tr>
+      <tr ng-if="!trackers.length">
+        <td colspan="10">No trackers available.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -716,6 +716,7 @@ torrent-sidebar + .main-panel {
         torrent-details-info-tab,
         torrent-details-files-tab,
         torrent-details-peers-tab {
+        torrent-details-trackers-tab {
             display: flex;
             flex: 1 1 auto;
             min-height: 0;
@@ -753,6 +754,7 @@ torrent-sidebar + .main-panel {
         .torrent-details-files-content,
         .torrent-details-peers,
         .torrent-details-peers-content {
+        .torrent-details-trackers {
             flex: 1 1 auto;
             height: 100%;
             min-height: 0;
@@ -879,6 +881,26 @@ torrent-sidebar + .main-panel {
             min-height: 0;
             overflow-x: auto;
             overflow-y: auto;
+        }
+
+        .torrent-details-trackers {
+            overflow: auto;
+
+            .table {
+                margin: 0;
+            }
+
+            th,
+            td {
+                white-space: nowrap;
+            }
+
+            .torrent-details-tracker-url {
+                min-width: 260px;
+                max-width: 520px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
         }
 
         .torrent-details-files {

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -715,7 +715,7 @@ torrent-sidebar + .main-panel {
 
         torrent-details-info-tab,
         torrent-details-files-tab,
-        torrent-details-peers-tab {
+        torrent-details-peers-tab,
         torrent-details-trackers-tab {
             display: flex;
             flex: 1 1 auto;
@@ -753,7 +753,7 @@ torrent-sidebar + .main-panel {
         .torrent-details-files,
         .torrent-details-files-content,
         .torrent-details-peers,
-        .torrent-details-peers-content {
+        .torrent-details-peers-content,
         .torrent-details-trackers {
             flex: 1 1 auto;
             height: 100%;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -103,6 +103,10 @@ export interface BittorrentGetTorrentPeersRequest {
     hash: string
 }
 
+export interface BittorrentGetTorrentTrackersRequest {
+    hash: string
+}
+
 export type BittorrentTorrentDetailsPrimitive = string | number | boolean | null
 
 export interface BittorrentGetTorrentDetailsRequest {
@@ -119,6 +123,19 @@ export interface BittorrentTorrentDetailsFile {
     priority?: number
     wanted: boolean
     isSeed?: boolean
+}
+
+export interface BittorrentTorrentDetailsTracker {
+    url: string
+    status?: string
+    tier?: number
+    peers?: number
+    seeds?: number
+    leeches?: number
+    downloaded?: number
+    message?: string
+    lastAnnounce?: number
+    nextAnnounce?: number
 }
 
 export interface BittorrentTorrentDetailsData {
@@ -408,6 +425,7 @@ export interface ElectorrentBridge {
         getTorrentDetails(request: BittorrentGetTorrentDetailsRequest): Promise<BittorrentTorrentDetailsData>
         getTorrentFiles(request: BittorrentGetTorrentFilesRequest): Promise<BittorrentTorrentDetailsFile[]>
         getTorrentPeers(request: BittorrentGetTorrentPeersRequest): Promise<BittorrentTorrentPeer[]>
+        getTorrentTrackers(request: BittorrentGetTorrentTrackersRequest): Promise<BittorrentTorrentDetailsTracker[]>
         setTorrentFileSelection(request: BittorrentSetTorrentFileSelectionRequest): Promise<void>
     }
     updates: {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -36,6 +36,7 @@ export const IPC_CHANNELS = {
         getTorrentDetails: 'bittorrent:get-torrent-details',
         getTorrentFiles: 'bittorrent:get-torrent-files',
         getTorrentPeers: 'bittorrent:get-torrent-peers',
+        getTorrentTrackers: 'bittorrent:get-torrent-trackers',
         setTorrentFileSelection: 'bittorrent:set-torrent-file-selection',
     },
     updates: {

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -169,7 +169,7 @@ export class Torrent {
     return panel
   }
 
-  async openDetailsTab(tab: "info" | "files" | "peers") {
+  async openDetailsTab(tab: "info" | "files" | "peers" | "trackers") {
     const panel = $("[data-role='torrent-details-panel']")
     await panel.waitForDisplayed({ timeout: this.timeout })
 

--- a/test/shared/opentracker/peer/rootfs/usr/local/bin/gen-torrent
+++ b/test/shared/opentracker/peer/rootfs/usr/local/bin/gen-torrent
@@ -4,6 +4,7 @@ set -e
 
 FILE_PATHS=()
 FILE_SIZES=()
+TRACKER_URLS=()
 
 # Parse CLI options for upload speed, download speed, file contents, torrent file name, and tracker URL
 while [[ "$#" -gt 0 ]]; do
@@ -14,7 +15,7 @@ while [[ "$#" -gt 0 ]]; do
         --file-size) FILE_SIZE="$2"; shift ;;
         --file) FILE_PATHS+=("$2"); FILE_SIZES+=("$3"); shift 2 ;;
         --torrent-name) TORRENT_NAME="$2"; shift ;;
-        --tracker-url) TRACKER_URL="$2"; shift ;;
+        --tracker-url) TRACKER_URLS+=("$2"); shift ;;
         *) echo >&2 "Usage: $0 [--foreground] [--upload-speed <up-speed>] [--download-speed <dl-speed>] [--file-size <file-size> | --file <path> <size> ...] --torrent-name <torrent-name> [--tracker-url <tracker-url>]"; exit 1 ;;
     esac
     shift
@@ -22,7 +23,10 @@ done
 
 # Set default values if not provided
 FILE_SIZE="${FILE_SIZE:-1}"
-TRACKER_URL="${TRACKER_URL:-http://tracker:6969/announce}"
+if [ "${#TRACKER_URLS[@]}" -eq 0 ]; then
+    TRACKER_URLS=("http://tracker:6969/announce")
+fi
+TRACKER_URL=$(IFS=,; echo "${TRACKER_URLS[*]}")
 if [ "${#FILE_PATHS[@]}" -gt 0 ]; then
     CONTENT_PATH="/srv/$TORRENT_NAME"
     rm -rf "$CONTENT_PATH"

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -6,6 +6,11 @@ import { configureSpec, formatBytes, getTestFixture, requireFeature } from "../.
 import { createTorrentFile } from "../../torrent"
 
 const tracker = getTestFixture().tracker
+const trackerUrls = [
+  "http://tracker-one.test:6969/announce",
+  "http://tracker-two.test:6969/announce",
+  "http://tracker-three.test:6969/announce",
+]
 describe("torrent details", function () {
   configureSpec()
   requireFeature(({ features }) => features.torrentDetails === true)
@@ -22,6 +27,7 @@ describe("torrent details", function () {
       },
       downloadSpeed: 1,
       uploadSpeed: 1,
+      trackerUrls,
     })
     torrentMetadata = parseTorrent(fs.readFileSync(filename)) as parseTorrent.Instance
     torrent = await this.app.uploadTorrent({ filename })
@@ -89,6 +95,26 @@ describe("torrent details", function () {
     await folderRow.$(".torrent-details-folder-toggle").click()
     await eventually(async () => (await filesTab.$$("tbody tr")).length)
       .satisfies("decrease after collapsing a folder", (count) => count < rowCountBeforeCollapse)
+
+    await torrent.closeDetailsPanel()
+  })
+
+  it("shows every torrent tracker in the trackers tab", async function () {
+    this.timeout(60 * 1000)
+
+    const panel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("trackers")
+
+    const trackersTab = panel.$("[data-role='torrent-details-trackers']")
+    await eventually(() => trackersTab.getText()).satisfies(
+      "contain every configured tracker",
+      (text) => trackerUrls.every((url) => text.includes(url)),
+      { timeout: 30_000 },
+    )
+
+    const trackerRows = await trackersTab.$$("tbody tr[data-tracker-url]")
+    const displayedUrls = await trackerRows.map((row) => row.getAttribute("data-tracker-url"))
+    trackerUrls.forEach((url) => displayedUrls.should.contain(url))
 
     await torrent.closeDetailsPanel()
   })

--- a/test/torrent.ts
+++ b/test/torrent.ts
@@ -17,6 +17,7 @@ export async function createTorrentFile(tracker: DockerComposeService, options: 
     downloadSpeed?: number;
     uploadSpeed?: number;
     trackerUrl?: string;
+    trackerUrls?: string[];
 }): Promise<string> {
     const randomString = Math.random().toString(36).substring(2, 10);
     const torrentName = options.torrentName || `test-torrent-${randomString}`;
@@ -40,6 +41,9 @@ export async function createTorrentFile(tracker: DockerComposeService, options: 
     }
     if (options.trackerUrl) {
         cmd.push("--tracker-url", options.trackerUrl);
+    }
+    for (const trackerUrl of options.trackerUrls || []) {
+        cmd.push("--tracker-url", trackerUrl);
     }
     await tracker.exec(cmd);
     const torrentPath = path.join(__dirname, `shared/opentracker/data/shared/${torrentName}.torrent`)


### PR DESCRIPTION
## What changed

Adds a Trackers tab to torrent details, backed by a common IPC contract and client-native tracker queries for qBittorrent, Transmission, Deluge, rTorrent, and the mock runtime.

The tab renders tracker URL, status, tier, swarm counts, announce times, and messages. Test fixtures can now create multi-tracker torrents using compose aliases.

## Why

Users need per-tracker state for the selected torrent without client-specific UI behavior.

## Validation

- npm run lint
- npm run build
- torrent-details E2E spec: qBittorrent, Transmission, Deluge, and rTorrent