### PR TITLE
fix: blank unavailable torrent size

### DIFF
--- a/src/renderer/app/filters/bytes.filter.ts
+++ b/src/renderer/app/filters/bytes.filter.ts
@@ -6,10 +6,18 @@ export class BytesFilter {
     }
 
     public transform: IFilterNumber = (value, fractionSize = 1): string => {
+        if (value === null || value === undefined) {
+            return "";
+        }
+
         const bytes = Number(value);
         const decimals = Number(fractionSize);
 
-        if (!bytes) {
+        if (!Number.isFinite(bytes) || bytes < 0) {
+            return "";
+        }
+
+        if (bytes === 0) {
             return "0 B";
         }
 

--- a/test/specs/mock/torrent-size.spec.ts
+++ b/test/specs/mock/torrent-size.spec.ts
@@ -1,0 +1,30 @@
+import chai from "chai"
+import { browser } from "@wdio/globals"
+import { Torrent } from "../../e2e"
+import { configureSpec, getTestFixture } from "../../framework/fixture"
+
+const assert: Chai.AssertStatic = chai.assert
+
+describe("mock torrent size", function () {
+  configureSpec()
+
+  it("leaves the size blank while metadata is unavailable", async function () {
+    const hash = "0000000000000000000000000000000000000001"
+    await browser.execute(async (torrent) => {
+      await (window as any).electorrent.bittorrent.invokeAction({
+        action: "addMockedTorrent",
+        args: [torrent],
+      })
+    }, {
+      hash,
+      name: "Magnet awaiting metadata",
+      size: -1,
+      state: "metaDL",
+    })
+
+    const torrent = new Torrent({ hash, app: getTestFixture().app })
+    await torrent.waitForExist()
+
+    assert.equal((await torrent.getColumn("size")).trim(), "")
+  })
+})


### PR DESCRIPTION
## Summary

Render missing or invalid torrent sizes as blank instead of `NaN undefined` while magnet metadata is unavailable.

## Root cause

The shared `bytes` filter formatted the negative size sentinel used before metadata retrieval.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client mock --spec test/specs/mock/torrent-size.spec.ts`