### PR TITLE
refactor(details): isolate tab data loading

### DIFF
--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
@@ -5,6 +5,8 @@ import {
   TorrentDetailsPanelData,
 } from "@renderer/app/bittorrent/torrentclient";
 import { loadSortingState, SortingOptions } from "@renderer/app/directives/sorting/sorting.controller";
+import type { SettingsService } from "@renderer/app/services/settings";
+import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 
 type TorrentDetailsFiles = TorrentDetailsPanelData["files"];
 
@@ -26,24 +28,22 @@ interface TorrentDetailsFileNode {
   data: TorrentDetailsFileItem;
 }
 
-interface UpdateSelectionLocals {
-  files: TorrentDetailsFileItem[];
-  wanted: boolean;
-}
-
 export interface TorrentDetailsFilesTabScope extends IScope {
+  torrent: any;
+  refresh: number;
   files: TorrentDetailsFiles;
   resizeMode: string;
   resizeProfile: string;
-  canSelectFiles: boolean;
-  updateSelection: (locals: UpdateSelectionLocals) => Promise<void>;
   sortedFiles: TorrentDetailsFileRow[];
+  loading: boolean;
+  loaded: boolean;
+  error: string | null;
   selectionUpdating: boolean;
   selectionError: string | null;
 }
 
 export class TorrentDetailsFilesTabController {
-  static $inject = ["$scope", "$filter", "$window"];
+  static $inject = ["$scope", "$rootScope", "$filter", "$window", "settingsService"];
 
   private readonly sortingOptions: SortingOptions = {
     defaultSortKey: "name",
@@ -54,15 +54,24 @@ export class TorrentDetailsFilesTabController {
   private fileSortKey = "name";
   private fileSortDescending = false;
   private readonly collapsedFolders = new Set<string>();
+  private requestId = 0;
+  private torrentHash?: string;
 
   constructor(
     public scope: TorrentDetailsFilesTabScope,
+    private rootScope: ElectorrentRootScope,
     private $filter: IFilterService,
     private $window: IWindowService,
+    private settingsService: SettingsService,
   ) {
+    this.scope.files = { columns: [], items: [] };
     this.scope.sortedFiles = [];
+    this.scope.loading = false;
+    this.scope.loaded = false;
+    this.scope.error = null;
     this.scope.selectionUpdating = false;
     this.scope.selectionError = null;
+    this.configureResize();
     this.scope.$watch(
       () => this.scope.files,
       (files) => {
@@ -74,6 +83,22 @@ export class TorrentDetailsFilesTabController {
         this.sortFiles();
       },
     );
+    this.scope.$watchGroup(
+      [() => this.scope.torrent, () => this.scope.refresh],
+      () => { void this.load(); },
+    );
+    this.scope.$watchGroup(
+      [
+        () => this.settingsService.getAllSettings().ui.resizeMode,
+        () => this.rootScope.$server?.id || this.rootScope.$btclient?.id,
+      ],
+      () => this.configureResize(),
+    );
+    this.scope.$on("$destroy", () => { this.requestId += 1; });
+  }
+
+  canSelectFiles() {
+    return !!this.rootScope.$btclient?.features.fileSelection;
   }
 
   changeSorting = (columnId: string, descending: boolean) => {
@@ -282,7 +307,9 @@ export class TorrentDetailsFilesTabController {
   }
 
   private async updateFileSelection(files: TorrentDetailsFileItem[], wanted: boolean) {
-    if (!this.scope.canSelectFiles || this.scope.selectionUpdating || !files.length) {
+    const client = this.rootScope.$btclient;
+    const torrent = this.scope.torrent;
+    if (!this.canSelectFiles() || !client || !torrent || this.scope.selectionUpdating || !files.length) {
       return;
     }
 
@@ -293,7 +320,10 @@ export class TorrentDetailsFilesTabController {
     this.sortFiles();
 
     try {
-      await this.scope.updateSelection({ files, wanted });
+      await client.setTorrentFileSelection(torrent, files.map((file) => ({ ...file, wanted })));
+      if (this.scope.torrent === torrent) {
+        await this.load();
+      }
     } catch (err) {
       previous.forEach((entry) => { entry.file.wanted = entry.wanted; });
       this.scope.selectionError = err && err.message ? err.message : "Failed to update file selection";
@@ -302,6 +332,52 @@ export class TorrentDetailsFilesTabController {
       this.scope.selectionUpdating = false;
       this.scope.$evalAsync();
     }
+  }
+
+  private async load() {
+    const torrent = this.scope.torrent;
+    if (!torrent) {
+      return;
+    }
+
+    if (this.torrentHash !== torrent.hash) {
+      this.torrentHash = torrent.hash;
+      this.scope.files = { columns: [], items: [] };
+      this.scope.loaded = false;
+      this.collapsedFolders.clear();
+    }
+
+    const requestId = ++this.requestId;
+    this.scope.loading = true;
+    this.scope.error = null;
+
+    try {
+      const client = this.rootScope.$btclient;
+      if (!client) {
+        throw new Error("No torrent client is connected");
+      }
+      const data = await client.getTorrentDetailsFiles(torrent);
+      if (requestId !== this.requestId || this.scope.torrent !== torrent) {
+        return;
+      }
+      this.scope.files = data || { columns: [], items: [] };
+      this.scope.loaded = true;
+    } catch (err) {
+      if (requestId === this.requestId && this.scope.torrent === torrent && !this.scope.loaded) {
+        this.scope.error = err && err.message ? err.message : "Failed to load torrent files";
+      }
+    } finally {
+      if (requestId === this.requestId && this.scope.torrent === torrent) {
+        this.scope.loading = false;
+        this.scope.$evalAsync();
+      }
+    }
+  }
+
+  private configureResize() {
+    const serverId = this.rootScope.$server?.id || this.rootScope.$btclient?.id || "default";
+    this.scope.resizeMode = this.settingsService.getAllSettings().ui.resizeMode || "OverflowResizer";
+    this.scope.resizeProfile = `torrent-details-files.${serverId}`;
   }
 
   private loadSortingSettings() {

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.directive.ts
@@ -6,11 +6,8 @@ export class TorrentDetailsFilesTabDirective implements IDirective {
   template = html;
   restrict = "E";
   scope = {
-    files: "<",
-    resizeMode: "<",
-    resizeProfile: "<",
-    canSelectFiles: "<",
-    updateSelection: "&",
+    torrent: "<",
+    refresh: "<",
   };
   controller = TorrentDetailsFilesTabController;
   controllerAs = "ctl";

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
@@ -1,5 +1,14 @@
 <div class="torrent-details-files" data-role="torrent-details-files">
-  <div class="torrent-details-files-content">
+  <div ng-if="ctl.scope.loading && !ctl.scope.loaded" class="torrent-details-state torrent-details-panel-loader">
+    <div class="ui active inline loader"></div>
+  </div>
+  <div ng-if="ctl.scope.error" class="torrent-details-state torrent-details-message" data-role="torrent-details-message">
+    <div class="torrent-details-state-content">
+      <i class="big warning circle icon"></i>
+      <p>{{ ctl.scope.error }}</p>
+    </div>
+  </div>
+  <div class="torrent-details-files-content" ng-if="!ctl.scope.error && (!ctl.scope.loading || ctl.scope.loaded)">
     <div class="ui tiny negative message torrent-details-files-error" ng-if="ctl.scope.selectionError">
       {{ ctl.scope.selectionError }}
     </div>
@@ -36,7 +45,7 @@
                 data-role="torrent-details-files-select-all"
                 ng-checked="ctl.allFilesWanted()"
                 indeterminate-value="ctl.allFilesSelectionIndeterminate()"
-                ng-disabled="!ctl.scope.canSelectFiles || ctl.scope.selectionUpdating"
+                ng-disabled="!ctl.canSelectFiles() || ctl.scope.selectionUpdating"
                 ng-click="ctl.toggleAllFiles($event)"
               />
               <label></label>
@@ -61,7 +70,7 @@
                   data-role="torrent-details-file-checkbox"
                   ng-checked="ctl.rowWanted(row)"
                   indeterminate-value="ctl.rowSelectionIndeterminate(row)"
-                  ng-disabled="!ctl.scope.canSelectFiles || ctl.scope.selectionUpdating"
+                  ng-disabled="!ctl.canSelectFiles() || ctl.scope.selectionUpdating"
                   ng-click="ctl.toggleRowSelection(row, $event)"
                 />
                 <label></label>

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.controller.ts
@@ -1,17 +1,37 @@
 import { IFilterService, IScope } from "angular";
 import { TorrentDetailsInfoField, TorrentDetailsInfoSection } from "@renderer/app/bittorrent/torrentclient";
+import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 
 export interface TorrentDetailsInfoTabScope extends IScope {
+  torrent: any;
+  refresh: number;
   sections: TorrentDetailsInfoSection[];
+  loading: boolean;
+  loaded: boolean;
+  error: string | null;
 }
 
 export class TorrentDetailsInfoTabController {
-  static $inject = ["$scope", "$filter"];
+  static $inject = ["$scope", "$rootScope", "$filter"];
+
+  private requestId = 0;
+  private torrentHash?: string;
 
   constructor(
     public scope: TorrentDetailsInfoTabScope,
+    private rootScope: ElectorrentRootScope,
     private $filter: IFilterService,
-  ) {}
+  ) {
+    this.scope.sections = [];
+    this.scope.loading = false;
+    this.scope.loaded = false;
+    this.scope.error = null;
+    this.scope.$watchGroup(
+      [() => this.scope.torrent, () => this.scope.refresh],
+      () => { void this.load(); },
+    );
+    this.scope.$on("$destroy", () => { this.requestId += 1; });
+  }
 
   formatFieldValue(field: TorrentDetailsInfoField) {
     switch (field.format) {
@@ -56,6 +76,45 @@ export class TorrentDetailsInfoTabController {
     };
 
     return icons[sectionId] || "list alternate outline";
+  }
+
+  private async load() {
+    const torrent = this.scope.torrent;
+    if (!torrent) {
+      return;
+    }
+
+    if (this.torrentHash !== torrent.hash) {
+      this.torrentHash = torrent.hash;
+      this.scope.sections = [];
+      this.scope.loaded = false;
+    }
+
+    const requestId = ++this.requestId;
+    this.scope.loading = true;
+    this.scope.error = null;
+
+    try {
+      const client = this.rootScope.$btclient;
+      if (!client) {
+        throw new Error("No torrent client is connected");
+      }
+      const data = await client.getTorrentDetails(torrent);
+      if (requestId !== this.requestId || this.scope.torrent !== torrent) {
+        return;
+      }
+      this.scope.sections = data?.sections || [];
+      this.scope.loaded = true;
+    } catch (err) {
+      if (requestId === this.requestId && this.scope.torrent === torrent && !this.scope.loaded) {
+        this.scope.error = err && err.message ? err.message : "Failed to load torrent info";
+      }
+    } finally {
+      if (requestId === this.requestId && this.scope.torrent === torrent) {
+        this.scope.loading = false;
+        this.scope.$evalAsync();
+      }
+    }
   }
 
   private formatPercent(value: unknown) {

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.directive.ts
@@ -6,7 +6,8 @@ export class TorrentDetailsInfoTabDirective implements IDirective {
   template = html;
   restrict = "E";
   scope = {
-    sections: "<",
+    torrent: "<",
+    refresh: "<",
   };
   controller = TorrentDetailsInfoTabController;
   controllerAs = "ctl";

--- a/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-info-tab/torrent-details-info-tab.template.html
@@ -1,5 +1,15 @@
 <div class="torrent-details-info" data-role="torrent-details-info">
+  <div ng-if="ctl.scope.loading && !ctl.scope.loaded" class="torrent-details-state torrent-details-panel-loader">
+    <div class="ui active inline loader"></div>
+  </div>
+  <div ng-if="ctl.scope.error" class="torrent-details-state torrent-details-message" data-role="torrent-details-message">
+    <div class="torrent-details-state-content">
+      <i class="big warning circle icon"></i>
+      <p>{{ ctl.scope.error }}</p>
+    </div>
+  </div>
   <section
+    ng-if="!ctl.scope.error"
     class="torrent-details-section"
     ng-repeat="section in ctl.scope.sections track by section.id"
     aria-labelledby="torrent-details-section-{{ section.id }}"

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -1,19 +1,13 @@
 import { IDocumentService, IScope, IWindowService } from "angular";
-import { TorrentDetailsFileItem, TorrentDetailsPanelData } from "@renderer/app/bittorrent/torrentclient";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 
 type TorrentDetailsTab = "info" | "files" | "peers" | "trackers";
 
 export interface TorrentDetailsPanelScope extends IScope {
-  settings: any;
   isOpen: boolean;
-  loading: boolean;
-  error: string | null;
   torrent: any;
-  panel: TorrentDetailsPanelData;
+  refresh: number;
   activeTab: TorrentDetailsTab;
-  resizeMode: string;
-  resizeProfiles: Record<TorrentDetailsTab, string>;
 }
 
 export class TorrentDetailsPanelController {
@@ -22,10 +16,6 @@ export class TorrentDetailsPanelController {
   private readonly defaultPanelHeight = 320;
   private readonly minPanelHeight = 220;
   private panelHeight = this.defaultPanelHeight;
-  private loadRequestIds: Record<TorrentDetailsTab, number> = { info: 0, files: 0, peers: 0, trackers: 0 };
-  private loadedTabs: Record<TorrentDetailsTab, boolean> = { info: false, files: false, peers: false, trackers: false };
-  private loadingTabs: Record<TorrentDetailsTab, boolean> = { info: false, files: false, peers: false, trackers: false };
-  private tabErrors: Record<TorrentDetailsTab, string | null> = { info: null, files: null, peers: null, trackers: null };
   private stopResizeListeners?: () => void;
 
   constructor(
@@ -35,25 +25,9 @@ export class TorrentDetailsPanelController {
     private $document: IDocumentService,
   ) {
     this.scope.isOpen = false;
-    this.scope.loading = false;
-    this.scope.error = null;
     this.scope.torrent = null;
+    this.scope.refresh = 0;
     this.scope.activeTab = "info";
-    this.scope.resizeMode = "OverflowResizer";
-    this.scope.resizeProfiles = this.getResizeProfiles();
-    this.scope.panel = {
-      info: { sections: [] },
-      files: { columns: [], items: [] },
-      peers: { items: [] },
-      trackers: { items: [] },
-    };
-
-    this.scope.$watch(
-      () => this.scope.settings?.ui?.resizeMode,
-      (resizeMode?: string) => {
-        this.scope.resizeMode = resizeMode || "OverflowResizer";
-      },
-    );
 
     const openListener = this.rootScope.$on("torrentDetails:open", (_event, torrent) => {
       this.open(torrent);
@@ -68,8 +42,8 @@ export class TorrentDetailsPanelController {
         return;
       }
 
-      this.prepareTorrent(torrent);
-      this.loadTab(this.scope.activeTab, torrent, true);
+      this.scope.torrent = torrent;
+      this.scope.refresh += 1;
     });
     const resetListener = this.rootScope.$on("wipe:torrents", () => {
       this.close();
@@ -83,7 +57,7 @@ export class TorrentDetailsPanelController {
     });
   }
 
-  async open(torrent: any) {
+  open(torrent: any) {
     if (!torrent) {
       return;
     }
@@ -91,55 +65,23 @@ export class TorrentDetailsPanelController {
     this.scope.isOpen = true;
     this.panelHeight = this.defaultPanelHeight;
     this.scope.activeTab = "info";
-    this.syncResizeBindings();
-    this.prepareTorrent(torrent);
-    await this.loadTab(this.scope.activeTab, torrent);
+    this.scope.torrent = torrent;
+    this.scope.refresh += 1;
   }
 
   close() {
     this.stopResizeListeners?.();
     this.scope.isOpen = false;
     this.scope.activeTab = "info";
-    this.resetPanelState();
+    this.clearSelection();
   }
 
   showTab(tab: TorrentDetailsTab) {
     this.scope.activeTab = tab;
-    this.syncActiveTabState();
-    if (this.scope.torrent && !this.loadedTabs[tab]) {
-      void this.loadTab(tab, this.scope.torrent);
-    }
   }
 
   isActiveTab(tab: TorrentDetailsTab) {
     return this.scope.activeTab === tab;
-  }
-
-  showStateMessage() {
-    return !this.scope.loading && (!!this.scope.error || !this.scope.torrent);
-  }
-
-  showLoader() {
-    return this.scope.loading && !this.loadedTabs[this.scope.activeTab] && !this.hasActiveTabData();
-  }
-
-  hasActiveTabData() {
-    if (this.scope.activeTab === "info") {
-      return this.scope.panel.info.sections.length > 0;
-    }
-    return this.scope.activeTab === "files"
-      ? this.scope.panel.files.items.length > 0
-      : this.scope.activeTab === "peers"
-        ? this.scope.panel.peers.items.length > 0
-        : this.scope.panel.trackers.items.length > 0;
-  }
-
-  stateMessageIcon() {
-    return this.scope.error ? "warning circle" : "info circle";
-  }
-
-  stateMessageText() {
-    return this.scope.error || "Select a torrent to view its details.";
   }
 
   panelStyle() {
@@ -148,24 +90,9 @@ export class TorrentDetailsPanelController {
     };
   }
 
-  canSelectFiles() {
-    return !!this.rootScope.$btclient?.features.fileSelection;
-  }
-
   canShowPeers() {
     return !!this.rootScope.$btclient?.features.torrentPeers;
   }
-
-  updateFileSelection = async (files: TorrentDetailsFileItem[], wanted: boolean) => {
-    const client = this.rootScope.$btclient;
-    const torrent = this.scope.torrent;
-    if (!this.canSelectFiles() || !client || !torrent || !files.length) {
-      return;
-    }
-
-    await client.setTorrentFileSelection(torrent, files.map((file) => ({ ...file, wanted })));
-    this.scheduleDetailsFilesUpdate(torrent);
-  };
 
   startResizing(event: MouseEvent) {
     event.preventDefault();
@@ -198,117 +125,8 @@ export class TorrentDetailsPanelController {
     this.stopResizeListeners = onMouseUp;
   }
 
-  private getResizeProfiles() {
-    const serverId = this.rootScope.$server?.id || this.rootScope.$btclient?.id || "default";
-    return {
-      info: `torrent-details-info.${serverId}`,
-      files: `torrent-details-files.${serverId}`,
-      peers: `torrent-details-peers.${serverId}`,
-      trackers: `torrent-details-trackers.${serverId}`,
-    };
-  }
-
-  private async loadTab(tab: TorrentDetailsTab, torrent: any, force = false) {
-    if (!force && this.loadedTabs[tab]) {
-      return;
-    }
-    const wasLoaded = this.loadedTabs[tab];
-    const requestId = ++this.loadRequestIds[tab];
-    this.syncResizeBindings();
-    this.loadingTabs[tab] = true;
-    this.tabErrors[tab] = null;
-    this.syncActiveTabState();
-
-    try {
-      const client = this.rootScope.$btclient;
-      const data = tab === "info"
-        ? await client?.getTorrentDetails(torrent)
-        : tab === "files"
-          ? await client?.getTorrentDetailsFiles(torrent)
-          : tab === "peers"
-            ? await client?.getTorrentDetailsPeers(torrent)
-            : await client?.getTorrentDetailsTrackers(torrent);
-      if (requestId !== this.loadRequestIds[tab] || this.scope.torrent !== torrent) {
-        return;
-      }
-
-      if (data) {
-        if (tab === "info") {
-          this.scope.panel.info = data as TorrentDetailsPanelData["info"];
-        } else if (tab === "files") {
-          this.scope.panel.files = data as TorrentDetailsPanelData["files"];
-        } else if (tab === "peers") {
-          this.scope.panel.peers = data as TorrentDetailsPanelData["peers"];
-        } else {
-          this.scope.panel.trackers = data as TorrentDetailsPanelData["trackers"];
-        }
-      }
-      this.loadedTabs[tab] = true;
-    } catch (err) {
-      if (requestId !== this.loadRequestIds[tab] || this.scope.torrent !== torrent) {
-        return;
-      }
-
-      if (!wasLoaded) {
-        this.tabErrors[tab] = err && err.message ? err.message : `Failed to load torrent ${tab}`;
-      }
-    } finally {
-      if (requestId === this.loadRequestIds[tab] && this.scope.torrent === torrent) {
-        this.loadingTabs[tab] = false;
-        this.syncActiveTabState();
-        this.scope.$evalAsync();
-      }
-    }
-  }
-
-  private scheduleDetailsFilesUpdate(torrent: any) {
-    this.scope.$evalAsync(() => {
-      if (this.scope.isOpen && this.scope.torrent === torrent) {
-        void this.loadTab("files", torrent, true);
-      }
-    });
-  }
-
-  private syncResizeBindings() {
-    this.scope.resizeMode = this.scope.settings?.ui?.resizeMode || "OverflowResizer";
-    this.scope.resizeProfiles = this.getResizeProfiles();
-  }
-
   private clearSelection() {
-    this.resetPanelState();
-  }
-
-  private prepareTorrent(torrent: any) {
-    const currentHash = this.scope.torrent?.hash;
-    const nextHash = torrent?.hash;
-    if (!currentHash || !nextHash || currentHash !== nextHash) {
-      this.resetPanelState();
-    }
-    this.scope.torrent = torrent;
-  }
-
-  private syncActiveTabState() {
-    const tab = this.scope.activeTab;
-    this.scope.loading = this.loadingTabs[tab];
-    this.scope.error = this.tabErrors[tab];
-  }
-
-  private resetPanelState() {
-    this.loadRequestIds.info += 1;
-    this.loadRequestIds.files += 1;
-    this.loadRequestIds.peers += 1;
-    this.loadRequestIds.trackers += 1;
-    this.loadedTabs = { info: false, files: false, peers: false, trackers: false };
-    this.loadingTabs = { info: false, files: false, peers: false, trackers: false };
-    this.tabErrors = { info: null, files: null, peers: null, trackers: null };
-    this.scope.loading = false;
-    this.scope.error = null;
     this.scope.torrent = null;
-    this.scope.panel = {
-      info: { sections: [] },
-      files: { columns: [], items: [] },
-      peers: { items: [] },
-      trackers: { items: [] },
-    };
+    this.scope.refresh += 1;
   }
 }

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.directive.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.directive.ts
@@ -5,9 +5,7 @@ import html from "./torrent-details-panel.template.html";
 export class TorrentDetailsPanelDirective implements IDirective {
   template = html;
   restrict = "E";
-  scope = {
-    settings: "=",
-  };
+  scope = {};
   controller = TorrentDetailsPanelController;
   controllerAs = "ctl";
 

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -51,42 +51,34 @@
   </div>
 
   <div class="torrent-details-panel-body">
-    <div ng-if="ctl.showLoader()" class="torrent-details-state torrent-details-panel-loader">
-      <div class="ui active inline loader"></div>
-    </div>
-
-    <div ng-if="ctl.showStateMessage()" class="torrent-details-state torrent-details-message" data-role="torrent-details-message">
+    <div ng-if="!ctl.scope.torrent" class="torrent-details-state torrent-details-message" data-role="torrent-details-message">
       <div class="torrent-details-state-content">
-        <i class="big icon" ng-class="ctl.stateMessageIcon()"></i>
-        <p>{{ ctl.stateMessageText() }}</p>
+        <i class="big info circle icon"></i>
+        <p>Select a torrent to view its details.</p>
       </div>
     </div>
 
     <torrent-details-info-tab
-      ng-if="!ctl.showStateMessage() && ctl.isActiveTab('info')"
-      sections="ctl.scope.panel.info.sections"
+      ng-if="ctl.scope.torrent && ctl.isActiveTab('info')"
+      torrent="ctl.scope.torrent"
+      refresh="ctl.scope.refresh"
     ></torrent-details-info-tab>
 
     <torrent-details-files-tab
-      ng-if="!ctl.showStateMessage() && ctl.isActiveTab('files')"
-      files="ctl.scope.panel.files"
-      resize-mode="ctl.scope.resizeMode"
-      resize-profile="ctl.scope.resizeProfiles.files"
-      can-select-files="ctl.canSelectFiles()"
-      update-selection="ctl.updateFileSelection(files, wanted)"
+      ng-if="ctl.scope.torrent && ctl.isActiveTab('files')"
+      torrent="ctl.scope.torrent"
+      refresh="ctl.scope.refresh"
     ></torrent-details-files-tab>
 
     <torrent-details-peers-tab
-      ng-if="!ctl.showStateMessage() && ctl.isActiveTab('peers')"
-      peers="ctl.scope.panel.peers"
-      resize-mode="ctl.scope.resizeMode"
-      resize-profile="ctl.scope.resizeProfiles.peers"
+      ng-if="ctl.scope.torrent && ctl.isActiveTab('peers')"
+      torrent="ctl.scope.torrent"
+      refresh="ctl.scope.refresh"
     ></torrent-details-peers-tab>
     <torrent-details-trackers-tab
-      ng-if="!ctl.showStateMessage() && ctl.isActiveTab('trackers')"
-      trackers="ctl.scope.panel.trackers.items"
-      resize-mode="ctl.scope.resizeMode"
-      resize-profile="ctl.scope.resizeProfiles.trackers"
+      ng-if="ctl.scope.torrent && ctl.isActiveTab('trackers')"
+      torrent="ctl.scope.torrent"
+      refresh="ctl.scope.refresh"
     ></torrent-details-trackers-tab>
   </div>
 </div>

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
@@ -1,12 +1,19 @@
 import { IScope } from "angular"
+import type { SettingsService } from "@renderer/app/services/settings"
+import type { ElectorrentRootScope } from "@renderer/app/types/root-scope"
 import type { BittorrentTorrentPeer } from "@shared/ipc-contract"
 
 export interface TorrentDetailsPeersTabScope extends IScope {
+  torrent: any
+  refresh: number
   peers: { items: BittorrentTorrentPeer[] }
   resizeMode: string
   resizeProfile: string
   columns: TorrentDetailsPeerColumn[]
   sortedPeers: BittorrentTorrentPeer[]
+  loading: boolean
+  loaded: boolean
+  error: string | null
 }
 
 interface TorrentDetailsPeerColumn {
@@ -16,9 +23,16 @@ interface TorrentDetailsPeerColumn {
 }
 
 export class TorrentDetailsPeersTabController {
-  static $inject = ["$scope"]
+  static $inject = ["$scope", "$rootScope", "settingsService"]
 
-  constructor(public scope: TorrentDetailsPeersTabScope) {
+  private requestId = 0
+  private torrentHash?: string
+
+  constructor(
+    public scope: TorrentDetailsPeersTabScope,
+    private rootScope: ElectorrentRootScope,
+    private settingsService: SettingsService,
+  ) {
     this.scope.columns = [
       { id: "country", label: "Country", sortType: "alphabetical" },
       { id: "ip", label: "IP", sortType: "alphabetical" },
@@ -32,8 +46,25 @@ export class TorrentDetailsPeersTabController {
       { id: "connection", label: "Connection", sortType: "alphabetical" },
       { id: "flags", label: "Flags", sortType: "alphabetical" },
     ]
+    this.scope.peers = { items: [] }
     this.scope.sortedPeers = []
+    this.scope.loading = false
+    this.scope.loaded = false
+    this.scope.error = null
+    this.configureResize()
     this.scope.$watch(() => this.scope.peers, () => this.sortPeers())
+    this.scope.$watchGroup(
+      [() => this.scope.torrent, () => this.scope.refresh],
+      () => { void this.load() },
+    )
+    this.scope.$watchGroup(
+      [
+        () => this.settingsService.getAllSettings().ui.resizeMode,
+        () => this.rootScope.$server?.id || this.rootScope.$btclient?.id,
+      ],
+      () => this.configureResize(),
+    )
+    this.scope.$on("$destroy", () => { this.requestId += 1 })
   }
 
   private sortKey: TorrentDetailsPeerColumn["id"] = "ip"
@@ -59,6 +90,51 @@ export class TorrentDetailsPeersTabController {
 
   progressPercent(peer: BittorrentTorrentPeer) {
     return Math.max(0, Math.min(100, (Number(peer.progress) || 0) * 100))
+  }
+
+  private async load() {
+    const torrent = this.scope.torrent
+    if (!torrent) {
+      return
+    }
+
+    if (this.torrentHash !== torrent.hash) {
+      this.torrentHash = torrent.hash
+      this.scope.peers = { items: [] }
+      this.scope.loaded = false
+    }
+
+    const requestId = ++this.requestId
+    this.scope.loading = true
+    this.scope.error = null
+
+    try {
+      const client = this.rootScope.$btclient
+      if (!client) {
+        throw new Error("No torrent client is connected")
+      }
+      const data = await client.getTorrentDetailsPeers(torrent)
+      if (requestId !== this.requestId || this.scope.torrent !== torrent) {
+        return
+      }
+      this.scope.peers = data || { items: [] }
+      this.scope.loaded = true
+    } catch (err) {
+      if (requestId === this.requestId && this.scope.torrent === torrent && !this.scope.loaded) {
+        this.scope.error = err && err.message ? err.message : "Failed to load torrent peers"
+      }
+    } finally {
+      if (requestId === this.requestId && this.scope.torrent === torrent) {
+        this.scope.loading = false
+        this.scope.$evalAsync()
+      }
+    }
+  }
+
+  private configureResize() {
+    const serverId = this.rootScope.$server?.id || this.rootScope.$btclient?.id || "default"
+    this.scope.resizeMode = this.settingsService.getAllSettings().ui.resizeMode || "OverflowResizer"
+    this.scope.resizeProfile = `torrent-details-peers.${serverId}`
   }
 
   private sortPeers() {

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.directive.ts
@@ -6,9 +6,8 @@ export class TorrentDetailsPeersTabDirective implements IDirective {
   template = html
   restrict = "E"
   scope = {
-    peers: "<",
-    resizeMode: "<",
-    resizeProfile: "<",
+    torrent: "<",
+    refresh: "<",
   }
   controller = TorrentDetailsPeersTabController
   controllerAs = "ctl"

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
@@ -1,5 +1,14 @@
 <div class="torrent-details-peers" data-role="torrent-details-peers">
-  <div class="torrent-details-peers-content torrent-details-table-content">
+  <div ng-if="ctl.scope.loading && !ctl.scope.loaded" class="torrent-details-state torrent-details-panel-loader">
+    <div class="ui active inline loader"></div>
+  </div>
+  <div ng-if="ctl.scope.error" class="torrent-details-state torrent-details-message" data-role="torrent-details-message">
+    <div class="torrent-details-state-content">
+      <i class="big warning circle icon"></i>
+      <p>{{ ctl.scope.error }}</p>
+    </div>
+  </div>
+  <div class="torrent-details-peers-content torrent-details-table-content" ng-if="!ctl.scope.error && (!ctl.scope.loading || ctl.scope.loaded)">
     <table
       id="torrentDetailsPeersTable"
       class="ui compact single line unstackable fixed torrent resize table torrent-details-table"

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
@@ -1,4 +1,6 @@
 import { IScope } from "angular"
+import type { SettingsService } from "@renderer/app/services/settings"
+import type { ElectorrentRootScope } from "@renderer/app/types/root-scope"
 import type { BittorrentTorrentDetailsTracker } from "@shared/ipc-contract"
 
 interface TorrentDetailsTrackerColumn {
@@ -8,20 +10,31 @@ interface TorrentDetailsTrackerColumn {
 }
 
 export interface TorrentDetailsTrackersTabScope extends IScope {
+  torrent: any
+  refresh: number
   trackers: BittorrentTorrentDetailsTracker[]
   resizeMode: string
   resizeProfile: string
   columns: TorrentDetailsTrackerColumn[]
   sortedTrackers: BittorrentTorrentDetailsTracker[]
+  loading: boolean
+  loaded: boolean
+  error: string | null
 }
 
 export class TorrentDetailsTrackersTabController {
-  static $inject = ["$scope"]
+  static $inject = ["$scope", "$rootScope", "settingsService"]
 
   private sortKey: keyof BittorrentTorrentDetailsTracker = "url"
   private sortDescending = false
+  private requestId = 0
+  private torrentHash?: string
 
-  constructor(public scope: TorrentDetailsTrackersTabScope) {
+  constructor(
+    public scope: TorrentDetailsTrackersTabScope,
+    private rootScope: ElectorrentRootScope,
+    private settingsService: SettingsService,
+  ) {
     this.scope.columns = [
       { id: "url", label: "URL", sortType: "alphabetical" },
       { id: "status", label: "Status", sortType: "alphabetical" },
@@ -34,14 +47,76 @@ export class TorrentDetailsTrackersTabController {
       { id: "nextAnnounce", label: "Next announce", sortType: "numeric" },
       { id: "message", label: "Message", sortType: "alphabetical" },
     ]
+    this.scope.trackers = []
     this.scope.sortedTrackers = []
+    this.scope.loading = false
+    this.scope.loaded = false
+    this.scope.error = null
+    this.configureResize()
     this.scope.$watch(() => this.scope.trackers, () => this.sortTrackers())
+    this.scope.$watchGroup(
+      [() => this.scope.torrent, () => this.scope.refresh],
+      () => { void this.load() },
+    )
+    this.scope.$watchGroup(
+      [
+        () => this.settingsService.getAllSettings().ui.resizeMode,
+        () => this.rootScope.$server?.id || this.rootScope.$btclient?.id,
+      ],
+      () => this.configureResize(),
+    )
+    this.scope.$on("$destroy", () => { this.requestId += 1 })
   }
 
   changeSorting = (columnId: keyof BittorrentTorrentDetailsTracker, descending: boolean) => {
     this.sortKey = columnId
     this.sortDescending = descending
     this.sortTrackers()
+  }
+
+  private async load() {
+    const torrent = this.scope.torrent
+    if (!torrent) {
+      return
+    }
+
+    if (this.torrentHash !== torrent.hash) {
+      this.torrentHash = torrent.hash
+      this.scope.trackers = []
+      this.scope.loaded = false
+    }
+
+    const requestId = ++this.requestId
+    this.scope.loading = true
+    this.scope.error = null
+
+    try {
+      const client = this.rootScope.$btclient
+      if (!client) {
+        throw new Error("No torrent client is connected")
+      }
+      const data = await client.getTorrentDetailsTrackers(torrent)
+      if (requestId !== this.requestId || this.scope.torrent !== torrent) {
+        return
+      }
+      this.scope.trackers = data?.items || []
+      this.scope.loaded = true
+    } catch (err) {
+      if (requestId === this.requestId && this.scope.torrent === torrent && !this.scope.loaded) {
+        this.scope.error = err && err.message ? err.message : "Failed to load torrent trackers"
+      }
+    } finally {
+      if (requestId === this.requestId && this.scope.torrent === torrent) {
+        this.scope.loading = false
+        this.scope.$evalAsync()
+      }
+    }
+  }
+
+  private configureResize() {
+    const serverId = this.rootScope.$server?.id || this.rootScope.$btclient?.id || "default"
+    this.scope.resizeMode = this.settingsService.getAllSettings().ui.resizeMode || "OverflowResizer"
+    this.scope.resizeProfile = `torrent-details-trackers.${serverId}`
   }
 
   private sortTrackers() {

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.directive.ts
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.directive.ts
@@ -6,9 +6,8 @@ export class TorrentDetailsTrackersTabDirective implements IDirective {
   template = html;
   restrict = "E";
   scope = {
-    trackers: "<",
-    resizeMode: "<",
-    resizeProfile: "<",
+    torrent: "<",
+    refresh: "<",
   };
   controller = TorrentDetailsTrackersTabController;
   controllerAs = "ctl";

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
@@ -1,5 +1,14 @@
 <div class="torrent-details-trackers" data-role="torrent-details-trackers">
-  <div class="torrent-details-trackers-content torrent-details-table-content">
+  <div ng-if="ctl.scope.loading && !ctl.scope.loaded" class="torrent-details-state torrent-details-panel-loader">
+    <div class="ui active inline loader"></div>
+  </div>
+  <div ng-if="ctl.scope.error" class="torrent-details-state torrent-details-message" data-role="torrent-details-message">
+    <div class="torrent-details-state-content">
+      <i class="big warning circle icon"></i>
+      <p>{{ ctl.scope.error }}</p>
+    </div>
+  </div>
+  <div class="torrent-details-trackers-content torrent-details-table-content" ng-if="!ctl.scope.error && (!ctl.scope.loading || ctl.scope.loaded)">
   <table
     id="torrentDetailsTrackersTable"
     class="ui compact single line unstackable fixed torrent resize table torrent-details-table"

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -112,7 +112,7 @@
                 </table>
             </div>
         </div>
-        <torrent-details-panel settings="settings"></torrent-details-panel>
+        <torrent-details-panel></torrent-details-panel>
         <div class="action footer status-bar">
             <div class="client-version" ng-if="$btclient.version">
                 {{$btclient.name}} {{$btclient.version}}


### PR DESCRIPTION
## Summary
- make the details panel a thin tab and resize orchestrator
- let info, files, peers, and trackers tabs load and own their data independently
- use a minimal torrent plus refresh boundary between panel and tabs

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts"