### PR TITLE
feat(details): add torrent peers tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "electron-regedit": "^2.0.0",
+        "geoip-country": "^5.0.202607180103",
         "less": "^4.4.1",
         "q": "^1.5.1",
         "winreg": "^1.2.2"
@@ -6326,7 +6327,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -7693,6 +7693,12 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "node_modules/countries-list": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/countries-list/-/countries-list-3.4.1.tgz",
+      "integrity": "sha512-sKLGAZD5EAdzQwQ19vOp/9u33MTjmZ0CkdXPYtp/An6cyIlJ/E8TwGf2FcPe1AnzHO+h7nbTfoHyXIi58Hpa+Q==",
+      "license": "MIT"
     },
     "node_modules/crc": {
       "version": "3.8.0",
@@ -10790,7 +10796,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -11154,6 +11159,60 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/geoip-country": {
+      "version": "5.0.202607180103",
+      "resolved": "https://registry.npmjs.org/geoip-country/-/geoip-country-5.0.202607180103.tgz",
+      "integrity": "sha512-UlOfSeHs8P9M5nukx5hPH9oKGFZ7ch4RkC7C+Gut6i84lmWHiPk4zVrm+clnYTSdyYkRpyFjrBF7xitJUxpb3Q==",
+      "license": "MaxMind GeoLite2 License",
+      "dependencies": {
+        "async": "^2.6.4",
+        "countries-list": "^3.1.1",
+        "ip-address": "^6.4.0",
+        "yauzl": "^2.10.0"
+      },
+      "engines": {
+        "node": ">=10.20.0"
+      }
+    },
+    "node_modules/geoip-country/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/geoip-country/node_modules/ip-address": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.4.0.tgz",
+      "integrity": "sha512-c5uxc2WUTuRBVHT/6r4m7HIr/DfV0bF6DvLH3iZGSK8wp8iMwwZSgIq2do0asFf8q9ECug0SE+6+1ACMe4sorA==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "lodash.find": "4.6.0",
+        "lodash.max": "4.0.1",
+        "lodash.merge": "4.6.2",
+        "lodash.padstart": "4.6.1",
+        "lodash.repeat": "4.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/geoip-country/node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
+    "node_modules/geoip-country/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/geometry-interfaces": {
       "version": "1.1.4",
@@ -12885,7 +12944,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.assign": {
@@ -12901,6 +12959,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -12908,17 +12972,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw==",
+      "license": "MIT"
     },
     "node_modules/lodash.pickby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.repeat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
+      "integrity": "sha512-eWsgQW89IewS95ZOcr15HHCX6FVDxq3f2PNUIng3fyzsPev9imFQxIYdFZ6crl8L56UR6ZlGDLcEb3RZsCSSqw==",
       "license": "MIT"
     },
     "node_modules/lodash.union": {
@@ -15075,8 +15156,7 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -19503,7 +19583,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "tympanix",
   "dependencies": {
     "electron-regedit": "^2.0.0",
+    "geoip-country": "^5.0.202607180103",
     "less": "^4.4.1",
     "q": "^1.5.1",
     "winreg": "^1.2.2"

--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,7 @@
 import request from "request"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
 import {
     defer,
     HTTP_LOGIN_TIMEOUT,
@@ -257,6 +257,7 @@ export class DelugeRuntime implements BittorrentRuntime {
                 labels: this.supportsLabels,
                 uploadFileSelection: true,
                 torrentDetails: true,
+                torrentPeers: true,
                 speedLimits: true,
                 ratioLimits: true,
                 freeDiskSpace: true,
@@ -363,6 +364,19 @@ export class DelugeRuntime implements BittorrentRuntime {
                     wanted: priority !== 0,
                 }
             })
+    }
+
+    async getTorrentPeers(hash: string): Promise<BittorrentTorrentPeer[]> {
+        const details = await defer<Record<string, any>>((done) => this.rpc("web.get_torrent_status", [hash, ["peers"]], done))
+        return (Array.isArray(details.peers) ? details.peers : []).map((peer: any) => ({
+            ip: typeof peer.ip === "string" ? peer.ip : "",
+            port: Number(peer.port) || undefined,
+            client: typeof peer.client === "string" ? peer.client : "",
+            progress: Number(peer.progress) || (peer.seed ? 1 : 0),
+            downloadSpeed: Number(peer.down_speed) || 0,
+            uploadSpeed: Number(peer.up_speed) || 0,
+            country: typeof peer.country === "string" ? peer.country : undefined,
+        }))
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -3,6 +3,7 @@ import type {
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
+    BittorrentTorrentPeer,
     TorrentClientConnection,
 } from "@shared/ipc-contract"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
@@ -87,6 +88,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
                 uploadFileSelection: true,
                 setLocation: true,
                 torrentDetails: true,
+                torrentPeers: true,
                 ratioLimits: true,
                 freeDiskSpace: true,
                 uploadOptions: {
@@ -289,6 +291,26 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
             priority: file.priority,
             isSeed: file.is_seed,
         }))
+    }
+
+    async getTorrentPeers(hash: string): Promise<BittorrentTorrentPeer[]> {
+        this.assertConnected()
+        if (!this.torrents.has(hash)) {
+            throw new Error("Mock torrent not found")
+        }
+
+        return [{
+            ip: "8.8.8.8",
+            port: 6881,
+            client: "Mock Peer 1.0",
+            progress: 0.75,
+            downloadSpeed: 128 * 1024,
+            uploadSpeed: 32 * 1024,
+            downloaded: 750 * 1024 * 1024,
+            uploaded: 250 * 1024 * 1024,
+            connection: "Outgoing",
+            flags: "Interested, encrypted",
+        }]
     }
 
     async setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]): Promise<void> {

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
@@ -43,6 +43,12 @@ export class QBittorrentApiV1 extends QBittorrentBaseApi {
         })
     }
 
+    getTorrentPeers(hash: string, cb: (err?: any, body?: any) => void) {
+        this.getJson(`query/propertiesPeers/${hash}`, {}, (err, res, body) => {
+            this.handleError(cb, TORRENT_ERRORS)(err, res, body)
+        })
+    }
+
     addTorrentFileContent(content: Buffer | Uint8Array, filename: string, options: Record<string, any> | undefined, cb: (err?: any, body?: any) => void) {
         const formData = {
             torrents: {

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
@@ -52,6 +52,12 @@ export class QBittorrentApiV2 extends QBittorrentBaseApi {
         })
     }
 
+    getTorrentPeers(hash: string, cb: (err?: any, body?: any) => void) {
+        this.getJson("sync/torrentPeers", { qs: { hash } }, (err, res, body) => {
+            this.handleError(cb, TORRENT_ERRORS)(err, res, body)
+        })
+    }
+
     addTorrentFileContent(content: Buffer | Uint8Array, filename: string, options: Record<string, any> | undefined, cb: (err?: any, body?: any) => void) {
         const formData = {
             torrents: {

--- a/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
@@ -143,6 +143,7 @@ export abstract class QBittorrentBaseApi {
     abstract syncMaindata(cb: (err?: any, body?: any) => void): void
 
     abstract getTorrentTrackers(hash: string, cb: (err?: any, body?: any) => void): void
+    abstract getTorrentPeers(hash: string, cb: (err?: any, body?: any) => void): void
 
     abstract addTorrentFileContent(content: Buffer | Uint8Array, filename: string, options: Record<string, any> | undefined, cb: (err?: any, body?: any) => void): void
 

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -7,6 +7,7 @@ import type {
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
+    BittorrentTorrentPeer,
     TorrentClientConnection,
 } from "@shared/ipc-contract"
 import { defer, HTTP_LOGIN_TIMEOUT, HTTP_REQUEST_TIMEOUT, serverOriginUrl, serverUrl, urlPath } from "@main/lib/bittorrent/helpers"
@@ -45,6 +46,35 @@ function normalizeTorrentDetailsFiles(body: unknown): BittorrentTorrentDetailsFi
             priority,
             wanted: priority !== QBITTORRENT_PRIORITY_SKIP,
             isSeed: Boolean(value.is_seed),
+        }
+    })
+}
+
+function normalizeTorrentPeers(body: unknown): BittorrentTorrentPeer[] {
+    if (!isRecord(body)) {
+        throw new Error("Invalid torrent peers response")
+    }
+
+    return Object.values(body).map((value) => {
+        if (!isRecord(value)) {
+            throw new Error("Invalid torrent peer response")
+        }
+
+        return {
+            ip: typeof value.ip === "string" ? value.ip : "",
+            port: typeof value.port === "number" ? value.port : Number(value.port) || undefined,
+            client: typeof value.client === "string" ? value.client : "",
+            progress: typeof value.progress === "number" ? value.progress : Number(value.progress) || 0,
+            downloadSpeed: typeof value.dl_speed === "number" ? value.dl_speed : Number(value.dl_speed) || 0,
+            uploadSpeed: typeof value.up_speed === "number" ? value.up_speed : Number(value.up_speed) || 0,
+            downloaded: typeof value.downloaded === "number" ? value.downloaded : Number(value.downloaded) || 0,
+            uploaded: typeof value.uploaded === "number" ? value.uploaded : Number(value.uploaded) || 0,
+            connection: typeof value.connection === "string" ? value.connection : undefined,
+            flags: typeof value.flags_desc === "string" ? value.flags_desc : (typeof value.flags === "string" ? value.flags : undefined),
+            country: typeof value.country === "string" ? value.country : undefined,
+            countryCode: typeof value.country_code === "string" && /^[a-z]{2}$/i.test(value.country_code)
+                ? value.country_code.toUpperCase()
+                : undefined,
         }
     })
 }
@@ -124,6 +154,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 uploadFileSelection: true,
                 setLocation: true,
                 torrentDetails: true,
+                torrentPeers: true,
                 trackerFilter: true,
                 alternativeSpeedLimits: true,
                 speedLimits: true,
@@ -566,6 +597,20 @@ export class QBittorrentRuntime implements BittorrentRuntime {
 
     async getTorrentFiles(hash: string): Promise<BittorrentTorrentDetailsFile[]> {
         return normalizeTorrentDetailsFiles(await this.fetchTorrentFiles(hash))
+    }
+
+    async getTorrentPeers(hash: string): Promise<BittorrentTorrentPeer[]> {
+        const api = this.getApi()
+        const peers = await new Promise<unknown>((resolve, reject) => {
+            api.getTorrentPeers(hash, (err: unknown, body: unknown) => {
+                if (err) {
+                    reject(err)
+                    return
+                }
+                resolve(isRecord(body) && isRecord(body.peers) ? body.peers : body)
+            })
+        })
+        return normalizeTorrentPeers(peers)
     }
 
     async setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]): Promise<void> {

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -3,7 +3,7 @@ import { URL } from "node:url"
 import xmlrpc from "@electorrent/xmlrpc"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
 import { defer, HTTP_LOGIN_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { doubleArrayToHash, postfix, rtorrentFields, stringsToBooleans, stringsToNumbers, urlHostname } from "./helpers"
@@ -217,6 +217,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
                 labels: true,
                 uploadFileSelection: true,
                 torrentDetails: true,
+                torrentPeers: true,
                 trackerFilter: true,
                 speedLimits: true,
                 uploadOptions: {
@@ -401,6 +402,31 @@ export class RtorrentRuntime implements BittorrentRuntime {
                     wanted: priority !== 0,
                 }
             })
+    }
+
+    async getTorrentPeers(hash: string): Promise<BittorrentTorrentPeer[]> {
+        const peers = await this.getMulticall("p.multicall", [hash, ""], {
+            ip: "p.address",
+            port: "p.port",
+            client: "p.client_version",
+            progress: "p.completed_percent",
+            downloadSpeed: "p.down_rate",
+            uploadSpeed: "p.up_rate",
+            downloaded: "p.down_total",
+            uploaded: "p.up_total",
+            flags: "p.flags",
+        })
+        return peers.map((peer) => ({
+            ip: typeof peer.ip === "string" ? peer.ip : "",
+            port: Number(peer.port) || undefined,
+            client: typeof peer.client === "string" ? peer.client : "",
+            progress: Math.max(0, Math.min(1, (Number(peer.progress) || 0) / 100)),
+            downloadSpeed: Number(peer.downloadSpeed) || 0,
+            uploadSpeed: Number(peer.uploadSpeed) || 0,
+            downloaded: Number(peer.downloaded) || 0,
+            uploaded: Number(peer.uploaded) || 0,
+            flags: typeof peer.flags === "string" ? peer.flags : undefined,
+        }))
     }
 
     async addTorrentUrl(uri: string, options?: Record<string, any>): Promise<void> {

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import https from 'https'
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, TorrentClientConnection } from '@shared/ipc-contract'
+import type { BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentPeer, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -210,6 +210,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
                 uploadFileSelection: true,
                 setLocation: true,
                 torrentDetails: true,
+                torrentPeers: true,
                 trackerFilter: true,
                 speedLimits: true,
                 ratioLimits: true,
@@ -334,6 +335,28 @@ export class TransmissionRuntime implements BittorrentRuntime {
                     wanted: Boolean(stats.wanted ?? wanted[index] ?? true),
                 }
             })
+    }
+
+    async getTorrentPeers(hash: string): Promise<BittorrentTorrentPeer[]> {
+        const response = await this.getHttpClient().post(this.url(), {
+            arguments: { ids: [hash], fields: ['peers'] },
+            method: 'torrent-get',
+        })
+        const torrent = response?.data?.arguments?.torrents?.[0]
+        if (!torrent) {
+            throw new Error('Transmission did not return torrent peers')
+        }
+
+        return (Array.isArray(torrent.peers) ? torrent.peers : []).map((peer: any) => ({
+            ip: typeof peer.address === 'string' ? peer.address : '',
+            port: Number(peer.port) || undefined,
+            client: typeof peer.clientName === 'string' ? peer.clientName : '',
+            progress: Number(peer.progress) || 0,
+            downloadSpeed: Number(peer.rateToClient) || 0,
+            uploadSpeed: Number(peer.rateToPeer) || 0,
+            connection: peer.isIncoming ? 'Incoming' : 'Outgoing',
+            flags: typeof peer.flagStr === 'string' ? peer.flagStr : undefined,
+        }))
     }
 
     private removeEmpty(obj: Record<string, any>) {

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -1,6 +1,7 @@
 import fs from "fs"
 import path from "path"
 import type { WebContents } from "electron"
+import { lookup as lookupCountry } from "geoip-country"
 import type {
     BittorrentAddTorrentUrlRequest,
     BittorrentInvokeActionRequest,
@@ -9,6 +10,7 @@ import type {
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
+    BittorrentTorrentPeer,
     BittorrentUploadTorrentRequest,
 } from "@shared/ipc-contract"
 import logger from "../logger"
@@ -185,6 +187,23 @@ class BittorrentManager {
             throw new Error("Torrent files not supported for this client")
         }
         return runtime.getTorrentFiles(hash)
+    }
+
+    async getTorrentPeers(sender: WebContents, hash: string): Promise<BittorrentTorrentPeer[]> {
+        const runtime = await this.getSession(sender)
+        if (typeof runtime.getTorrentPeers !== "function") {
+            throw new Error("Torrent peers not supported for this client")
+        }
+
+        const peers = await runtime.getTorrentPeers(hash)
+        return peers.map((peer) => {
+            if (peer.countryCode && peer.country) {
+                return peer
+            }
+
+            const geo = lookupCountry(peer.ip)
+            return geo ? { ...peer, countryCode: geo.country, country: geo.name } : peer
+        })
     }
 
     async setTorrentFileSelection(sender: WebContents, request: BittorrentSetTorrentFileSelectionRequest) {

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -4,6 +4,7 @@ import type {
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
+    BittorrentTorrentPeer,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
 
@@ -17,6 +18,7 @@ export interface BittorrentRuntime {
     setLocation?(hashes: string[], location: string): Promise<void>
     getTorrentDetails?(hash: string): Promise<BittorrentTorrentDetailsData>
     getTorrentFiles?(hash: string): Promise<BittorrentTorrentDetailsFile[]>
+    getTorrentPeers?(hash: string): Promise<BittorrentTorrentPeer[]>
     setTorrentFileSelection?(hash: string, files: BittorrentFileSelection[]): Promise<void>
     disconnect?(): Promise<void>
 }

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -255,6 +255,10 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
         return bittorrentManager.getTorrentFiles(event.sender, hash)
     })
 
+    ipcMain.handle(IPC_CHANNELS.bittorrent.getTorrentPeers, async function(event: IpcMainInvokeEvent, { hash }) {
+        return bittorrentManager.getTorrentPeers(event.sender, hash)
+    })
+
     ipcMain.handle(IPC_CHANNELS.bittorrent.setTorrentFileSelection, async function(event: IpcMainInvokeEvent, request) {
         return bittorrentManager.setTorrentFileSelection(event.sender, request)
     })

--- a/src/main/types/geoip-country.d.ts
+++ b/src/main/types/geoip-country.d.ts
@@ -1,0 +1,8 @@
+declare module "geoip-country" {
+    interface GeoIpCountryResult {
+        country: string
+        name: string
+    }
+
+    export function lookup(ip: string): GeoIpCountryResult | null
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -60,6 +60,7 @@ const electorrentBridge: ElectorrentBridge = {
         invokeAction: (request) => invoke(IPC_CHANNELS.bittorrent.invokeAction, request),
         getTorrentDetails: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentDetails, request),
         getTorrentFiles: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentFiles, request),
+        getTorrentPeers: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentPeers, request),
         setTorrentFileSelection: (request) => invoke(IPC_CHANNELS.bittorrent.setTorrentFileSelection, request),
     },
     updates: {

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -207,6 +207,8 @@ import { TorrentDetailsInfoTabDirective } from "@renderer/app/directives/torrent
 torrentApp.directive('torrentDetailsInfoTab', TorrentDetailsInfoTabDirective.getInstance())
 import { TorrentDetailsFilesTabDirective } from "@renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.directive";
 torrentApp.directive('torrentDetailsFilesTab', TorrentDetailsFilesTabDirective.getInstance())
+import { TorrentDetailsPeersTabDirective } from "@renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.directive";
+torrentApp.directive('torrentDetailsPeersTab', TorrentDetailsPeersTabDirective.getInstance())
 import { SetLocationModalDirective } from "@renderer/app/directives/set-location-modal/set-location-modal.directive";
 torrentApp.directive('setLocationModal', SetLocationModalDirective.getInstance())
 import { TorrentSpeedModalDirective } from "@renderer/app/directives/torrent-speed-modal/torrent-speed-modal.directive";

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -2,6 +2,7 @@ import type {
     BittorrentTorrentDetailsData,
     ElectorrentBridge,
     BittorrentFileSelection,
+    BittorrentTorrentPeer,
     BittorrentServerConfig,
     TorrentClientConnection,
     TorrentUploadOptions,
@@ -60,6 +61,10 @@ export function getTorrentDetails(hash: string): Promise<BittorrentTorrentDetail
 
 export function getTorrentFiles(hash: string) {
     return bridge().getTorrentFiles({ hash })
+}
+
+export function getTorrentPeers(hash: string): Promise<BittorrentTorrentPeer[]> {
+    return bridge().getTorrentPeers({ hash })
 }
 
 export function setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]) {

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -2,12 +2,13 @@ import { Torrent, TorrentFile } from "./abstracttorrent"
 import type {
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
+    BittorrentTorrentPeer,
     ResolvedTorrentClientFeatures,
     TorrentClientFeatures,
     TorrentSpeedLimitOptions,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
-import { connect, getTorrentFiles as getTorrentFilesData } from "./ipc"
+import { connect, getTorrentFiles as getTorrentFilesData, getTorrentPeers as getTorrentPeersData } from "./ipc"
 
 export type { TorrentSpeedLimitOptions, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@shared/ipc-contract"
 
@@ -58,6 +59,7 @@ const DEFAULT_FEATURES: ResolvedTorrentClientFeatures = Object.freeze({
     uploadFileSelection: false,
     setLocation: false,
     torrentDetails: false,
+    torrentPeers: false,
     trackerFilter: false,
     alternativeSpeedLimits: false,
     speedLimits: false,
@@ -180,10 +182,14 @@ export interface TorrentDetailsPanelData {
         columns: TorrentDetailsFileColumn[]
         items: TorrentDetailsFileItem[]
     }
+    peers: {
+        items: BittorrentTorrentPeer[]
+    }
 }
 
 export type TorrentDetailsInfoData = TorrentDetailsPanelData["info"]
 export type TorrentDetailsFilesData = TorrentDetailsPanelData["files"]
+export type TorrentDetailsPeersData = TorrentDetailsPanelData["peers"]
 
 export abstract class TorrentClient<T extends Torrent = Torrent> {
     private resolvedFeatures = DEFAULT_FEATURES
@@ -364,6 +370,14 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
             columns: this.getTorrentDetailsFilesColumns(torrent),
             items: files.map((file) => this.mapTorrentDetailsFile(torrent, file)),
         }
+    }
+
+    async getTorrentDetailsPeers(torrent: T): Promise<TorrentDetailsPeersData> {
+        if (!this.features.torrentPeers) {
+            throw new Error("Torrent peers not supported for this client")
+        }
+
+        return { items: await getTorrentPeersData(torrent.hash) }
     }
 
     protected async getTorrentDetailsData(_torrent: T): Promise<BittorrentTorrentDetailsData> {

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -2,6 +2,8 @@ import { IDocumentService, IScope, IWindowService } from "angular";
 import { TorrentDetailsFileItem, TorrentDetailsPanelData } from "@renderer/app/bittorrent/torrentclient";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 
+type TorrentDetailsTab = "info" | "files" | "peers";
+
 export interface TorrentDetailsPanelScope extends IScope {
   settings: any;
   isOpen: boolean;
@@ -9,7 +11,7 @@ export interface TorrentDetailsPanelScope extends IScope {
   error: string | null;
   torrent: any;
   panel: TorrentDetailsPanelData;
-  activeTab: "info" | "files";
+  activeTab: TorrentDetailsTab;
   resizeMode: string;
   resizeProfile: string;
 }
@@ -20,10 +22,10 @@ export class TorrentDetailsPanelController {
   private readonly defaultPanelHeight = 320;
   private readonly minPanelHeight = 220;
   private panelHeight = this.defaultPanelHeight;
-  private loadRequestIds = { info: 0, files: 0 };
-  private loadedTabs = { info: false, files: false };
-  private loadingTabs = { info: false, files: false };
-  private tabErrors: Record<"info" | "files", string | null> = { info: null, files: null };
+  private loadRequestIds: Record<TorrentDetailsTab, number> = { info: 0, files: 0, peers: 0 };
+  private loadedTabs: Record<TorrentDetailsTab, boolean> = { info: false, files: false, peers: false };
+  private loadingTabs: Record<TorrentDetailsTab, boolean> = { info: false, files: false, peers: false };
+  private tabErrors: Record<TorrentDetailsTab, string | null> = { info: null, files: null, peers: null };
   private stopResizeListeners?: () => void;
 
   constructor(
@@ -42,6 +44,7 @@ export class TorrentDetailsPanelController {
     this.scope.panel = {
       info: { sections: [] },
       files: { columns: [], items: [] },
+      peers: { items: [] },
     };
 
     this.scope.$watch(
@@ -99,7 +102,7 @@ export class TorrentDetailsPanelController {
     this.resetPanelState();
   }
 
-  showTab(tab: "info" | "files") {
+  showTab(tab: TorrentDetailsTab) {
     this.scope.activeTab = tab;
     this.syncActiveTabState();
     if (this.scope.torrent && !this.loadedTabs[tab]) {
@@ -107,7 +110,7 @@ export class TorrentDetailsPanelController {
     }
   }
 
-  isActiveTab(tab: "info" | "files") {
+  isActiveTab(tab: TorrentDetailsTab) {
     return this.scope.activeTab === tab;
   }
 
@@ -116,9 +119,12 @@ export class TorrentDetailsPanelController {
   }
 
   hasActiveTabData() {
-    return this.scope.activeTab === "info"
-      ? this.scope.panel.info.sections.length > 0
-      : this.scope.panel.files.items.length > 0;
+    if (this.scope.activeTab === "info") {
+      return this.scope.panel.info.sections.length > 0;
+    }
+    return this.scope.activeTab === "files"
+      ? this.scope.panel.files.items.length > 0
+      : this.scope.panel.peers.items.length > 0;
   }
 
   stateMessageIcon() {
@@ -137,6 +143,10 @@ export class TorrentDetailsPanelController {
 
   canSelectFiles() {
     return !!this.rootScope.$btclient?.features.fileSelection;
+  }
+
+  canShowPeers() {
+    return !!this.rootScope.$btclient?.features.torrentPeers;
   }
 
   updateFileSelection = async (files: TorrentDetailsFileItem[], wanted: boolean) => {
@@ -186,7 +196,7 @@ export class TorrentDetailsPanelController {
     return `torrent-details-files.${serverId}`;
   }
 
-  private async loadTab(tab: "info" | "files", torrent: any, force = false) {
+  private async loadTab(tab: TorrentDetailsTab, torrent: any, force = false) {
     if (!force && this.loadedTabs[tab]) {
       return;
     }
@@ -200,7 +210,9 @@ export class TorrentDetailsPanelController {
       const client = this.rootScope.$btclient;
       const data = tab === "info"
         ? await client?.getTorrentDetails(torrent)
-        : await client?.getTorrentDetailsFiles(torrent);
+        : tab === "files"
+          ? await client?.getTorrentDetailsFiles(torrent)
+          : await client?.getTorrentDetailsPeers(torrent);
       if (requestId !== this.loadRequestIds[tab] || this.scope.torrent !== torrent) {
         return;
       }
@@ -208,8 +220,10 @@ export class TorrentDetailsPanelController {
       if (data) {
         if (tab === "info") {
           this.scope.panel.info = data as TorrentDetailsPanelData["info"];
-        } else {
+        } else if (tab === "files") {
           this.scope.panel.files = data as TorrentDetailsPanelData["files"];
+        } else {
+          this.scope.panel.peers = data as TorrentDetailsPanelData["peers"];
         }
       }
       this.loadedTabs[tab] = true;
@@ -261,15 +275,17 @@ export class TorrentDetailsPanelController {
   private resetPanelState() {
     this.loadRequestIds.info += 1;
     this.loadRequestIds.files += 1;
-    this.loadedTabs = { info: false, files: false };
-    this.loadingTabs = { info: false, files: false };
-    this.tabErrors = { info: null, files: null };
+    this.loadRequestIds.peers += 1;
+    this.loadedTabs = { info: false, files: false, peers: false };
+    this.loadingTabs = { info: false, files: false, peers: false };
+    this.tabErrors = { info: null, files: null, peers: null };
     this.scope.loading = false;
     this.scope.error = null;
     this.scope.torrent = null;
     this.scope.panel = {
       info: { sections: [] },
       files: { columns: [], items: [] },
+      peers: { items: [] },
     };
   }
 }

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -17,6 +17,15 @@
     >
       Files
     </a>
+    <a
+      class="item"
+      data-role="torrent-details-tab-peers"
+      ng-if="ctl.canShowPeers()"
+      ng-class="{ active: ctl.isActiveTab('peers') }"
+      ng-click="ctl.showTab('peers')"
+    >
+      Peers
+    </a>
     <div class="right menu">
       <a
         class="item"
@@ -54,5 +63,10 @@
       can-select-files="ctl.canSelectFiles()"
       update-selection="ctl.updateFileSelection(files, wanted)"
     ></torrent-details-files-tab>
+
+    <torrent-details-peers-tab
+      ng-if="!ctl.showStateMessage() && ctl.isActiveTab('peers')"
+      peers="ctl.scope.panel.peers"
+    ></torrent-details-peers-tab>
   </div>
 </div>

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
@@ -1,0 +1,20 @@
+import { IScope } from "angular"
+import type { BittorrentTorrentPeer } from "@shared/ipc-contract"
+
+export interface TorrentDetailsPeersTabScope extends IScope {
+  peers: { items: BittorrentTorrentPeer[] }
+}
+
+export class TorrentDetailsPeersTabController {
+  static $inject = ["$scope"]
+
+  constructor(public scope: TorrentDetailsPeersTabScope) {}
+
+  countryFlagClass(peer: BittorrentTorrentPeer) {
+    return peer.countryCode ? `${peer.countryCode.toLowerCase()} flag` : ""
+  }
+
+  progressPercent(peer: BittorrentTorrentPeer) {
+    return Math.max(0, Math.min(100, (Number(peer.progress) || 0) * 100))
+  }
+}

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.directive.ts
@@ -1,0 +1,15 @@
+import { IDirective, IDirectiveFactory } from "angular"
+import { TorrentDetailsPeersTabController } from "./torrent-details-peers-tab.controller"
+import html from "./torrent-details-peers-tab.template.html"
+
+export class TorrentDetailsPeersTabDirective implements IDirective {
+  template = html
+  restrict = "E"
+  scope = { peers: "=" }
+  controller = TorrentDetailsPeersTabController
+  controllerAs = "ctl"
+
+  static getInstance(): IDirectiveFactory {
+    return () => new TorrentDetailsPeersTabDirective()
+  }
+}

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
@@ -1,0 +1,42 @@
+<div class="torrent-details-peers" data-role="torrent-details-peers">
+  <div class="torrent-details-peers-content">
+    <table class="ui compact single line unstackable torrent table" data-role="torrent-details-peers-table">
+      <thead>
+        <tr>
+          <th>Country</th>
+          <th>IP</th>
+          <th>Port</th>
+          <th>Client</th>
+          <th>Progress</th>
+          <th>Down Speed</th>
+          <th>Up Speed</th>
+          <th>Downloaded</th>
+          <th>Uploaded</th>
+          <th>Connection</th>
+          <th>Flags</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="peer in ctl.scope.peers.items track by (peer.ip + ':' + peer.port + ':' + $index)">
+          <td data-col="country">
+            <i ng-if="peer.countryCode" ng-class="ctl.countryFlagClass(peer)" title="{{ peer.country }}"></i>
+            <span>{{ peer.country || peer.countryCode || '' }}</span>
+          </td>
+          <td data-col="ip">{{ peer.ip }}</td>
+          <td data-col="port">{{ peer.port || '' }}</td>
+          <td data-col="client">{{ peer.client }}</td>
+          <td data-col="progress">{{ ctl.progressPercent(peer) | number:1 }}%</td>
+          <td data-col="downloadSpeed">{{ peer.downloadSpeed | speed }}</td>
+          <td data-col="uploadSpeed">{{ peer.uploadSpeed | speed }}</td>
+          <td data-col="downloaded">{{ peer.downloaded == null ? '' : (peer.downloaded | bytes) }}</td>
+          <td data-col="uploaded">{{ peer.uploaded == null ? '' : (peer.uploaded | bytes) }}</td>
+          <td data-col="connection">{{ peer.connection || '' }}</td>
+          <td data-col="flags">{{ peer.flags || '' }}</td>
+        </tr>
+        <tr ng-if="!ctl.scope.peers.items.length">
+          <td colspan="11">No peers connected.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -714,7 +714,8 @@ torrent-sidebar + .main-panel {
         }
 
         torrent-details-info-tab,
-        torrent-details-files-tab {
+        torrent-details-files-tab,
+        torrent-details-peers-tab {
             display: flex;
             flex: 1 1 auto;
             min-height: 0;
@@ -749,7 +750,9 @@ torrent-sidebar + .main-panel {
 
         .torrent-details-info,
         .torrent-details-files,
-        .torrent-details-files-content {
+        .torrent-details-files-content,
+        .torrent-details-peers,
+        .torrent-details-peers-content {
             flex: 1 1 auto;
             height: 100%;
             min-height: 0;
@@ -882,6 +885,29 @@ torrent-sidebar + .main-panel {
             display: flex;
             flex-direction: column;
             overflow: hidden;
+        }
+
+        .torrent-details-peers {
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .torrent-details-peers-content {
+            overflow: auto;
+
+            .torrent.table {
+                margin: 0;
+
+                th,
+                td {
+                    white-space: nowrap;
+                }
+
+                .flag {
+                    margin-right: 0.45rem;
+                }
+            }
         }
 
         .torrent-details-files.table,

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -99,6 +99,10 @@ export interface BittorrentGetTorrentFilesRequest {
     hash: string
 }
 
+export interface BittorrentGetTorrentPeersRequest {
+    hash: string
+}
+
 export type BittorrentTorrentDetailsPrimitive = string | number | boolean | null
 
 export interface BittorrentGetTorrentDetailsRequest {
@@ -119,6 +123,21 @@ export interface BittorrentTorrentDetailsFile {
 
 export interface BittorrentTorrentDetailsData {
     info: Record<string, BittorrentTorrentDetailsPrimitive>
+}
+
+export interface BittorrentTorrentPeer {
+    ip: string
+    port?: number
+    client: string
+    progress: number
+    downloadSpeed: number
+    uploadSpeed: number
+    downloaded?: number
+    uploaded?: number
+    connection?: string
+    flags?: string
+    country?: string
+    countryCode?: string
 }
 
 export interface BittorrentFileSelection {
@@ -198,6 +217,7 @@ export interface TorrentClientFeatures {
     readonly uploadFileSelection?: boolean
     readonly setLocation?: boolean
     readonly torrentDetails?: boolean
+    readonly torrentPeers?: boolean
     readonly trackerFilter?: boolean
     readonly alternativeSpeedLimits?: boolean
     readonly speedLimits?: boolean
@@ -239,6 +259,7 @@ export interface ResolvedTorrentClientFeatures {
     readonly uploadFileSelection: boolean
     readonly setLocation: boolean
     readonly torrentDetails: boolean
+    readonly torrentPeers: boolean
     readonly trackerFilter: boolean
     readonly alternativeSpeedLimits: boolean
     readonly speedLimits: boolean
@@ -386,6 +407,7 @@ export interface ElectorrentBridge {
         invokeAction(request: BittorrentInvokeActionRequest): Promise<void>
         getTorrentDetails(request: BittorrentGetTorrentDetailsRequest): Promise<BittorrentTorrentDetailsData>
         getTorrentFiles(request: BittorrentGetTorrentFilesRequest): Promise<BittorrentTorrentDetailsFile[]>
+        getTorrentPeers(request: BittorrentGetTorrentPeersRequest): Promise<BittorrentTorrentPeer[]>
         setTorrentFileSelection(request: BittorrentSetTorrentFileSelectionRequest): Promise<void>
     }
     updates: {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -35,6 +35,7 @@ export const IPC_CHANNELS = {
         invokeAction: 'bittorrent:invoke-action',
         getTorrentDetails: 'bittorrent:get-torrent-details',
         getTorrentFiles: 'bittorrent:get-torrent-files',
+        getTorrentPeers: 'bittorrent:get-torrent-peers',
         setTorrentFileSelection: 'bittorrent:set-torrent-file-selection',
     },
     updates: {

--- a/test/clients/deluge/index.ts
+++ b/test/clients/deluge/index.ts
@@ -6,6 +6,7 @@ const baseFeatures = {
   labels: true,
   uploadFileSelection: true,
   torrentDetails: true,
+  torrentPeers: true,
   speedLimits: true,
   ratioLimits: true,
   freeDiskSpace: true,

--- a/test/clients/mock/index.ts
+++ b/test/clients/mock/index.ts
@@ -8,6 +8,7 @@ const features = {
   uploadFileSelection: true,
   setLocation: true,
   torrentDetails: true,
+  torrentPeers: true,
   freeDiskSpace: true,
   uploadOptions: {
     saveLocation: true,

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -9,6 +9,7 @@ const features = {
   uploadFileSelection: true,
   setLocation: true,
   torrentDetails: true,
+  torrentPeers: true,
   trackerFilter: true,
   alternativeSpeedLimits: true,
   speedLimits: true,

--- a/test/clients/rtorrent/index.ts
+++ b/test/clients/rtorrent/index.ts
@@ -7,6 +7,7 @@ const features = {
   labels: true,
   uploadFileSelection: true,
   torrentDetails: true,
+  torrentPeers: true,
   trackerFilter: true,
   speedLimits: true,
   uploadOptions: {

--- a/test/clients/transmission/index.ts
+++ b/test/clients/transmission/index.ts
@@ -8,6 +8,7 @@ const features = {
   uploadFileSelection: true,
   setLocation: true,
   torrentDetails: true,
+  torrentPeers: true,
   trackerFilter: true,
   speedLimits: true,
   ratioLimits: true,

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -169,7 +169,7 @@ export class Torrent {
     return panel
   }
 
-  async openDetailsTab(tab: "info" | "files") {
+  async openDetailsTab(tab: "info" | "files" | "peers") {
     const panel = $("[data-role='torrent-details-panel']")
     await panel.waitForDisplayed({ timeout: this.timeout })
 

--- a/test/specs/mock/torrent-peers.spec.ts
+++ b/test/specs/mock/torrent-peers.spec.ts
@@ -1,0 +1,41 @@
+import chai from "chai"
+import { browser } from "@wdio/globals"
+import { Torrent } from "../../e2e"
+import { configureSpec } from "../../framework/fixture"
+
+describe("torrent peers", function () {
+  configureSpec()
+
+  it("shows normalized peer data and its country flag", async function () {
+    this.timeout(60 * 1000)
+
+    const hash = "1".padStart(40, "0")
+    await browser.execute(async (request) => {
+      await (window as any).electorrent.bittorrent.invokeAction(request)
+    }, { action: "addMockedTorrent", args: [{ hash, name: "Peer test" }] })
+
+    const torrent = new Torrent({ hash, app: this.app })
+    await torrent.waitForExist()
+
+    const panel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("peers")
+
+    const peersTable = panel.$("[data-role='torrent-details-peers-table']")
+    await peersTable.waitForDisplayed()
+    const row = peersTable.$("tbody tr")
+
+    const countryCell = row.$("td[data-col='country']")
+    await countryCell.waitForDisplayed()
+    chai.assert.include(await countryCell.getText(), "United States")
+    chai.assert.isTrue(await row.$("td[data-col='country'] i.us.flag").isExisting())
+    chai.assert.equal(await row.$("td[data-col='ip']").getText(), "8.8.8.8")
+    chai.assert.equal(await row.$("td[data-col='port']").getText(), "6881")
+    chai.assert.equal(await row.$("td[data-col='client']").getText(), "Mock Peer 1.0")
+    chai.assert.equal(await row.$("td[data-col='progress']").getText(), "75.0%")
+    chai.assert.equal(await row.$("td[data-col='connection']").getText(), "Outgoing")
+    chai.assert.equal(await row.$("td[data-col='flags']").getText(), "Interested, encrypted")
+
+    await torrent.closeDetailsPanel()
+    await torrent.delete()
+  })
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,8 @@ const __dirname = path.dirname(__filename)
 const defaultInclude = path.resolve(__dirname, 'src')
 const outDir = path.resolve(__dirname, 'app')
 const semanticUiLessDir = path.resolve(__dirname, 'node_modules/semantic-ui-less')
+const geoIpCountryDir = path.resolve(__dirname, 'node_modules/geoip-country')
+const countriesListDir = path.resolve(__dirname, 'node_modules/countries-list')
 const semanticThemeConfigPath = path.resolve(__dirname, 'src/renderer/styles/semantic/theme.config')
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -79,6 +81,14 @@ const commonPlugins = [
         from: path.resolve(__dirname, 'src/renderer/assets/img'),
         to: path.resolve(outDir, 'img'),
         noErrorOnMissing: true,
+      },
+      {
+        from: geoIpCountryDir,
+        to: path.resolve(outDir, 'node_modules/geoip-country'),
+      },
+      {
+        from: countriesListDir,
+        to: path.resolve(outDir, 'node_modules/countries-list'),
       },
     ],
   }),
@@ -210,6 +220,9 @@ function makeNodeConfig({ name, entry, target, tsConfig }) {
     target,
     mode: isProduction ? 'production' : 'development',
     externals: [
+      {
+        'geoip-country': 'commonjs geoip-country',
+      },
       nodeExternals({
         modulesDir: 'app/node_modules',
       }),


### PR DESCRIPTION
## Summary
- add normalized peer retrieval across supported torrent clients
- expose peers through the shared IPC contract and render a details tab
- resolve peer countries with geoip-country and show Semantic UI flags

## Validation
- npm run lint
- npm run build
- npm run test -- --client "mock" --spec "test/specs/mock/torrent-peers.spec.ts" *(blocked locally before spec execution by Electron WebDriver session timeout)*