### PR TITLE
test(mock): cover search actions servers

### DIFF
--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -97,6 +97,7 @@ export class TorrentsPageController {
             minMatchCharLength: 1,
             keys: [
                 "decodedName",
+                "hash",
             ],
         };
 

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -97,7 +97,6 @@ export class TorrentsPageController {
             minMatchCharLength: 1,
             keys: [
                 "decodedName",
-                "hash",
             ],
         };
 
@@ -891,7 +890,11 @@ export class TorrentsPageController {
             if ($scope.filters.search) {
                 const value = search || $scope.filters.search;
                 fuse.setCollection(torrents);
-                return fuse.search(value);
+                const matchingHashes = torrents.filter((torrent) => {
+                    return typeof torrent.hash === "string"
+                        && torrent.hash.toLowerCase().includes(value.toLowerCase());
+                });
+                return Array.from(new Set([...fuse.search(value), ...matchingHashes]));
             }
             return torrents;
         }

--- a/test/specs/mock/bulk-torrent-actions.spec.ts
+++ b/test/specs/mock/bulk-torrent-actions.spec.ts
@@ -1,0 +1,98 @@
+import chai from "chai"
+import { $, $$, browser } from "@wdio/globals"
+import { Key } from "webdriverio"
+import { eventually } from "../../e2e/eventually"
+import { configureSpec } from "../../framework/fixture"
+
+const assert: Chai.AssertStatic = chai.assert
+
+const torrents = [
+  { hash: "11".padStart(40, "0"), name: "Selected torrent one", state: "downloading" },
+  { hash: "22".padStart(40, "0"), name: "Selected torrent two", state: "downloading" },
+  { hash: "33".padStart(40, "0"), name: "Unselected torrent", state: "downloading" },
+]
+
+describe("mock bulk torrent actions", function () {
+  configureSpec({ clearTorrents: false })
+
+  before(async function () {
+    await invokeMockAction("clearMockedTorrents")
+    for (const torrent of torrents) {
+      await invokeMockAction("addMockedTorrent", torrent)
+    }
+    await eventually(async () => (await $$("#torrentTable tbody tr[data-hash]")).length)
+      .equals(torrents.length)
+  })
+
+  it("applies a stop and resume action to every selected torrent", async function () {
+    const firstSelected = await $(`#torrentTable tbody tr[data-hash='${torrents[0].hash}']`)
+    const secondSelected = await $(`#torrentTable tbody tr[data-hash='${torrents[1].hash}']`)
+    await firstSelected.waitForClickable()
+    await firstSelected.click()
+    await shiftClick(secondSelected)
+
+    await eventually(getSelectedHashes).satisfies(
+      "include both selected torrents",
+      (hashes) => hashes.length === 2
+        && hashes.includes(torrents[0].hash)
+        && hashes.includes(torrents[1].hash),
+    )
+
+    const stopButton = $("#torrent-action-header a[data-role='stop']")
+    await stopButton.waitForClickable()
+    await stopButton.click()
+
+    await expectTorrentState(torrents[0].hash, "Stopped")
+    await expectTorrentState(torrents[1].hash, "Stopped")
+    assert.include(await getTorrentState(torrents[2].hash), "Downloading")
+
+    const resumeButton = $("#torrent-action-header a[data-role='resume']")
+    await resumeButton.waitForClickable()
+    await resumeButton.click()
+
+    await expectTorrentState(torrents[0].hash, "Downloading")
+    await expectTorrentState(torrents[1].hash, "Downloading")
+    assert.include(await getTorrentState(torrents[2].hash), "Downloading")
+  })
+})
+
+async function invokeMockAction(action: string, ...args: any[]) {
+  await browser.execute(async (request) => {
+    await (window as any).electorrent.bittorrent.invokeAction(request)
+  }, { action, args })
+}
+
+async function shiftClick(row: Awaited<ReturnType<typeof $>>) {
+  await browser.actions([
+    browser.action("key")
+      .down(Key.Shift)
+      .pause(0)
+      .pause(0)
+      .pause(0)
+      .up(Key.Shift),
+    browser.action("pointer")
+      .pause(0)
+      .move({ origin: row, duration: 0 })
+      .down({ button: 0 })
+      .up({ button: 0 })
+      .pause(0),
+  ])
+}
+
+async function getSelectedHashes() {
+  const rows = await $$("#torrentTable tbody tr.active[data-hash]")
+  const hashes: string[] = []
+  for (const row of rows) {
+    hashes.push(await row.getAttribute("data-hash"))
+  }
+  return hashes
+}
+
+async function getTorrentState(hash: string) {
+  return $(`#torrentTable tbody tr[data-hash='${hash}'] td[data-col='percent']`).getText()
+}
+
+async function expectTorrentState(hash: string, expected: string) {
+  await eventually(() => getTorrentState(hash))
+    .satisfies(`include ${expected}`, (state) => state.includes(expected))
+}

--- a/test/specs/mock/saved-servers.spec.ts
+++ b/test/specs/mock/saved-servers.spec.ts
@@ -1,0 +1,90 @@
+import chai from "chai"
+import { $, $$ } from "@wdio/globals"
+import { configureSpec, getTestFixture } from "../../framework/fixture"
+import { restartApplication } from "../../shared"
+
+const assert: Chai.AssertStatic = chai.assert
+const savedServerHost = "saved-mock.local"
+
+describe("mock saved servers", function () {
+  configureSpec({ clearTorrents: false })
+
+  it("adds, persists, and removes a saved server through Settings", async function () {
+    const app = getTestFixture().app
+    const serverMenu = $("//button[contains(@class, 'title-bar-menu-trigger') and normalize-space(.)='Servers']")
+    await serverMenu.waitForClickable()
+    await serverMenu.click()
+
+    const addServer = $("//button[contains(@class, 'title-bar-menu-item')][.//span[normalize-space(.)='Add new server...']]")
+    await addServer.waitForClickable()
+    await addServer.click()
+    await app.welcomePageIsVisible()
+
+    await app.login({
+      host: savedServerHost,
+      username: "",
+      password: "",
+      port: 1,
+      clientId: "mock",
+    })
+    await app.torrentsPageIsVisible()
+
+    await app.openSettings()
+    await app.settingsGotoTab("servers")
+    assert.include(await getSettingsServerHosts(), savedServerHost)
+    await app.settingsCancel()
+
+    await restartApplication(this)
+    await app.serverSelectionPageIsVisible()
+    assert.isTrue(
+      (await getServerSelectionAddresses()).some((address) => address.endsWith(`@ ${savedServerHost}`)),
+      `expected the server selection to include ${savedServerHost}`,
+    )
+
+    await app.connectServerSelection(0)
+    await app.torrentsPageIsVisible()
+    await app.openSettings()
+    await app.settingsGotoTab("servers")
+    await removeSettingsServer(savedServerHost)
+    await app.settingsSave()
+    await app.torrentsPageIsVisible()
+
+    await restartApplication(this)
+    await app.torrentsPageIsVisible()
+    await app.openSettings()
+    await app.settingsGotoTab("servers")
+    assert.notInclude(await getSettingsServerHosts(), savedServerHost)
+    assert.equal(await app.getSettingsServerCount(), 1)
+  })
+})
+
+async function getSettingsServerHosts() {
+  const rows = await $$("#page-settings-servers tbody tr")
+  const hosts: string[] = []
+  for (const row of rows) {
+    hosts.push((await row.$("td:nth-child(3)").getText()).trim())
+  }
+  return hosts
+}
+
+async function getServerSelectionAddresses() {
+  const cards = await $$("#page-server-selection .server.list .card")
+  const hosts: string[] = []
+  for (const card of cards) {
+    hosts.push((await card.$(".meta").getText()).trim())
+  }
+  return hosts
+}
+
+async function removeSettingsServer(host: string) {
+  const rows = await $$("#page-settings-servers tbody tr")
+  for (const row of rows) {
+    if ((await row.$("td:nth-child(3)").getText()).trim() === host) {
+      const removeButton = row.$("button.circular.red")
+      await removeButton.waitForClickable()
+      await removeButton.click()
+      return
+    }
+  }
+  assert.fail(`Saved server ${host} was not found`)
+}

--- a/test/specs/mock/torrent-search.spec.ts
+++ b/test/specs/mock/torrent-search.spec.ts
@@ -1,5 +1,6 @@
 import chai from "chai"
 import { $, $$, browser } from "@wdio/globals"
+import { Key } from "webdriverio"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec } from "../../framework/fixture"
 
@@ -51,7 +52,10 @@ async function getVisibleHashes() {
 }
 
 async function setSearch(searchInput: ReturnType<typeof $>, value: string) {
-  await searchInput.setValue(value)
+  await searchInput.click()
+  const selectAllKey = process.platform === "darwin" ? Key.Command : Key.Control
+  await browser.keys([selectAllKey, "a"])
+  await browser.keys(value || Key.Backspace)
   await eventually(() => searchInput.getValue()).equals(value)
 }
 

--- a/test/specs/mock/torrent-search.spec.ts
+++ b/test/specs/mock/torrent-search.spec.ts
@@ -52,11 +52,13 @@ async function getVisibleHashes() {
 }
 
 async function setSearch(searchInput: ReturnType<typeof $>, value: string) {
-  await searchInput.clearValue()
+  await searchInput.click()
+  await browser.keys([Key.Ctrl, "a"])
   if (value) {
-    await searchInput.addValue(value)
+    await browser.keys(value)
+  } else {
+    await browser.keys(Key.Backspace)
   }
-  await browser.keys(Key.Tab)
   await eventually(() => searchInput.getValue()).equals(value)
 }
 

--- a/test/specs/mock/torrent-search.spec.ts
+++ b/test/specs/mock/torrent-search.spec.ts
@@ -1,6 +1,5 @@
 import chai from "chai"
 import { $, $$, browser } from "@wdio/globals"
-import { Key } from "webdriverio"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec } from "../../framework/fixture"
 
@@ -52,13 +51,7 @@ async function getVisibleHashes() {
 }
 
 async function setSearch(searchInput: ReturnType<typeof $>, value: string) {
-  await searchInput.click()
-  await browser.keys([Key.Ctrl, "a"])
-  if (value) {
-    await browser.keys(value)
-  } else {
-    await browser.keys(Key.Backspace)
-  }
+  await searchInput.setValue(value)
   await eventually(() => searchInput.getValue()).equals(value)
 }
 

--- a/test/specs/mock/torrent-search.spec.ts
+++ b/test/specs/mock/torrent-search.spec.ts
@@ -1,0 +1,77 @@
+import chai from "chai"
+import { $, $$, browser } from "@wdio/globals"
+import { Key } from "webdriverio"
+import { eventually } from "../../e2e/eventually"
+import { configureSpec } from "../../framework/fixture"
+
+const assert: Chai.AssertStatic = chai.assert
+
+const torrents = [
+  { hash: "1234567890abcdef1234567890abcdef12345678", name: "Alpine Linux image" },
+  { hash: "deadbeef0123456789abcdef0123456789abcdef", name: "Debian installation media" },
+  { hash: "fedcba0987654321fedcba0987654321fedcba09", name: "Fedora workstation image" },
+]
+
+describe("mock torrent search", function () {
+  configureSpec({ clearTorrents: false })
+
+  before(async function () {
+    await invokeMockAction("clearMockedTorrents")
+    for (const torrent of torrents) {
+      await invokeMockAction("addMockedTorrent", torrent)
+    }
+    await expectVisibleHashes(torrents.map(({ hash }) => hash))
+  })
+
+  it("filters torrents by name and info hash search", async function () {
+    const searchInput = $("input[placeholder='Search torrents...']")
+    await searchInput.waitForDisplayed()
+
+    await expectSearchResults(searchInput, "Debian installation", [torrents[1].hash])
+
+    await expectSearchResults(searchInput, "deadbeef", [torrents[1].hash])
+
+    await expectSearchResults(searchInput, "", torrents.map(({ hash }) => hash))
+    assert.equal(await searchInput.getValue(), "")
+  })
+})
+
+async function invokeMockAction(action: string, ...args: any[]) {
+  await browser.execute(async (request) => {
+    await (window as any).electorrent.bittorrent.invokeAction(request)
+  }, { action, args })
+}
+
+async function getVisibleHashes() {
+  const rows = await $$("#torrentTable tbody tr[data-hash]")
+  const hashes: string[] = []
+  for (const row of rows) {
+    hashes.push(await row.getAttribute("data-hash"))
+  }
+  return hashes
+}
+
+async function setSearch(searchInput: ReturnType<typeof $>, value: string) {
+  await searchInput.clearValue()
+  if (value) {
+    await searchInput.addValue(value)
+  }
+  await browser.keys(Key.Tab)
+  await eventually(() => searchInput.getValue()).equals(value)
+}
+
+async function expectSearchResults(searchInput: ReturnType<typeof $>, search: string, expected: string[]) {
+  const sortedExpected = [...expected].sort().join(",")
+  await setSearch(searchInput, search)
+  await eventually(async () => {
+    if (await searchInput.getValue() !== search) {
+      await setSearch(searchInput, search)
+    }
+    return (await getVisibleHashes()).sort().join(",")
+  }).equals(sortedExpected)
+}
+
+async function expectVisibleHashes(expected: string[]) {
+  await eventually(async () => (await getVisibleHashes()).sort().join(","))
+    .equals([...expected].sort().join(","))
+}


### PR DESCRIPTION
## Summary
- add mock coverage for name and hash torrent search
- cover bulk stop and resume actions
- cover saved-server persistence and removal

## Validation
- npm run lint
- npm run build
- npm run test -- --client "mock" --spec "test/specs/mock/torrent-search.spec.ts" --spec "test/specs/mock/bulk-torrent-actions.spec.ts" --spec "test/specs/mock/saved-servers.spec.ts"