### PR TITLE
fix(torrent-details): restore table scrolling

### DIFF
--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
@@ -1,6 +1,6 @@
 torrent-details-files-tab {
     .torrent-details-files,
-    .torrent-details-files-content { flex: 1 1 auto; height: 100%; min-height: 0; }
+    .torrent-details-files-content { flex: 1 1 auto; height: 100%; min-width: 0; min-height: 0; }
     .torrent-details-files { display: flex; flex-direction: column; overflow: hidden; }
     .torrent-details-files-content { overflow: auto; }
 

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.less
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.less
@@ -54,6 +54,7 @@ torrent-details-panel {
         torrent-details-trackers-tab {
             flex: 1 1 auto;
             display: flex;
+            min-width: 0;
             min-height: 0;
         }
     }

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.less
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.less
@@ -3,6 +3,7 @@ torrent-details-peers-tab {
     .torrent-details-peers-content {
         flex: 1 1 auto;
         height: 100%;
+        min-width: 0;
         min-height: 0;
     }
 

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.less
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.less
@@ -2,6 +2,7 @@ torrent-details-trackers-tab {
     .torrent-details-trackers {
         flex: 1 1 auto;
         height: 100%;
+        min-width: 0;
         min-height: 0;
         overflow: auto;
 


### PR DESCRIPTION
## Summary
- let torrent detail tab flex containers shrink to panel width
- enable horizontal overflow on resized files, peers, and trackers tables

## Validation
- npm run build
- npm run lint *(blocked by pre-existing TypeScript errors)*
- targeted torrent-details test *(blocked by incompatible installed WDIO dependencies)*