### PR TITLE
feat(details): copy info values

### DIFF
--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -147,6 +147,10 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
         return clipboard.readText()
     })
 
+    ipcMain.handle(IPC_CHANNELS.clipboard.writeText, async function(_event: IpcMainInvokeEvent, { text }) {
+        clipboard.writeText(text)
+    })
+
     ipcMain.handle(IPC_CHANNELS.shell.openExternal, async function(_event: IpcMainInvokeEvent, { url }) {
         await shell.openExternal(url)
     })

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -92,6 +92,7 @@ const electorrentBridge: ElectorrentBridge = {
     },
     clipboard: {
         readText: () => invoke(IPC_CHANNELS.clipboard.readText),
+        writeText: (text: string) => invoke(IPC_CHANNELS.clipboard.writeText, { text }),
     },
 }
 

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.controller.ts
@@ -46,6 +46,10 @@ export class TorrentDetailsInfoTabController {
     return field.multiline || field.format === "path" ? this.formatFieldValue(field) : "";
   }
 
+  copyFieldValue(field: TorrentDetailsInfoField) {
+    return window.electorrent.clipboard.writeText(this.formatFieldValue(field));
+  }
+
   sectionIcon(sectionId: string) {
     const icons: Record<string, string> = {
       overview: "info circle",

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.less
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.less
@@ -17,9 +17,7 @@ torrent-details-info-tab {
     .torrent-details-section {
         min-width: 0;
         background: @pageForeground;
-        border: 1px solid @borderColor;
-        border-radius: 4px;
-        box-shadow: 0 1px 2px fade(#000, 5%);
+        box-shadow: inset -1px -1px @borderColor;
     }
 
     .torrent-details-section-header {
@@ -31,11 +29,28 @@ torrent-details-info-tab {
         background: fade(@pageMiddleground, 55%);
         border-bottom: 1px solid fade(@borderColor, 75%);
 
-        .icon { width: 1.15rem; margin: 0; color: @primaryColor; text-align: center; }
-        h3 { margin: 0; color: @textColor; font-size: .85rem; font-weight: 700; line-height: 1.2; letter-spacing: .035em; text-transform: uppercase; }
+        .icon {
+            width: 1.15rem;
+            margin: 0;
+            line-height: 1.2;
+            color: @primaryColor;
+            text-align: center;
+        }
+
+        h3 {
+            margin: 0;
+            color: @textColor;
+            font-size: .85rem;
+            font-weight: 700;
+            line-height: 1.2;
+            letter-spacing: .035em;
+            text-transform: uppercase;
+        }
     }
 
-    .torrent-details-field-list { margin: 0; }
+    .torrent-details-field-list {
+        margin: 0;
+    }
 
     .torrent-details-field {
         display: grid;
@@ -44,11 +59,23 @@ torrent-details-info-tab {
         padding: .55rem .85rem;
         border-bottom: 1px solid fade(@borderColor, 42%);
 
-        &:last-child { border-bottom: 0; }
-        &:hover { background: fade(@pageMiddleground, 32%); }
+        &:last-child {
+            border-bottom: 0;
+        }
+
+        &:hover {
+            background: fade(@pageMiddleground, 32%);
+        }
     }
 
-    dt { min-width: 0; color: fade(@textColor, 62%); font-size: .82rem; font-weight: 600; line-height: 1.45; }
+    dt {
+        min-width: 0;
+        color: fade(@textColor, 62%);
+        font-size: .82rem;
+        font-weight: 600;
+        line-height: 1.45;
+    }
+
     dd {
         min-width: 0;
         margin: 0;
@@ -59,7 +86,10 @@ torrent-details-info-tab {
         line-height: 1.35;
         overflow-wrap: anywhere;
         text-align: right;
-        &.multiline { white-space: pre-wrap; }
+
+        &.multiline {
+            white-space: pre-wrap;
+        }
     }
 
     .torrent-details-field-copy {
@@ -80,14 +110,27 @@ torrent-details-info-tab {
     }
 
     .torrent-details-field-value-path,
-    .torrent-details-field-value-text.multiline { font-family: monospace; font-size: .82rem; font-weight: 400; text-align: left; }
+    .torrent-details-field-value-text.multiline {
+        font-family: monospace;
+        font-size: .82rem;
+        font-weight: 400;
+        text-align: left;
+    }
 
     @media (max-width: 720px) {
-        .torrent-details-info { grid-template-columns: minmax(0, 1fr); }
+        .torrent-details-info {
+            grid-template-columns: minmax(0, 1fr);
+        }
     }
 
     @media (max-width: 460px) {
-        .torrent-details-field { grid-template-columns: minmax(0, 1fr); gap: .2rem; }
-        .torrent-details-field dd { text-align: left; }
+        .torrent-details-field {
+            grid-template-columns: minmax(0, 1fr);
+            gap: .2rem;
+        }
+
+        .torrent-details-field dd {
+            text-align: left;
+        }
     }
 }

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.less
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.less
@@ -5,10 +5,10 @@ torrent-details-info-tab {
         align-content: start;
         grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
         grid-auto-rows: max-content;
-        gap: .75rem;
+        gap: 0;
         height: 100%;
         min-height: 0;
-        padding: 1rem;
+        padding: 0;
         overflow-x: hidden;
         overflow-y: auto;
         background: fade(@pageMiddleground, 45%);
@@ -60,6 +60,23 @@ torrent-details-info-tab {
         overflow-wrap: anywhere;
         text-align: right;
         &.multiline { white-space: pre-wrap; }
+    }
+
+    .torrent-details-field-copy {
+        width: 100%;
+        padding: 0;
+        color: inherit;
+        font: inherit;
+        text-align: inherit;
+        white-space: inherit;
+        background: none;
+        border: 0;
+        cursor: copy;
+
+        &:focus-visible {
+            outline: 2px solid @primaryColor;
+            outline-offset: 2px;
+        }
     }
 
     .torrent-details-field-value-path,

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
@@ -20,8 +20,15 @@
         <dd
           class="value torrent-details-field-value torrent-details-field-value-{{ field.format || 'text' }}"
           ng-class="{ multiline: field.multiline }"
-          title="{{ ctl.fieldTitle(field) }}"
-        >{{ ctl.formatFieldValue(field) }}</dd>
+        >
+          <button
+            type="button"
+            class="torrent-details-field-copy"
+            ng-click="ctl.copyFieldValue(field)"
+            title="{{ ctl.fieldTitle(field) || 'Copy value' }}"
+            aria-label="Copy {{ field.label }} value"
+          >{{ ctl.formatFieldValue(field) }}</button>
+        </dd>
       </div>
     </dl>
   </section>

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -456,5 +456,6 @@ export interface ElectorrentBridge {
     }
     clipboard: {
         readText(): Promise<string>
+        writeText(text: string): Promise<void>
     }
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -67,5 +67,6 @@ export const IPC_CHANNELS = {
     },
     clipboard: {
         readText: 'clipboard:read-text',
+        writeText: 'clipboard:write-text',
     },
 } as const

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -91,6 +91,11 @@ describe("torrent details", function () {
     infoText.should.contain(torrentMetadata.infoHash)
     infoText.should.contain(formatBytes(torrentMetadata.length || 0))
 
+    const hashValue = infoTab.$("[data-field-id='hash'] .torrent-details-field-copy")
+    await hashValue.click()
+    const clipboardText = await browser.electron.execute((electron) => electron.clipboard.readText())
+    clipboardText.should.equal(torrentMetadata.infoHash)
+
     await torrent.closeDetailsPanel()
   })
 


### PR DESCRIPTION
## Summary
- remove outer spacing around torrent detail sections
- let Info-tab values copy to the clipboard when clicked
- cover copying a torrent hash in the details E2E spec

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts"