### PR TITLE
test: run CI against packaged app

### DIFF
--- a/.github/workflows/electorrent-workflow.yml
+++ b/.github/workflows/electorrent-workflow.yml
@@ -62,8 +62,10 @@ jobs:
       run: npm install
     - name: Build web application
       run: npm run build
+    - name: Package application
+      run: npm run pack
     - name: Run tests
-      run: xvfb-run -a -- npm test -- --client "${{ matrix.client }}"
+      run: xvfb-run -a -- npm test -- --dist --client "${{ matrix.client }}"
 
   build:
     strategy:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:webpack": "webpack --config webpack.config.js",
     "build:watch": "webpack --config webpack.config.js --watch",
     "postinstall": "electron-builder install-app-deps",
-    "pack": "build --dir",
+    "pack": "electron-builder --dir",
     "predist": "npm run build",
     "dist": "electron-builder --publish never",
     "prerelease": "npm run build",

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -10,6 +10,7 @@ delete process.env.ELECTRON_RUN_AS_NODE
 const standardSpecs = [
     'test/specs/standard/**/*.spec.ts',
 ]
+const useDistribution = process.argv.includes('--dist')
 
 function requestedClients() {
     return process.argv.flatMap((argument, index, arguments_) => {
@@ -39,7 +40,7 @@ function electronCapability(client: (typeof selectedClients)[number]): Webdriver
         'wdio:specs': client.specs ?? standardSpecs,
         'electorrent:client': client,
         'wdio:electronServiceOptions': {
-            appEntryPoint: 'app/main.js',
+            ...useDistribution ? {} : { appEntryPoint: 'app/main.js' },
             appArgs: client.appArgs ?? [],
         },
         'goog:chromeOptions': {


### PR DESCRIPTION
## Summary

- add an opt-in `--dist` WebdriverIO test mode for electron-builder output
- package the app before CI test execution and enable that mode
- repair the package script to invoke electron-builder directly

## Validation

- npm run lint
- npm run build
- npm run pack
- npm run smoketest -- --dist