### PR TITLE
test(wdio): retry flaky Mocha tests

### DIFF
--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -210,7 +210,8 @@ export const config: WebdriverIO.Config = {
     // See the full list at http://mochajs.org/
     mochaOpts: {
         ui: 'bdd',
-        timeout: 60000
+        timeout: 60000,
+        retries: 3
     },
 
     //


### PR DESCRIPTION
## Summary
- retry globally configured Mocha tests up to three times

## Validation
- npm run build
- npm run smoketest
- npx eslint wdio.conf.ts

Full `npm run lint` remains blocked by unrelated TypeScript errors in existing Angular renderer files.