### PR TITLE
feat: compact torrent details tabs

### DIFF
--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -7,6 +7,7 @@
       ng-class="{ active: ctl.isActiveTab('info') }"
       ng-click="ctl.showTab('info')"
     >
+      <i class="small info circle icon" aria-hidden="true"></i>
       Info
     </a>
     <a
@@ -15,6 +16,7 @@
       ng-class="{ active: ctl.isActiveTab('files') }"
       ng-click="ctl.showTab('files')"
     >
+      <i class="small file alternate icon" aria-hidden="true"></i>
       Files
     </a>
     <a
@@ -24,6 +26,7 @@
       ng-class="{ active: ctl.isActiveTab('peers') }"
       ng-click="ctl.showTab('peers')"
     >
+      <i class="small users icon" aria-hidden="true"></i>
       Peers
     </a>
     <a
@@ -32,6 +35,7 @@
       ng-class="{ active: ctl.isActiveTab('trackers') }"
       ng-click="ctl.showTab('trackers')"
     >
+      <i class="small bullseye icon" aria-hidden="true"></i>
       Trackers
     </a>
     <div class="right menu">

--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -689,10 +689,10 @@ torrent-sidebar + .main-panel {
             margin: 0;
             border-bottom: 1px solid @borderColor;
             flex: 0 0 auto;
+            min-height: 2rem;
 
             a.item {
-
-                padding: 0.20rem 1rem;
+                padding: 0.15rem 0.75rem;
 
                 &.active {
                     border-top: none;
@@ -701,6 +701,14 @@ torrent-sidebar + .main-panel {
                         border-left: none;
                     }
                 }
+            }
+
+            > a.item > .icon {
+                margin-right: 0.4rem;
+            }
+
+            .right.menu .icon {
+                margin: 0;
             }
         }
 


### PR DESCRIPTION
## What changed
- Reduced the torrent details tab header height and padding.
- Added small, decorative icons to the Info and Files tabs.
- Preserved accessible tab names by hiding the icons from assistive technology.

## Why
Makes the details panel more compact while improving quick visual recognition of each tab.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts"`
- `git diff --check`