### PR TITLE
fix(menu): position title menu submenus

### DIFF
--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.less
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.less
@@ -43,10 +43,9 @@ title-bar-menu {
         }
     }
 
-    .title-bar-menu-dropdown {
+    .title-bar-menu-dropdown,
+    .title-bar-menu-flyout {
         position: absolute;
-        top: 34px;
-        left: 0;
         z-index: 1002;
         width: max-content;
         min-width: 270px;
@@ -58,6 +57,26 @@ title-bar-menu {
         border-radius: @defaultBorderRadius;
         box-shadow: @subtleShadow;
         app-region: no-drag;
+    }
+
+    .title-bar-menu-dropdown {
+        top: 34px;
+        left: 0;
+    }
+
+    .title-bar-menu-submenu {
+        position: relative;
+    }
+
+    .title-bar-menu-flyout {
+        top: -7px;
+        left: calc(100% - 1px);
+        display: none;
+    }
+
+    .title-bar-menu-submenu:not(.disabled):hover > .title-bar-menu-flyout,
+    .title-bar-menu-submenu:not(.disabled):focus-within > .title-bar-menu-flyout {
+        display: block;
     }
 
     .title-bar-menu-item {
@@ -88,6 +107,15 @@ title-bar-menu {
     .title-bar-menu-item.checked .title-bar-menu-check::before { content: "\2713"; }
     .title-bar-menu-label { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
     .title-bar-menu-accelerator { flex: 0 0 auto; margin-left: auto; color: @lightTextColor; font-size: .9em; }
+    .title-bar-menu-submenu-arrow {
+        flex: 0 0 7px;
+        width: 7px;
+        height: 7px;
+        margin-left: 4px;
+        border-top: 1.5px solid currentColor;
+        border-right: 1.5px solid currentColor;
+        transform: rotate(45deg);
+    }
     .title-bar-menu-item.disabled .title-bar-menu-accelerator,
     .title-bar-menu-item:disabled .title-bar-menu-accelerator { color: @disabledTextColor; }
     .title-bar-menu-divider { height: 1px; margin: 6px 0; background-color: @borderColor; }

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.template.html
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.template.html
@@ -1,43 +1,3 @@
-<script type="text/ng-template" id="title-bar-menu-items.html">
-    <div ng-repeat="item in visibleTitleBarMenuItems(currentMenu) track by $index">
-        <div ng-if="item.type === 'separator'" class="title-bar-menu-divider" role="separator"></div>
-        <button
-            ng-if="item.type !== 'separator' && !item.submenu"
-            type="button"
-            class="title-bar-menu-item"
-            ng-class="{ disabled: item.enabled === false, checked: item.checked }"
-            ng-click="runTitleBarMenuItem(item, $event)"
-            ng-mousedown="$event.preventDefault()"
-            role="menuitem"
-            ng-disabled="item.enabled === false">
-            <span class="title-bar-menu-check"></span>
-            <span class="title-bar-menu-label">{{item.label}}</span>
-            <span class="title-bar-menu-accelerator">{{formatTitleMenuAccelerator(item.accelerator)}}</span>
-        </button>
-        <div
-            ng-if="item.type !== 'separator' && item.submenu"
-            class="title-bar-menu-submenu"
-            ng-class="{ disabled: item.enabled === false }">
-            <button
-                type="button"
-                class="title-bar-menu-item title-bar-menu-submenu-trigger"
-                ng-class="{ disabled: item.enabled === false, checked: item.checked }"
-                ng-mousedown="$event.preventDefault()"
-                role="menuitem"
-                aria-haspopup="true"
-                ng-disabled="item.enabled === false">
-                <span class="title-bar-menu-check"></span>
-                <span class="title-bar-menu-label">{{item.label}}</span>
-                <span class="title-bar-menu-accelerator">{{formatTitleMenuAccelerator(item.accelerator)}}</span>
-                <span class="title-bar-menu-submenu-arrow" aria-hidden="true"></span>
-            </button>
-            <div class="title-bar-menu-flyout" role="menu">
-                <div ng-init="currentMenu = item" ng-include="'title-bar-menu-items.html'"></div>
-            </div>
-        </div>
-    </div>
-</script>
-
 <nav class="title-bar-menu" aria-label="Application menu">
     <div class="title-bar-menu-root" ng-repeat="menu in titleBarMenus track by menu.label">
         <button
@@ -52,7 +12,58 @@
             {{menu.label}}
         </button>
         <div class="title-bar-menu-dropdown" ng-if="activeTitleBarMenu === $index" ng-click="$event.stopPropagation()" role="menu">
-            <div ng-init="currentMenu = menu" ng-include="'title-bar-menu-items.html'"></div>
+            <div ng-repeat="item in visibleTitleBarMenuItems(menu) track by $index">
+                <div ng-if="item.type === 'separator'" class="title-bar-menu-divider" role="separator"></div>
+                <button
+                    ng-if="item.type !== 'separator' && !item.submenu"
+                    type="button"
+                    class="title-bar-menu-item"
+                    ng-class="{ disabled: item.enabled === false, checked: item.checked }"
+                    ng-click="runTitleBarMenuItem(item, $event)"
+                    ng-mousedown="$event.preventDefault()"
+                    role="menuitem"
+                    ng-disabled="item.enabled === false">
+                    <span class="title-bar-menu-check"></span>
+                    <span class="title-bar-menu-label">{{item.label}}</span>
+                    <span class="title-bar-menu-accelerator">{{formatTitleMenuAccelerator(item.accelerator)}}</span>
+                </button>
+                <div
+                    ng-if="item.type !== 'separator' && item.submenu"
+                    class="title-bar-menu-submenu"
+                    ng-class="{ disabled: item.enabled === false }">
+                    <button
+                        type="button"
+                        class="title-bar-menu-item title-bar-menu-submenu-trigger"
+                        ng-class="{ disabled: item.enabled === false, checked: item.checked }"
+                        ng-mousedown="$event.preventDefault()"
+                        role="menuitem"
+                        aria-haspopup="true"
+                        ng-disabled="item.enabled === false">
+                        <span class="title-bar-menu-check"></span>
+                        <span class="title-bar-menu-label">{{item.label}}</span>
+                        <span class="title-bar-menu-accelerator">{{formatTitleMenuAccelerator(item.accelerator)}}</span>
+                        <span class="title-bar-menu-submenu-arrow" aria-hidden="true"></span>
+                    </button>
+                    <div class="title-bar-menu-flyout" role="menu">
+                        <div ng-repeat="child in visibleTitleBarMenuItems(item) track by $index">
+                            <div ng-if="child.type === 'separator'" class="title-bar-menu-divider" role="separator"></div>
+                            <button
+                                ng-if="child.type !== 'separator'"
+                                type="button"
+                                class="title-bar-menu-item"
+                                ng-class="{ disabled: child.enabled === false, checked: child.checked }"
+                                ng-click="runTitleBarMenuItem(child, $event)"
+                                ng-mousedown="$event.preventDefault()"
+                                role="menuitem"
+                                ng-disabled="child.enabled === false">
+                                <span class="title-bar-menu-check"></span>
+                                <span class="title-bar-menu-label">{{child.label}}</span>
+                                <span class="title-bar-menu-accelerator">{{formatTitleMenuAccelerator(child.accelerator)}}</span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </nav>

--- a/src/renderer/app/directives/title-bar-menu/title-bar-menu.template.html
+++ b/src/renderer/app/directives/title-bar-menu/title-bar-menu.template.html
@@ -1,3 +1,43 @@
+<script type="text/ng-template" id="title-bar-menu-items.html">
+    <div ng-repeat="item in visibleTitleBarMenuItems(currentMenu) track by $index">
+        <div ng-if="item.type === 'separator'" class="title-bar-menu-divider" role="separator"></div>
+        <button
+            ng-if="item.type !== 'separator' && !item.submenu"
+            type="button"
+            class="title-bar-menu-item"
+            ng-class="{ disabled: item.enabled === false, checked: item.checked }"
+            ng-click="runTitleBarMenuItem(item, $event)"
+            ng-mousedown="$event.preventDefault()"
+            role="menuitem"
+            ng-disabled="item.enabled === false">
+            <span class="title-bar-menu-check"></span>
+            <span class="title-bar-menu-label">{{item.label}}</span>
+            <span class="title-bar-menu-accelerator">{{formatTitleMenuAccelerator(item.accelerator)}}</span>
+        </button>
+        <div
+            ng-if="item.type !== 'separator' && item.submenu"
+            class="title-bar-menu-submenu"
+            ng-class="{ disabled: item.enabled === false }">
+            <button
+                type="button"
+                class="title-bar-menu-item title-bar-menu-submenu-trigger"
+                ng-class="{ disabled: item.enabled === false, checked: item.checked }"
+                ng-mousedown="$event.preventDefault()"
+                role="menuitem"
+                aria-haspopup="true"
+                ng-disabled="item.enabled === false">
+                <span class="title-bar-menu-check"></span>
+                <span class="title-bar-menu-label">{{item.label}}</span>
+                <span class="title-bar-menu-accelerator">{{formatTitleMenuAccelerator(item.accelerator)}}</span>
+                <span class="title-bar-menu-submenu-arrow" aria-hidden="true"></span>
+            </button>
+            <div class="title-bar-menu-flyout" role="menu">
+                <div ng-init="currentMenu = item" ng-include="'title-bar-menu-items.html'"></div>
+            </div>
+        </div>
+    </div>
+</script>
+
 <nav class="title-bar-menu" aria-label="Application menu">
     <div class="title-bar-menu-root" ng-repeat="menu in titleBarMenus track by menu.label">
         <button
@@ -12,38 +52,7 @@
             {{menu.label}}
         </button>
         <div class="title-bar-menu-dropdown" ng-if="activeTitleBarMenu === $index" ng-click="$event.stopPropagation()" role="menu">
-            <div ng-repeat="item in visibleTitleBarMenuItems(menu) track by $index">
-                <div ng-if="item.type === 'separator'" class="title-bar-menu-divider" role="separator"></div>
-                <button
-                    ng-if="item.type !== 'separator' && !item.submenu"
-                    type="button"
-                    class="title-bar-menu-item"
-                    ng-class="{ disabled: item.enabled === false, checked: item.checked }"
-                    ng-click="runTitleBarMenuItem(item, $event)"
-                    ng-mousedown="$event.preventDefault()"
-                    role="menuitem"
-                    ng-disabled="item.enabled === false">
-                    <span class="title-bar-menu-check"></span>
-                    <span class="title-bar-menu-label">{{item.label}}</span>
-                    <span class="title-bar-menu-accelerator">{{formatTitleMenuAccelerator(item.accelerator)}}</span>
-                </button>
-                <div ng-if="item.submenu" class="title-bar-menu-submenu">
-                    <div class="title-bar-menu-submenu-label">{{item.label}}</div>
-                    <button
-                        ng-repeat="child in item.submenu track by $index"
-                        type="button"
-                        class="title-bar-menu-item title-bar-menu-submenu-item"
-                        ng-class="{ disabled: child.enabled === false }"
-                        ng-click="runTitleBarMenuItem(child, $event)"
-                        ng-mousedown="$event.preventDefault()"
-                        role="menuitem"
-                        ng-disabled="child.enabled === false">
-                        <span class="title-bar-menu-check"></span>
-                        <span class="title-bar-menu-label">{{child.label}}</span>
-                        <span class="title-bar-menu-accelerator">{{formatTitleMenuAccelerator(child.accelerator)}}</span>
-                    </button>
-                </div>
-            </div>
+            <div ng-init="currentMenu = menu" ng-include="'title-bar-menu-items.html'"></div>
         </div>
     </div>
 </nav>

--- a/test/specs/mock/actions-menu.spec.ts
+++ b/test/specs/mock/actions-menu.spec.ts
@@ -50,6 +50,34 @@ describe("mock Actions menu", function () {
     await detailsShortcut.waitForDisplayed()
     assert.notInclude(await detailsShortcut.getText(), "CmdOrCtrl")
   })
+
+  it("opens submenu items in a flyout to the right", async function () {
+    await browser.keys("Escape")
+
+    const row = $("#torrentTable tbody tr[data-hash]")
+    await row.waitForClickable()
+    await row.click()
+
+    const actionsMenu = $("//button[contains(@class, 'title-bar-menu-trigger') and normalize-space(.)='Actions']")
+    await actionsMenu.waitForClickable()
+    await actionsMenu.click()
+
+    const queueTrigger = $("//button[contains(@class, 'title-bar-menu-submenu-trigger')][.//span[normalize-space(.)='Queue']]")
+    await queueTrigger.waitForEnabled()
+    assert.isTrue(await queueTrigger.$(".title-bar-menu-submenu-arrow").isExisting())
+
+    const queueFlyout = queueTrigger.$("..").$(".title-bar-menu-flyout")
+    assert.isFalse(await queueFlyout.isDisplayed())
+
+    await queueTrigger.moveTo()
+    await queueFlyout.waitForDisplayed()
+    assert.equal(await queueFlyout.$(".title-bar-menu-label").getText(), "Move Up Queue")
+
+    const triggerX = await queueTrigger.getLocation("x")
+    const triggerWidth = await queueTrigger.getSize("width")
+    const flyoutX = await queueFlyout.getLocation("x")
+    assert.isAtLeast(flyoutX, triggerX + triggerWidth - 2)
+  })
 })
 
 async function getActionsMenu() {


### PR DESCRIPTION
## Summary
- render title-menu submenus as right-side flyouts
- show a chevron on submenu parent rows
- cover Queue flyout visibility and placement

## Validation
- npm run lint
- npm run build
- npm run test -- --client "mock" --spec "test/specs/mock/actions-menu.spec.ts"