### PR TITLE
fix(details): stabilize peer and tracker tables

### DIFF
--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -319,6 +319,15 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
             uploaded: 250 * 1024 * 1024,
             connection: "Outgoing",
             flags: "Interested, encrypted",
+        }, {
+            ip: "192.168.1.2",
+            port: 51413,
+            client: "Local Peer",
+            progress: 0.5,
+            downloadSpeed: 0,
+            uploadSpeed: 0,
+            connection: "Incoming",
+            flags: "Local",
         }]
     }
 

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -13,7 +13,7 @@ export interface TorrentDetailsPanelScope extends IScope {
   panel: TorrentDetailsPanelData;
   activeTab: TorrentDetailsTab;
   resizeMode: string;
-  resizeProfile: string;
+  resizeProfiles: Record<TorrentDetailsTab, string>;
 }
 
 export class TorrentDetailsPanelController {
@@ -40,7 +40,7 @@ export class TorrentDetailsPanelController {
     this.scope.torrent = null;
     this.scope.activeTab = "info";
     this.scope.resizeMode = "OverflowResizer";
-    this.scope.resizeProfile = this.getResizeProfile();
+    this.scope.resizeProfiles = this.getResizeProfiles();
     this.scope.panel = {
       info: { sections: [] },
       files: { columns: [], items: [] },
@@ -119,6 +119,10 @@ export class TorrentDetailsPanelController {
     return !this.scope.loading && (!!this.scope.error || !this.scope.torrent);
   }
 
+  showLoader() {
+    return this.scope.loading && !this.loadedTabs[this.scope.activeTab] && !this.hasActiveTabData();
+  }
+
   hasActiveTabData() {
     if (this.scope.activeTab === "info") {
       return this.scope.panel.info.sections.length > 0;
@@ -194,15 +198,21 @@ export class TorrentDetailsPanelController {
     this.stopResizeListeners = onMouseUp;
   }
 
-  private getResizeProfile() {
+  private getResizeProfiles() {
     const serverId = this.rootScope.$server?.id || this.rootScope.$btclient?.id || "default";
-    return `torrent-details-files.${serverId}`;
+    return {
+      info: `torrent-details-info.${serverId}`,
+      files: `torrent-details-files.${serverId}`,
+      peers: `torrent-details-peers.${serverId}`,
+      trackers: `torrent-details-trackers.${serverId}`,
+    };
   }
 
   private async loadTab(tab: TorrentDetailsTab, torrent: any, force = false) {
     if (!force && this.loadedTabs[tab]) {
       return;
     }
+    const wasLoaded = this.loadedTabs[tab];
     const requestId = ++this.loadRequestIds[tab];
     this.syncResizeBindings();
     this.loadingTabs[tab] = true;
@@ -239,7 +249,9 @@ export class TorrentDetailsPanelController {
         return;
       }
 
-      this.tabErrors[tab] = err && err.message ? err.message : `Failed to load torrent ${tab}`;
+      if (!wasLoaded) {
+        this.tabErrors[tab] = err && err.message ? err.message : `Failed to load torrent ${tab}`;
+      }
     } finally {
       if (requestId === this.loadRequestIds[tab] && this.scope.torrent === torrent) {
         this.loadingTabs[tab] = false;
@@ -259,7 +271,7 @@ export class TorrentDetailsPanelController {
 
   private syncResizeBindings() {
     this.scope.resizeMode = this.scope.settings?.ui?.resizeMode || "OverflowResizer";
-    this.scope.resizeProfile = this.getResizeProfile();
+    this.scope.resizeProfiles = this.getResizeProfiles();
   }
 
   private clearSelection() {
@@ -267,10 +279,12 @@ export class TorrentDetailsPanelController {
   }
 
   private prepareTorrent(torrent: any) {
-    if (this.scope.torrent !== torrent) {
+    const currentHash = this.scope.torrent?.hash;
+    const nextHash = torrent?.hash;
+    if (!currentHash || !nextHash || currentHash !== nextHash) {
       this.resetPanelState();
-      this.scope.torrent = torrent;
     }
+    this.scope.torrent = torrent;
   }
 
   private syncActiveTabState() {

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -51,7 +51,7 @@
   </div>
 
   <div class="torrent-details-panel-body">
-    <div ng-if="ctl.scope.loading && !ctl.hasActiveTabData()" class="torrent-details-state torrent-details-panel-loader">
+    <div ng-if="ctl.showLoader()" class="torrent-details-state torrent-details-panel-loader">
       <div class="ui active inline loader"></div>
     </div>
 
@@ -71,7 +71,7 @@
       ng-if="!ctl.showStateMessage() && ctl.isActiveTab('files')"
       files="ctl.scope.panel.files"
       resize-mode="ctl.scope.resizeMode"
-      resize-profile="ctl.scope.resizeProfile"
+      resize-profile="ctl.scope.resizeProfiles.files"
       can-select-files="ctl.canSelectFiles()"
       update-selection="ctl.updateFileSelection(files, wanted)"
     ></torrent-details-files-tab>
@@ -79,10 +79,14 @@
     <torrent-details-peers-tab
       ng-if="!ctl.showStateMessage() && ctl.isActiveTab('peers')"
       peers="ctl.scope.panel.peers"
+      resize-mode="ctl.scope.resizeMode"
+      resize-profile="ctl.scope.resizeProfiles.peers"
     ></torrent-details-peers-tab>
     <torrent-details-trackers-tab
       ng-if="!ctl.showStateMessage() && ctl.isActiveTab('trackers')"
       trackers="ctl.scope.panel.trackers.items"
+      resize-mode="ctl.scope.resizeMode"
+      resize-profile="ctl.scope.resizeProfiles.trackers"
     ></torrent-details-trackers-tab>
   </div>
 </div>

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
@@ -3,18 +3,74 @@ import type { BittorrentTorrentPeer } from "@shared/ipc-contract"
 
 export interface TorrentDetailsPeersTabScope extends IScope {
   peers: { items: BittorrentTorrentPeer[] }
+  resizeMode: string
+  resizeProfile: string
+  columns: TorrentDetailsPeerColumn[]
+  sortedPeers: BittorrentTorrentPeer[]
+}
+
+interface TorrentDetailsPeerColumn {
+  id: keyof BittorrentTorrentPeer | "country"
+  label: string
+  sortType: "alphabetical" | "numeric"
 }
 
 export class TorrentDetailsPeersTabController {
   static $inject = ["$scope"]
 
-  constructor(public scope: TorrentDetailsPeersTabScope) {}
+  constructor(public scope: TorrentDetailsPeersTabScope) {
+    this.scope.columns = [
+      { id: "country", label: "Country", sortType: "alphabetical" },
+      { id: "ip", label: "IP", sortType: "alphabetical" },
+      { id: "port", label: "Port", sortType: "numeric" },
+      { id: "client", label: "Client", sortType: "alphabetical" },
+      { id: "progress", label: "Progress", sortType: "numeric" },
+      { id: "downloadSpeed", label: "Down Speed", sortType: "numeric" },
+      { id: "uploadSpeed", label: "Up Speed", sortType: "numeric" },
+      { id: "downloaded", label: "Downloaded", sortType: "numeric" },
+      { id: "uploaded", label: "Uploaded", sortType: "numeric" },
+      { id: "connection", label: "Connection", sortType: "alphabetical" },
+      { id: "flags", label: "Flags", sortType: "alphabetical" },
+    ]
+    this.scope.sortedPeers = []
+    this.scope.$watch(() => this.scope.peers, () => this.sortPeers())
+  }
 
-  countryFlagClass(peer: BittorrentTorrentPeer) {
-    return peer.countryCode ? `${peer.countryCode.toLowerCase()} flag` : ""
+  private sortKey: TorrentDetailsPeerColumn["id"] = "ip"
+  private sortDescending = false
+
+  changeSorting = (columnId: TorrentDetailsPeerColumn["id"], descending: boolean) => {
+    this.sortKey = columnId
+    this.sortDescending = descending
+    this.sortPeers()
+  }
+
+  countryFlag(peer: BittorrentTorrentPeer) {
+    const code = peer.countryCode?.toUpperCase()
+    if (!code || !/^[A-Z]{2}$/.test(code)) {
+      return "🏳️"
+    }
+    return String.fromCodePoint(...Array.from(code).map((letter) => 0x1F1E6 + letter.charCodeAt(0) - 65))
+  }
+
+  countryName(peer: BittorrentTorrentPeer) {
+    return peer.country || peer.countryCode || "Unknown"
   }
 
   progressPercent(peer: BittorrentTorrentPeer) {
     return Math.max(0, Math.min(100, (Number(peer.progress) || 0) * 100))
+  }
+
+  private sortPeers() {
+    const column = this.scope.columns.find(({ id }) => id === this.sortKey) || this.scope.columns[1]
+    const value = (peer: BittorrentTorrentPeer) => column.id === "country" ? this.countryName(peer) : peer[column.id]
+    this.scope.sortedPeers = [...(this.scope.peers?.items || [])].sort((left, right) => {
+      const leftValue = value(left)
+      const rightValue = value(right)
+      const compared = column.sortType === "numeric"
+        ? Number(leftValue ?? 0) - Number(rightValue ?? 0)
+        : String(leftValue ?? "").localeCompare(String(rightValue ?? ""), undefined, { sensitivity: "base" })
+      return this.sortDescending ? -compared : compared
+    })
   }
 }

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.directive.ts
@@ -5,7 +5,11 @@ import html from "./torrent-details-peers-tab.template.html"
 export class TorrentDetailsPeersTabDirective implements IDirective {
   template = html
   restrict = "E"
-  scope = { peers: "=" }
+  scope = {
+    peers: "<",
+    resizeMode: "<",
+    resizeProfile: "<",
+  }
   controller = TorrentDetailsPeersTabController
   controllerAs = "ctl"
 

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
@@ -1,26 +1,27 @@
 <div class="torrent-details-peers" data-role="torrent-details-peers">
-  <div class="torrent-details-peers-content">
-    <table class="ui compact single line unstackable torrent table" data-role="torrent-details-peers-table">
+  <div class="torrent-details-peers-content torrent-details-table-content">
+    <table
+      id="torrentDetailsPeersTable"
+      class="ui compact single line unstackable fixed torrent resize table torrent-details-table"
+      data-role="torrent-details-peers-table"
+      rz-table
+      rz-profile="ctl.scope.resizeProfile"
+      rz-mode="ctl.scope.resizeMode"
+      rz-container=".torrent-details-peers-content"
+      columns="ctl.scope.columns"
+    >
       <thead>
-        <tr>
-          <th>Country</th>
-          <th>IP</th>
-          <th>Port</th>
-          <th>Client</th>
-          <th>Progress</th>
-          <th>Down Speed</th>
-          <th>Up Speed</th>
-          <th>Downloaded</th>
-          <th>Uploaded</th>
-          <th>Connection</th>
-          <th>Flags</th>
+        <tr sorting="ctl.changeSorting" mode="ctl.scope.resizeProfile" default-sort-key="ip" default-sort-order="false" sort-key-prefix="torrent-details-peers.sort-key" sort-order-prefix="torrent-details-peers.sort-desc">
+          <th ng-repeat="column in ctl.scope.columns track by column.id" rz-col="column.id" sort="column.id">
+            <span class="torrent-details-table-header-label">{{ column.label }}</span>
+          </th>
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="peer in ctl.scope.peers.items track by (peer.ip + ':' + peer.port + ':' + $index)">
+        <tr ng-repeat="peer in ctl.scope.sortedPeers track by (peer.ip + ':' + peer.port + ':' + $index)" data-peer-ip="{{ peer.ip }}">
           <td data-col="country">
-            <i ng-if="peer.countryCode" ng-class="ctl.countryFlagClass(peer)" title="{{ peer.country }}"></i>
-            <span>{{ peer.country || peer.countryCode || '' }}</span>
+            <span class="torrent-details-country-flag" title="{{ ctl.countryName(peer) }}" aria-hidden="true">{{ ctl.countryFlag(peer) }}</span>
+            <span>{{ ctl.countryName(peer) }}</span>
           </td>
           <td data-col="ip">{{ peer.ip }}</td>
           <td data-col="port">{{ peer.port || '' }}</td>
@@ -33,7 +34,7 @@
           <td data-col="connection">{{ peer.connection || '' }}</td>
           <td data-col="flags">{{ peer.flags || '' }}</td>
         </tr>
-        <tr ng-if="!ctl.scope.peers.items.length">
+        <tr ng-if="!ctl.scope.sortedPeers.length">
           <td colspan="11">No peers connected.</td>
         </tr>
       </tbody>

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
@@ -1,0 +1,58 @@
+import { IScope } from "angular"
+import type { BittorrentTorrentDetailsTracker } from "@shared/ipc-contract"
+
+interface TorrentDetailsTrackerColumn {
+  id: keyof BittorrentTorrentDetailsTracker
+  label: string
+  sortType: "alphabetical" | "numeric"
+}
+
+export interface TorrentDetailsTrackersTabScope extends IScope {
+  trackers: BittorrentTorrentDetailsTracker[]
+  resizeMode: string
+  resizeProfile: string
+  columns: TorrentDetailsTrackerColumn[]
+  sortedTrackers: BittorrentTorrentDetailsTracker[]
+}
+
+export class TorrentDetailsTrackersTabController {
+  static $inject = ["$scope"]
+
+  private sortKey: keyof BittorrentTorrentDetailsTracker = "url"
+  private sortDescending = false
+
+  constructor(public scope: TorrentDetailsTrackersTabScope) {
+    this.scope.columns = [
+      { id: "url", label: "URL", sortType: "alphabetical" },
+      { id: "status", label: "Status", sortType: "alphabetical" },
+      { id: "tier", label: "Tier", sortType: "numeric" },
+      { id: "peers", label: "Peers", sortType: "numeric" },
+      { id: "seeds", label: "Seeds", sortType: "numeric" },
+      { id: "leeches", label: "Leeches", sortType: "numeric" },
+      { id: "downloaded", label: "Downloaded", sortType: "numeric" },
+      { id: "lastAnnounce", label: "Last announce", sortType: "numeric" },
+      { id: "nextAnnounce", label: "Next announce", sortType: "numeric" },
+      { id: "message", label: "Message", sortType: "alphabetical" },
+    ]
+    this.scope.sortedTrackers = []
+    this.scope.$watch(() => this.scope.trackers, () => this.sortTrackers())
+  }
+
+  changeSorting = (columnId: keyof BittorrentTorrentDetailsTracker, descending: boolean) => {
+    this.sortKey = columnId
+    this.sortDescending = descending
+    this.sortTrackers()
+  }
+
+  private sortTrackers() {
+    const column = this.scope.columns.find(({ id }) => id === this.sortKey) || this.scope.columns[0]
+    this.scope.sortedTrackers = [...(this.scope.trackers || [])].sort((left, right) => {
+      const leftValue = left[column.id]
+      const rightValue = right[column.id]
+      const compared = column.sortType === "numeric"
+        ? Number(leftValue ?? 0) - Number(rightValue ?? 0)
+        : String(leftValue ?? "").localeCompare(String(rightValue ?? ""), undefined, { sensitivity: "base" })
+      return this.sortDescending ? -compared : compared
+    })
+  }
+}

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.directive.ts
@@ -1,4 +1,5 @@
 import { IDirective, IDirectiveFactory } from "angular";
+import { TorrentDetailsTrackersTabController } from "./torrent-details-trackers-tab.controller";
 import html from "./torrent-details-trackers-tab.template.html";
 
 export class TorrentDetailsTrackersTabDirective implements IDirective {
@@ -6,7 +7,11 @@ export class TorrentDetailsTrackersTabDirective implements IDirective {
   restrict = "E";
   scope = {
     trackers: "<",
+    resizeMode: "<",
+    resizeProfile: "<",
   };
+  controller = TorrentDetailsTrackersTabController;
+  controllerAs = "ctl";
 
   static getInstance(): IDirectiveFactory {
     return () => new TorrentDetailsTrackersTabDirective();

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
@@ -1,21 +1,24 @@
 <div class="torrent-details-trackers" data-role="torrent-details-trackers">
-  <table class="ui compact single line unstackable table" data-role="torrent-details-trackers-table">
+  <div class="torrent-details-trackers-content torrent-details-table-content">
+  <table
+    id="torrentDetailsTrackersTable"
+    class="ui compact single line unstackable fixed torrent resize table torrent-details-table"
+    data-role="torrent-details-trackers-table"
+    rz-table
+    rz-profile="ctl.scope.resizeProfile"
+    rz-mode="ctl.scope.resizeMode"
+    rz-container=".torrent-details-trackers-content"
+    columns="ctl.scope.columns"
+  >
     <thead>
-      <tr>
-        <th>URL</th>
-        <th>Status</th>
-        <th>Tier</th>
-        <th>Peers</th>
-        <th>Seeds</th>
-        <th>Leeches</th>
-        <th>Downloaded</th>
-        <th>Last announce</th>
-        <th>Next announce</th>
-        <th>Message</th>
+      <tr sorting="ctl.changeSorting" mode="ctl.scope.resizeProfile" default-sort-key="url" default-sort-order="false" sort-key-prefix="torrent-details-trackers.sort-key" sort-order-prefix="torrent-details-trackers.sort-desc">
+        <th ng-repeat="column in ctl.scope.columns track by column.id" rz-col="column.id" sort="column.id">
+          <span class="torrent-details-table-header-label">{{ column.label }}</span>
+        </th>
       </tr>
     </thead>
     <tbody>
-      <tr ng-repeat="tracker in trackers track by $index" data-tracker-url="{{ tracker.url }}">
+      <tr ng-repeat="tracker in ctl.scope.sortedTrackers track by $index" data-tracker-url="{{ tracker.url }}">
         <td class="torrent-details-tracker-url" title="{{ tracker.url }}">{{ tracker.url }}</td>
         <td>{{ tracker.status }}</td>
         <td>{{ tracker.tier }}</td>
@@ -27,9 +30,10 @@
         <td>{{ tracker.nextAnnounce ? (tracker.nextAnnounce | epoch) : '' }}</td>
         <td title="{{ tracker.message }}">{{ tracker.message }}</td>
       </tr>
-      <tr ng-if="!trackers.length">
+      <tr ng-if="!ctl.scope.sortedTrackers.length">
         <td colspan="10">No trackers available.</td>
       </tr>
     </tbody>
   </table>
+  </div>
 </div>

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -154,6 +154,20 @@ describe("torrent details", function () {
     const displayedUrls = await trackerRows.map((row) => row.getAttribute("data-tracker-url"))
     trackerUrls.forEach((url) => displayedUrls.should.contain(url))
 
+    const trackersTable = trackersTab.$("[data-role='torrent-details-trackers-table']")
+    const urlHeader = trackersTable.$("thead th:first-child")
+    await urlHeader.click()
+    const sortedRows = await trackersTable.$$("tbody tr[data-tracker-url]")
+    const sortedUrls = await sortedRows.map((row) => row.getAttribute("data-tracker-url"))
+    sortedUrls.should.deep.equal([...displayedUrls].sort().reverse())
+
+    const handle = urlHeader.$(".rz-handle")
+    await handle.waitForDisplayed({ timeout: 10_000 })
+    const initialWidth = (await urlHeader.getSize()).width
+    await handle.dragAndDrop({ x: 40, y: 0 })
+    await eventually(async () => (await urlHeader.getSize()).width)
+      .satisfies(`change by at least 10 from ${initialWidth}`, (nextWidth) => Math.abs(nextWidth - initialWidth) >= 10)
+
     await torrent.closeDetailsPanel()
   })
 


### PR DESCRIPTION
## Summary
- retain detail tab data during scheduled refreshes
- restore reliable peer country and unknown flags
- align peer/tracker tables with files styling and add sorting/resizing

## Validation
- npm run lint
- npm run build
- npm run test -- --client "mock" --spec "torrent-peers.spec.ts"
- npm run test -- --client "qbittorrent:latest" --spec "torrent-details.spec.ts"