### PR TITLE
fix(sidebar): style no-label chip

### DIFF
--- a/src/renderer/app/directives/label-chip/label-chip.less
+++ b/src/renderer/app/directives/label-chip/label-chip.less
@@ -1,5 +1,6 @@
 [label-chip],
-[label-color] {
+[label-color],
+.label-chip {
     &.ui.circular.label.label-chip {
         display: inline-flex;
         align-items: center;

--- a/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.less
+++ b/src/renderer/app/directives/torrent-sidebar/torrent-sidebar-section.less
@@ -36,7 +36,7 @@ torrent-sidebar-section {
         &.is-active { border: 2px solid oklch(@labelChipDotLightness @labelChipDotChroma var(--label-hue, 225)); }
     }
 
-    .ui.circular.label.torrent-sidebar-label-chip--empty {
+    .ui.circular.label.label-chip.torrent-sidebar-label-chip--empty {
         justify-content: flex-start;
         color: @textColor;
         line-height: 1.15;


### PR DESCRIPTION
## Summary
- apply shared label-chip layout and selection styles to the special No label chip
- retain its grey sidebar appearance

## Validation
- npm run build
- npm run lint *(fails: pre-existing TypeScript errors)*
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-labels.spec.ts" *(blocked: installed WebdriverIO dependency incompatibility)*