### PR TITLE
feat(aria2): add JSON-RPC client support

### DIFF
--- a/.github/workflows/electorrent-workflow.yml
+++ b/.github/workflows/electorrent-workflow.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         client:
+          - aria2
           - mock
           - qbittorrent:4
           - qbittorrent:5

--- a/src/main/lib/bittorrent/clients/aria2/index.ts
+++ b/src/main/lib/bittorrent/clients/aria2/index.ts
@@ -1,0 +1,716 @@
+import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
+import { HTTP_LOGIN_TIMEOUT } from "@main/lib/bittorrent/helpers"
+import type {
+    BittorrentFileSelection,
+    BittorrentServerConfig,
+    BittorrentTorrentDetailsData,
+    BittorrentTorrentDetailsFile,
+    BittorrentTorrentDetailsTracker,
+    BittorrentTorrentPeer,
+    TorrentClientConnection,
+    TorrentUploadOptions,
+} from "@shared/ipc-contract"
+import type { TorrentActionItem } from "@shared/torrent-actions"
+import { Aria2JsonRpcTransport, Aria2RpcError, type Aria2RpcCall } from "./json-rpc"
+
+const TORRENT_FIELDS = [
+    "gid", "status", "totalLength", "completedLength", "uploadLength",
+    "downloadSpeed", "uploadSpeed", "connections", "numSeeders", "seeder",
+    "dir", "files", "bittorrent", "infoHash", "verifiedLength", "verifyIntegrityPending",
+    "pieceLength", "numPieces", "errorCode", "errorMessage", "followedBy",
+]
+
+const MAX_RESULTS = 2_147_483_647
+const REMOVABLE_STATUSES = new Set(["active", "waiting", "paused"])
+const CHANGEABLE_STATUSES = new Set(["active", "waiting", "paused"])
+const STOPPED_STATUSES = new Set(["complete", "error", "removed"])
+
+interface Aria2TorrentData extends Record<string, unknown> {
+    gid?: unknown
+    status?: unknown
+    bittorrent?: unknown
+    followedBy?: unknown
+}
+
+interface TorrentSessionMetadata {
+    dateAdded: number
+    dateCompleted?: number
+    completed: boolean
+}
+
+function finiteNumber(value: unknown): number {
+    const parsed = typeof value === "number" ? value : Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+}
+
+function boolean(value: unknown): boolean {
+    return value === true || value === "true" || value === 1 || value === "1"
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+    return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function infoHash(torrent: Aria2TorrentData): string | undefined {
+    const directValue = nonEmptyString(torrent.infoHash)
+    if (directValue) return directValue.toLowerCase()
+
+    const bittorrent = torrent.bittorrent
+    if (!bittorrent || typeof bittorrent !== "object") return undefined
+    const value = nonEmptyString((bittorrent as Record<string, unknown>).infoHash)
+    return value?.toLowerCase()
+}
+
+function torrentName(torrent: Aria2TorrentData): string {
+    const bittorrent = torrent.bittorrent
+    if (bittorrent && typeof bittorrent === "object") {
+        const info = (bittorrent as Record<string, unknown>).info
+        if (info && typeof info === "object") {
+            const name = nonEmptyString((info as Record<string, unknown>).name)
+            if (name) return name
+        }
+    }
+
+    const files = torrent.files
+    const firstFile = Array.isArray(files) && files[0]
+    const path = firstFile && typeof firstFile === "object"
+        ? nonEmptyString((firstFile as Record<string, unknown>).path)
+        : undefined
+    return path?.split(/[/\\]/).pop() || nonEmptyString(torrent.gid) || "Unknown"
+}
+
+function trackers(torrent: Aria2TorrentData): string[] {
+    const bittorrent = torrent.bittorrent
+    const announceList = bittorrent && typeof bittorrent === "object"
+        ? (bittorrent as Record<string, unknown>).announceList
+        : undefined
+    if (!Array.isArray(announceList)) return []
+
+    return [...new Set(announceList.flatMap((tier) => Array.isArray(tier) ? tier : [tier])
+        .filter((tracker): tracker is string => typeof tracker === "string" && tracker.length > 0))]
+}
+
+function trackerDetails(torrent: Aria2TorrentData): BittorrentTorrentDetailsTracker[] {
+    const bittorrent = torrent.bittorrent
+    const announceList = bittorrent && typeof bittorrent === "object"
+        ? (bittorrent as Record<string, unknown>).announceList
+        : undefined
+    if (!Array.isArray(announceList)) return []
+
+    const seen = new Set<string>()
+    return announceList.flatMap((tier, tierIndex) => {
+        const values = Array.isArray(tier) ? tier : [tier]
+        return values.flatMap((value) => {
+            const url = nonEmptyString(value)
+            if (!url || seen.has(url)) return []
+            seen.add(url)
+            return [{ url, tier: tierIndex }]
+        })
+    })
+}
+
+function optionalFiniteNumber(value: unknown): number | undefined {
+    if (value === undefined || value === null || value === "") return undefined
+    const parsed = typeof value === "number" ? value : Number(value)
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+function peerClient(peerId: unknown): string {
+    const encoded = nonEmptyString(peerId)
+    if (!encoded) return ""
+
+    try {
+        return decodeURIComponent(encoded)
+    } catch {
+        return encoded.replace(/%([0-9a-f]{2})/gi, (_match, hex: string) => {
+            const byte = Number.parseInt(hex, 16)
+            return byte >= 0x20 && byte <= 0x7e ? String.fromCharCode(byte) : "�"
+        })
+    }
+}
+
+function bitfieldProgress(bitfield: unknown, numPieces: unknown): number {
+    const pieces = optionalFiniteNumber(numPieces)
+    if (!pieces || pieces <= 0 || typeof bitfield !== "string") return 0
+    const normalized = bitfield.trim()
+    if (!/^[0-9a-f]*$/i.test(normalized)) return 0
+
+    let populated = 0
+    for (const digit of normalized) {
+        let value = Number.parseInt(digit, 16)
+        while (value > 0) {
+            populated += value & 1
+            value >>= 1
+        }
+    }
+    return Math.max(0, Math.min(1, Math.min(populated, Math.floor(pieces)) / pieces))
+}
+
+function integerOption(value: unknown, multiplier = 1): string | undefined {
+    if (value === undefined || value === null || value === "") return undefined
+    const parsed = Number(value)
+    if (!Number.isFinite(parsed) || parsed < 0) return undefined
+    return String(Math.floor(parsed * multiplier))
+}
+
+function optionNumber(value: unknown): number {
+    if (typeof value === "number") return Number.isFinite(value) ? value : 0
+    if (typeof value !== "string") return 0
+    const match = value.trim().match(/^([0-9]+(?:\.[0-9]+)?)\s*([kmgt])?b?$/i)
+    if (!match) return 0
+    const units: Record<string, number> = { k: 1024, m: 1024 ** 2, g: 1024 ** 3, t: 1024 ** 4 }
+    return Number(match[1]) * (match[2] ? units[match[2].toLowerCase()] : 1)
+}
+
+function compactFileSelection(indices: number[]): string {
+    const values = [...new Set(indices.filter((index) => Number.isInteger(index) && index >= 0))]
+        .sort((left, right) => left - right)
+        .map((index) => index + 1)
+    const ranges: string[] = []
+
+    for (let offset = 0; offset < values.length;) {
+        const start = values[offset]
+        let end = start
+        while (offset + 1 < values.length && values[offset + 1] === end + 1) {
+            end = values[++offset]
+        }
+        ranges.push(start === end ? String(start) : `${start}-${end}`)
+        offset += 1
+    }
+
+    return ranges.join(",")
+}
+
+function relativeFilePath(path: string, directory: string | undefined): string {
+    const normalizedPath = path.replace(/\\/g, "/")
+    const normalizedDirectory = directory?.replace(/\\/g, "/").replace(/\/+$/, "")
+    if (!normalizedDirectory) return normalizedPath
+    return normalizedPath.startsWith(`${normalizedDirectory}/`)
+        ? normalizedPath.slice(normalizedDirectory.length + 1)
+        : normalizedPath
+}
+
+function aria2Options(options?: TorrentUploadOptions): Record<string, string> {
+    if (!options) return {}
+
+    const selectedFiles = options.fileSelection
+        ? compactFileSelection(options.fileSelection.filter((file) => file.wanted).map((file) => file.index))
+        : undefined
+
+    const result: Record<string, string | undefined> = {
+        dir: nonEmptyString(options.saveLocation),
+        pause: options.startTorrent === undefined ? undefined : String(!options.startTorrent),
+        "bt-max-peers": integerOption(options.peerLimit),
+        "check-integrity": options.skipCheck === undefined ? undefined : String(!options.skipCheck),
+        "bt-prioritize-piece": options.firstAndLastPiecePrio ? "head,tail" : undefined,
+        "max-download-limit": integerOption(options.downloadSpeedLimit, 1024),
+        "max-upload-limit": integerOption(options.uploadSpeedLimit, 1024),
+        "select-file": selectedFiles,
+    }
+
+    return Object.fromEntries(Object.entries(result)
+        .filter((entry): entry is [string, string] => entry[1] !== undefined))
+}
+
+function preference(torrent: Aria2TorrentData, followedGids: Set<string>): number {
+    const gid = nonEmptyString(torrent.gid) || ""
+    const status = nonEmptyString(torrent.status)
+    return (followedGids.has(gid) ? 100 : 0)
+        + (status === "active" ? 20 : status === "waiting" || status === "paused" ? 10 : 0)
+        + (torrent.bittorrent ? 1 : 0)
+}
+
+export class Aria2Runtime implements BittorrentRuntime {
+    readonly actions: TorrentActionItem[] = [
+        { role: "details", label: "Details", icon: "info circle" },
+        { role: "files", label: "Files", icon: "file" },
+        { role: "set-speed-limits", label: "Set Speed Limits", icon: "dashboard" },
+        { role: "set-ratio", label: "Set Ratio", icon: "percent" },
+        { label: "Start", action: "resume", icon: "play" },
+        { label: "Pause", action: "pause", icon: "pause" },
+        { role: "delete", label: "Remove", action: "remove", icon: "remove" },
+    ]
+
+    private rpc?: Aria2JsonRpcTransport
+    private gidByHash = new Map<string, string>()
+    private statusByGid = new Map<string, string>()
+    private selectedFilesByHash = new Map<string, Set<number>>()
+    private dirByHash = new Map<string, string>()
+    private sessionMetadata = new Map<string, TorrentSessionMetadata>()
+    private identityByGid = new Map<string, string>()
+
+    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+        this.rpc = new Aria2JsonRpcTransport(server)
+        this.gidByHash.clear()
+        this.statusByGid.clear()
+        this.selectedFilesByHash.clear()
+        this.dirByHash.clear()
+        this.sessionMetadata.clear()
+        this.identityByGid.clear()
+        const result = await this.rpc.call<{ version?: string }>("aria2.getVersion", [], HTTP_LOGIN_TIMEOUT)
+        if (typeof result?.version !== "string" || !result.version.trim()) {
+            throw new Error("aria2 did not return its version")
+        }
+
+        return {
+            version: `aria2 ${result.version.trim()}`,
+            features: {
+                magnetLinks: true,
+                fileSelection: true,
+                uploadFileSelection: true,
+                torrentDetails: true,
+                torrentPeers: true,
+                trackerFilter: true,
+                speedLimits: true,
+                ratioLimits: true,
+                uploadOptions: {
+                    saveLocation: true,
+                    startTorrent: true,
+                    peerLimit: true,
+                    skipCheck: true,
+                    firstAndLastPiecePrio: true,
+                    downloadSpeedLimit: true,
+                    uploadSpeedLimit: true,
+                },
+            },
+        }
+    }
+
+    async getSnapshot(): Promise<{ torrents: unknown[], globalStat: Record<string, number> }> {
+        const calls: Aria2RpcCall[] = [
+            { method: "aria2.tellActive", params: [TORRENT_FIELDS] },
+            { method: "aria2.tellWaiting", params: [0, MAX_RESULTS, TORRENT_FIELDS] },
+            { method: "aria2.tellStopped", params: [0, MAX_RESULTS, TORRENT_FIELDS] },
+            { method: "aria2.getGlobalStat" },
+        ]
+        const [active, waiting, stopped, globalStat] = await this.client().multicall<unknown>(calls)
+        const groups = [active, waiting, stopped]
+        const rawTorrents = groups.flatMap((group, groupIndex) => (Array.isArray(group) ? group : [])
+            .filter((torrent): torrent is Aria2TorrentData => Boolean(torrent) && typeof torrent === "object")
+            .map((torrent, index) => ({
+                ...torrent,
+                _queuePosition: groupIndex === 1 ? index : -1,
+            })))
+
+        const optionResults = rawTorrents.length === 0
+            ? []
+            : await this.client().multicall<Record<string, unknown>>(rawTorrents.map((torrent) => ({
+                method: "aria2.getOption",
+                params: [torrent.gid],
+            })))
+        const withOptions = rawTorrents.map((torrent, index) => ({ ...torrent, options: optionResults[index] || {} }))
+        const followedGids = new Set(withOptions.flatMap((torrent) => Array.isArray(torrent.followedBy)
+            ? torrent.followedBy.filter((gid): gid is string => typeof gid === "string")
+            : []))
+        const presentGids = new Set(withOptions.map((torrent) => nonEmptyString(torrent.gid)).filter((gid): gid is string => Boolean(gid)))
+        const candidates = withOptions.filter((torrent) => {
+            const children = Array.isArray(torrent.followedBy) ? torrent.followedBy : []
+            return !children.some((gid) => typeof gid === "string" && presentGids.has(gid))
+        })
+        const byIdentity = new Map<string, Aria2TorrentData>()
+        for (const torrent of candidates) {
+            const gid = nonEmptyString(torrent.gid)
+            if (!gid) continue
+            const identity = infoHash(torrent) || gid.toLowerCase()
+            const existing = byIdentity.get(identity)
+            if (!existing || preference(torrent, followedGids) > preference(existing, followedGids)) {
+                byIdentity.set(identity, torrent)
+            }
+        }
+
+        const observedAt = Date.now()
+        const predecessorIdentityByGid = new Map<string, string>()
+        for (const torrent of withOptions) {
+            const gid = nonEmptyString(torrent.gid)
+            if (!gid || !Array.isArray(torrent.followedBy)) continue
+            const identity = infoHash(torrent) || gid.toLowerCase()
+            for (const childGid of torrent.followedBy) {
+                if (typeof childGid === "string") predecessorIdentityByGid.set(childGid.toLowerCase(), identity)
+            }
+        }
+
+        const nextSessionMetadata = new Map<string, TorrentSessionMetadata>()
+        const nextIdentityByGid = new Map<string, string>()
+
+        this.gidByHash = new Map()
+        this.statusByGid = new Map()
+        this.dirByHash = new Map()
+        const torrents = [...byIdentity.entries()].map(([hash, torrent]) => {
+            const gid = String(torrent.gid)
+            const normalizedGid = gid.toLowerCase()
+            const status = nonEmptyString(torrent.status) || "unknown"
+            const totalLength = finiteNumber(torrent.totalLength)
+            const completedLength = finiteNumber(torrent.completedLength)
+            const connections = finiteNumber(torrent.connections)
+            const numSeeders = finiteNumber(torrent.numSeeders)
+            const knownPeers = Math.max(connections, numSeeders)
+            const isCompleted = status === "complete" || (totalLength > 0 && completedLength >= totalLength)
+            const metadataKeys = [
+                hash,
+                this.identityByGid.get(normalizedGid),
+                predecessorIdentityByGid.get(normalizedGid),
+            ].filter((key): key is string => Boolean(key))
+            const previousMetadata = metadataKeys
+                .map((key) => this.sessionMetadata.get(key))
+                .filter((metadata): metadata is TorrentSessionMetadata => Boolean(metadata))
+            const dateAdded = previousMetadata.length > 0
+                ? Math.min(...previousMetadata.map((metadata) => metadata.dateAdded))
+                : observedAt
+            const previousCompletion = previousMetadata
+                .filter((metadata) => metadata.completed && metadata.dateCompleted !== undefined)
+                .map((metadata) => metadata.dateCompleted as number)
+            const dateCompleted = isCompleted
+                ? (previousCompletion.length > 0 ? Math.min(...previousCompletion) : observedAt)
+                : undefined
+            nextSessionMetadata.set(hash, { dateAdded, dateCompleted, completed: isCompleted })
+            nextIdentityByGid.set(normalizedGid, hash)
+            this.gidByHash.set(hash, gid)
+            this.statusByGid.set(gid, status)
+            this.dirByHash.set(hash, nonEmptyString(torrent.dir) || "")
+
+            return {
+                hash,
+                gid,
+                status,
+                name: torrentName(torrent),
+                totalLength,
+                completedLength,
+                uploadLength: finiteNumber(torrent.uploadLength),
+                downloadSpeed: finiteNumber(torrent.downloadSpeed),
+                uploadSpeed: finiteNumber(torrent.uploadSpeed),
+                peersConnected: connections,
+                peersInSwarm: knownPeers,
+                seedsConnected: numSeeders,
+                seedsInSwarm: knownPeers,
+                dateAdded,
+                dateCompleted,
+                seeder: boolean(torrent.seeder),
+                dir: nonEmptyString(torrent.dir) || "",
+                trackers: trackers(torrent),
+                queuePosition: finiteNumber(torrent._queuePosition),
+                verifiedLength: finiteNumber(torrent.verifiedLength),
+                verifyIntegrityPending: boolean(torrent.verifyIntegrityPending),
+                errorMessage: nonEmptyString(torrent.errorMessage) || "",
+                options: torrent.options && typeof torrent.options === "object" ? torrent.options : {},
+            }
+        })
+        for (const [gid, predecessorIdentity] of predecessorIdentityByGid) {
+            if (!nextIdentityByGid.has(gid) && nextSessionMetadata.has(predecessorIdentity)) {
+                nextIdentityByGid.set(gid, predecessorIdentity)
+            }
+        }
+        this.sessionMetadata = nextSessionMetadata
+        this.identityByGid = nextIdentityByGid
+        const stats = globalStat && typeof globalStat === "object" ? globalStat as Record<string, unknown> : {}
+
+        return {
+            torrents,
+            globalStat: Object.fromEntries(Object.entries(stats).map(([key, value]) => [key, finiteNumber(value)])),
+        }
+    }
+
+    async addTorrentUrl(uri: string, options?: TorrentUploadOptions): Promise<void> {
+        await this.client().call("aria2.addUri", [[uri], aria2Options(options)])
+    }
+
+    async uploadTorrent(buffer: Uint8Array, _filename: string, options?: TorrentUploadOptions): Promise<void> {
+        await this.client().call("aria2.addTorrent", [Buffer.from(buffer).toString("base64"), [], aria2Options(options)])
+    }
+
+    async getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {
+        const gid = this.resolveGids([hash])[0]
+        const [status, options] = await this.client().multicall<Record<string, unknown>>([
+            { method: "aria2.tellStatus", params: [gid, TORRENT_FIELDS] },
+            { method: "aria2.getOption", params: [gid] },
+        ])
+        const data = status || {}
+        const torrentOptions = options || {}
+        const completedLength = finiteNumber(data.completedLength)
+        const uploadLength = finiteNumber(data.uploadLength)
+
+        return {
+            info: {
+                hash: infoHash(data) || hash.toLowerCase(),
+                savePath: nonEmptyString(data.dir) || null,
+                totalSize: finiteNumber(data.totalLength),
+                totalDownloaded: completedLength,
+                totalUploaded: uploadLength,
+                shareRatio: completedLength > 0 ? uploadLength / completedLength : 0,
+                ratioLimit: optionNumber(torrentOptions["seed-ratio"]),
+                downloadSpeed: finiteNumber(data.downloadSpeed),
+                uploadSpeed: finiteNumber(data.uploadSpeed),
+                downloadLimit: optionNumber(torrentOptions["max-download-limit"]),
+                uploadLimit: optionNumber(torrentOptions["max-upload-limit"]),
+                pieceSize: finiteNumber(data.pieceLength),
+                piecesTotal: finiteNumber(data.numPieces),
+                verifiedLength: optionalFiniteNumber(data.verifiedLength) ?? null,
+                verifyIntegrityPending: data.verifyIntegrityPending === undefined
+                    ? null
+                    : boolean(data.verifyIntegrityPending),
+                errorCode: nonEmptyString(data.errorCode) || null,
+                errorString: nonEmptyString(data.errorMessage) || null,
+                connections: finiteNumber(data.connections),
+                connectionsLimit: finiteNumber(torrentOptions["bt-max-peers"]),
+            },
+        }
+    }
+
+    async getTorrentFiles(hash: string): Promise<BittorrentTorrentDetailsFile[]> {
+        const gid = this.resolveGids([hash])[0]
+        const [files, status] = await this.client().multicall<unknown>([
+            { method: "aria2.getFiles", params: [gid] },
+            { method: "aria2.tellStatus", params: [gid, ["gid", "status", "dir", "bittorrent", "infoHash", "followedBy"]] },
+        ])
+        const context = status && typeof status === "object" ? status as Aria2TorrentData : {}
+        this.rememberDownloadState(hash, context, gid)
+        const directory = nonEmptyString(context.dir) || this.dirByHash.get(hash.toLowerCase())
+        const selectedOverride = this.selectedFilesByHash.get(hash.toLowerCase())
+        return (Array.isArray(files) ? files : []).flatMap((value) => {
+            if (!value || typeof value !== "object") return []
+            const file = value as Record<string, unknown>
+            const aria2Index = Number(file.index)
+            if (!Number.isInteger(aria2Index) || aria2Index < 1) return []
+            const path = relativeFilePath(
+                typeof file.path === "string" ? file.path : "",
+                directory,
+            )
+            const size = finiteNumber(file.length)
+            const completed = finiteNumber(file.completedLength)
+            return [{
+                index: aria2Index - 1,
+                path,
+                name: path.split(/[/\\]/).pop() || path,
+                size,
+                progress: size > 0 ? Math.max(0, Math.min(1, completed / size)) : 0,
+                wanted: selectedOverride ? selectedOverride.has(aria2Index - 1) : boolean(file.selected),
+            }]
+        })
+    }
+
+    async getTorrentPeers(hash: string): Promise<BittorrentTorrentPeer[]> {
+        const gid = this.resolveGids([hash])[0]
+        const [peers, status] = await this.client().multicall<unknown>([
+            { method: "aria2.getPeers", params: [gid] },
+            { method: "aria2.tellStatus", params: [gid, ["numPieces"]] },
+        ])
+        const torrentStatus = status && typeof status === "object" ? status as Record<string, unknown> : {}
+
+        return (Array.isArray(peers) ? peers : []).flatMap((value) => {
+            if (!value || typeof value !== "object") return []
+            const peer = value as Record<string, unknown>
+            const port = optionalFiniteNumber(peer.port)
+            return [{
+                ip: nonEmptyString(peer.ip) || "",
+                port: port && port > 0 ? port : undefined,
+                client: peerClient(peer.peerId),
+                progress: bitfieldProgress(peer.bitfield, torrentStatus.numPieces),
+                downloadSpeed: finiteNumber(peer.downloadSpeed),
+                uploadSpeed: finiteNumber(peer.uploadSpeed),
+                flags: [
+                    boolean(peer.seeder) ? "S" : "",
+                    boolean(peer.amChoking) ? "C" : "",
+                    boolean(peer.peerChoking) ? "c" : "",
+                ].join("") || undefined,
+            }]
+        })
+    }
+
+    async getTorrentTrackers(hash: string): Promise<BittorrentTorrentDetailsTracker[]> {
+        const gid = this.resolveGids([hash])[0]
+        const status = await this.client().call<unknown>("aria2.tellStatus", [gid, ["bittorrent"]])
+        return trackerDetails(status && typeof status === "object" ? status as Aria2TorrentData : {})
+    }
+
+    async setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]): Promise<void> {
+        const normalizedHash = hash.toLowerCase()
+        const wantedByIndex = new Map(files.map((file) => [file.index, file.wanted]))
+        const currentFiles = await this.getTorrentFiles(hash)
+        const selectedIndices = currentFiles
+            .filter((file) => wantedByIndex.get(file.index) ?? file.wanted)
+            .map((file) => file.index)
+        this.selectedFilesByHash.set(normalizedHash, new Set(selectedIndices))
+        if (currentFiles.length > 1) {
+            await this.changeFileSelection(normalizedHash, compactFileSelection(selectedIndices))
+        }
+    }
+
+    async setSpeedLimits(hashes: string[], options: Record<string, unknown>): Promise<void> {
+        const changedOptions: Record<string, string> = {}
+        const downloadLimit = integerOption(options.downloadSpeedLimit, 1024)
+        const uploadLimit = integerOption(options.uploadSpeedLimit, 1024)
+        if (downloadLimit !== undefined) changedOptions["max-download-limit"] = downloadLimit
+        if (uploadLimit !== undefined) changedOptions["max-upload-limit"] = uploadLimit
+        await this.changeOptions(hashes, changedOptions)
+    }
+
+    async setRatioLimit(hashes: string[], options: Record<string, unknown>): Promise<void> {
+        const ratioLimit = Number(options.ratioLimit)
+        if (!Number.isFinite(ratioLimit) || ratioLimit < 0) throw new Error("Ratio limit must be zero or greater")
+        await this.changeOptions(hashes, { "seed-ratio": String(ratioLimit) })
+    }
+
+    async resume(hashes: string[]): Promise<void> {
+        await this.forHashes("aria2.unpause", hashes, new Set(["paused"]))
+    }
+
+    async resumeAll(): Promise<void> {
+        await this.client().call("aria2.unpauseAll")
+    }
+
+    async pause(hashes: string[]): Promise<void> {
+        await this.forHashes("aria2.pause", hashes, new Set(["active", "waiting"]))
+    }
+
+    async pauseAll(): Promise<void> {
+        await this.client().call("aria2.pauseAll")
+    }
+
+    async remove(hashes: string[]): Promise<void> {
+        const gids = this.resolveGids(hashes)
+        const activeGids = gids.filter((gid) => REMOVABLE_STATUSES.has(this.statusByGid.get(gid) || ""))
+        await this.ignoreMissing(this.client().multicall(activeGids.map((gid) => ({ method: "aria2.remove", params: [gid] }))))
+        await this.removeDownloadResults(gids)
+        hashes.forEach((hash) => this.selectedFilesByHash.delete(hash.toLowerCase()))
+    }
+
+    private client() {
+        if (!this.rpc) throw new Error("aria2 is not connected")
+        return this.rpc
+    }
+
+    private resolveGids(hashes: string[]): string[] {
+        return [...new Set(hashes.map((hash) => {
+            const gid = this.gidByHash.get(hash.toLowerCase())
+            if (!gid) throw new Error(`aria2 download is no longer available: ${hash}`)
+            return gid
+        }))]
+    }
+
+    private async forHashes(method: string, hashes: string[], statuses: Set<string>) {
+        const gids = this.resolveGids(hashes).filter((gid) => statuses.has(this.statusByGid.get(gid) || ""))
+        await this.client().multicall(gids.map((gid) => ({ method, params: [gid] })))
+    }
+
+    private async changeOptions(hashes: string[], options: Record<string, string>) {
+        if (Object.keys(options).length === 0) return
+        const gids = this.resolveGids(hashes)
+        await this.client().multicall(gids.map((gid) => ({
+            method: "aria2.changeOption",
+            params: [gid, options],
+        })))
+    }
+
+    private async changeFileSelection(hash: string, selection: string): Promise<void> {
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+            const gid = this.gidByHash.get(hash)
+            if (!gid) return
+
+            let status = this.statusByGid.get(gid) || ""
+            if (!CHANGEABLE_STATUSES.has(status) && !STOPPED_STATUSES.has(status)) {
+                const current = await this.refreshDownloadState(hash, gid)
+                if (!current) return
+                status = current.status
+            }
+            if (STOPPED_STATUSES.has(status)) return
+            if (!CHANGEABLE_STATUSES.has(status)) {
+                throw new Error(`aria2 download has unsupported status for file selection: ${status || "unknown"}`)
+            }
+
+            try {
+                await this.client().call("aria2.changeOption", [gid, { "select-file": selection }])
+                return
+            } catch (error) {
+                if (this.isMissingGid(error)) {
+                    this.forgetGid(hash, gid)
+                    return
+                }
+                if (!this.isCannotChangeOption(error)) throw error
+
+                const current = await this.refreshDownloadState(hash, gid)
+                if (!current || STOPPED_STATUSES.has(current.status)) return
+                if (current.gid === gid && current.status === status) throw error
+            }
+        }
+
+        throw new Error(`aria2 download kept changing GID while updating file selection: ${hash}`)
+    }
+
+    private async refreshDownloadState(hash: string, gid: string): Promise<{ gid: string, status: string } | undefined> {
+        let current: Aria2TorrentData
+        try {
+            current = await this.client().call<Aria2TorrentData>("aria2.tellStatus", [
+                gid,
+                ["gid", "status", "bittorrent", "infoHash", "followedBy"],
+            ])
+        } catch (error) {
+            if (!this.isMissingGid(error)) throw error
+            this.forgetGid(hash, gid)
+            return undefined
+        }
+
+        const followedBy = Array.isArray(current.followedBy)
+            ? current.followedBy.filter((child): child is string => typeof child === "string" && child.length > 0)
+            : []
+        if (followedBy.length > 0) {
+            const children = await this.client().multicall<Aria2TorrentData>(followedBy.map((childGid) => ({
+                method: "aria2.tellStatus",
+                params: [childGid, ["gid", "status", "bittorrent", "infoHash", "followedBy"]],
+            })))
+            const child = children.find((candidate) => infoHash(candidate) === hash)
+                || children.find((candidate) => CHANGEABLE_STATUSES.has(nonEmptyString(candidate.status) || ""))
+                || children[0]
+            if (child) current = child
+        }
+
+        return this.rememberDownloadState(hash, current, gid)
+    }
+
+    private rememberDownloadState(hash: string, torrent: Aria2TorrentData, previousGid: string): { gid: string, status: string } {
+        const gid = nonEmptyString(torrent.gid) || previousGid
+        const status = nonEmptyString(torrent.status) || this.statusByGid.get(gid) || "unknown"
+        if (gid !== previousGid) this.statusByGid.delete(previousGid)
+        this.gidByHash.set(hash.toLowerCase(), gid)
+        this.statusByGid.set(gid, status)
+        return { gid, status }
+    }
+
+    private forgetGid(hash: string, gid: string): void {
+        if (this.gidByHash.get(hash) === gid) this.gidByHash.delete(hash)
+        this.statusByGid.delete(gid)
+    }
+
+    private isCannotChangeOption(error: unknown): error is Aria2RpcError {
+        return error instanceof Aria2RpcError
+            && error.code === 1
+            && /^Cannot change option for GID#[0-9a-f]+$/i.test(error.message)
+    }
+
+    private isMissingGid(error: unknown): error is Aria2RpcError {
+        return error instanceof Aria2RpcError
+            && error.code === 1
+            && /^(?:GID [0-9a-f]+ is not found|No such download for GID#[0-9a-f]+)$/i.test(error.message)
+    }
+
+    private async ignoreMissing(operation: Promise<unknown>): Promise<void> {
+        try {
+            await operation
+        } catch (error) {
+            if (!(error instanceof Aria2RpcError) || error.code !== 1) throw error
+        }
+    }
+
+    private async removeDownloadResults(gids: string[]): Promise<void> {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            try {
+                await this.client().multicall(gids.map((gid) => ({ method: "aria2.removeDownloadResult", params: [gid] })))
+                return
+            } catch (error) {
+                if (!(error instanceof Aria2RpcError) || error.code !== 1) throw error
+                if (attempt === 19) return
+                await new Promise((resolve) => setTimeout(resolve, 250))
+            }
+        }
+    }
+}
+
+export { Aria2JsonRpcTransport, Aria2RpcError } from "./json-rpc"

--- a/src/main/lib/bittorrent/clients/aria2/json-rpc.ts
+++ b/src/main/lib/bittorrent/clients/aria2/json-rpc.ts
@@ -1,0 +1,182 @@
+import axios, { type AxiosInstance, type AxiosResponse } from "axios"
+import httpAdapter from "axios/lib/adapters/http.js"
+import https from "node:https"
+
+import { HTTP_REQUEST_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
+import type { BittorrentServerConfig } from "@shared/ipc-contract"
+
+export interface Aria2RpcCall {
+    method: string
+    params?: unknown[]
+}
+
+interface JsonRpcRequest {
+    jsonrpc: "2.0"
+    id: string
+    method: string
+    params: unknown[]
+}
+
+interface JsonRpcErrorData {
+    code: number
+    message: string
+    data?: unknown
+}
+
+interface JsonRpcResponse<T = unknown> {
+    jsonrpc: "2.0"
+    id: string | number | null
+    result?: T
+    error?: JsonRpcErrorData
+}
+
+export interface Aria2MulticallFault {
+    faultCode: number
+    faultString: string
+}
+
+let nextRequestId = 0
+
+export class Aria2RpcError extends Error {
+    readonly code: number
+    readonly data?: unknown
+    readonly faultCode?: number
+    readonly faultString?: string
+
+    constructor(error: JsonRpcErrorData | Aria2MulticallFault) {
+        const isFault = "faultCode" in error
+        super(isFault ? error.faultString : error.message)
+        this.name = "Aria2RpcError"
+        this.code = isFault ? error.faultCode : error.code
+        this.data = isFault ? undefined : error.data
+        this.faultCode = isFault ? error.faultCode : undefined
+        this.faultString = isFault ? error.faultString : undefined
+    }
+}
+
+function isMulticallFault(value: unknown): value is Aria2MulticallFault | JsonRpcErrorData {
+    if (!value || typeof value !== "object") return false
+    const fault = value as Record<string, unknown>
+    return (typeof fault.faultCode === "number" && typeof fault.faultString === "string")
+        || (typeof fault.code === "number" && typeof fault.message === "string")
+}
+
+export class Aria2JsonRpcTransport {
+    private readonly http: AxiosInstance
+    private readonly endpoint: string
+    private readonly secret: string
+
+    constructor(server: BittorrentServerConfig) {
+        this.endpoint = serverUrl(server)
+        this.secret = server.password || ""
+        this.http = axios.create({
+            adapter: httpAdapter,
+            timeout: HTTP_REQUEST_TIMEOUT,
+            auth: server.user ? { username: server.user, password: server.password } : undefined,
+            httpsAgent: new https.Agent({
+                ca: server.certificateData ? Buffer.from(server.certificateData) : undefined,
+                rejectUnauthorized: server.tlsSecurity !== "insecure",
+            }),
+        })
+    }
+
+    async call<T = unknown>(method: string, params: unknown[] = [], timeout = HTTP_REQUEST_TIMEOUT): Promise<T> {
+        const request = this.createRequest(method, params)
+        try {
+            const response = await this.http.post<JsonRpcResponse<T>>(this.endpoint, request, { timeout })
+            return this.readResponse(response.data, request.id)
+        } catch (error) {
+            const response = axios.isAxiosError<JsonRpcResponse<T>>(error) ? error.response?.data : undefined
+            if (this.isErrorResponse(response, request.id)) {
+                throw new Aria2RpcError(response.error)
+            }
+            throw this.transportError(error)
+        }
+    }
+
+    async batch<T = unknown>(calls: Aria2RpcCall[], timeout = HTTP_REQUEST_TIMEOUT): Promise<T[]> {
+        if (calls.length === 0) return []
+
+        const requests = calls.map(({ method, params }) => this.createRequest(method, params || []))
+        let response: AxiosResponse<JsonRpcResponse<T>[]>
+        try {
+            response = await this.http.post<JsonRpcResponse<T>[]>(this.endpoint, requests, { timeout })
+        } catch (error) {
+            throw this.transportError(error)
+        }
+        if (!Array.isArray(response.data)) {
+            throw new Error("aria2 returned an invalid JSON-RPC batch response")
+        }
+
+        const responses = new Map(response.data.map((item) => [String(item.id), item]))
+        return requests.map((request) => {
+            const item = responses.get(request.id)
+            if (!item) {
+                throw new Error(`aria2 omitted JSON-RPC response ${request.id}`)
+            }
+            return this.readResponse(item, request.id)
+        })
+    }
+
+    async multicall<T = unknown>(calls: Aria2RpcCall[], timeout = HTTP_REQUEST_TIMEOUT): Promise<T[]> {
+        if (calls.length === 0) return []
+
+        const methods = calls.map(({ method, params }) => ({
+            methodName: method,
+            params: this.authorize(method, params || []),
+        }))
+        const results = await this.call<unknown[]>("system.multicall", [methods], timeout)
+        if (!Array.isArray(results) || results.length !== calls.length) {
+            throw new Error("aria2 returned an invalid system.multicall response")
+        }
+
+        return results.map((result) => {
+            if (isMulticallFault(result)) throw new Aria2RpcError(result)
+            if (!Array.isArray(result) || result.length !== 1) {
+                throw new Error("aria2 returned an invalid system.multicall result")
+            }
+            return result[0] as T
+        })
+    }
+
+    private createRequest(method: string, params: unknown[]): JsonRpcRequest {
+        return {
+            jsonrpc: "2.0",
+            id: `aria2-${++nextRequestId}`,
+            method,
+            params: this.authorize(method, params),
+        }
+    }
+
+    private authorize(method: string, params: unknown[]) {
+        if (!this.secret || method === "system.multicall" || method === "system.listMethods" || method === "system.listNotifications") {
+            return [...params]
+        }
+        return [`token:${this.secret}`, ...params]
+    }
+
+    private readResponse<T>(response: JsonRpcResponse<T>, id: string): T {
+        if (!response || typeof response !== "object" || String(response.id) !== id) {
+            throw new Error("aria2 returned an invalid JSON-RPC response")
+        }
+        if (response.error) throw new Aria2RpcError(response.error)
+        if (!("result" in response)) throw new Error("aria2 JSON-RPC response did not contain a result")
+        return response.result as T
+    }
+
+    private isErrorResponse<T>(response: JsonRpcResponse<T> | undefined, id: string): response is JsonRpcResponse<T> & { error: JsonRpcErrorData } {
+        return Boolean(response
+            && response.jsonrpc === "2.0"
+            && String(response.id) === id
+            && response.error
+            && typeof response.error.code === "number"
+            && typeof response.error.message === "string")
+    }
+
+    private transportError(error: unknown): unknown {
+        if (axios.isAxiosError(error) && !error.response && error.cause instanceof Error) {
+            return error.cause
+        }
+        return error
+    }
+}

--- a/src/main/lib/bittorrent/connection-error.ts
+++ b/src/main/lib/bittorrent/connection-error.ts
@@ -80,7 +80,7 @@ export function normalizeConnectionError(error: unknown): BittorrentConnectionEr
         return connectionError("tls", details)
     }
     if ([...details.statuses].some((status) => status === 401 || status === 403)
-        || /\b(401|403)\b|invalid (login|credentials)|failed to authenticate|incorrect password|no such account|account disabled|permission denied/.test(message)) {
+        || /\b(401|403)\b|unauthorized|invalid (login|credentials)|failed to authenticate|incorrect password|no such account|account disabled|permission denied/.test(message)) {
         return connectionError("authentication", details)
     }
     if ([...details.codes].some((code) => TIMEOUT_CODES.has(code)) || /timed? ?out|timeout/.test(message)) {

--- a/src/main/lib/bittorrent/registry.ts
+++ b/src/main/lib/bittorrent/registry.ts
@@ -1,4 +1,5 @@
 import { DelugeRuntime } from "@main/lib/bittorrent/clients/deluge"
+import { Aria2Runtime } from "@main/lib/bittorrent/clients/aria2"
 import { QBittorrentRuntime } from "@main/lib/bittorrent/clients/qbittorrent"
 import { RtorrentRuntime } from "@main/lib/bittorrent/clients/rtorrent"
 import { MockBittorrentRuntime } from "@main/lib/bittorrent/clients/mock"
@@ -9,6 +10,7 @@ import { isClientId, type ClientId } from "@shared/client-metadata"
 import type { BittorrentRuntime } from "./types"
 
 const runtimeFactories = {
+    aria2: () => new Aria2Runtime(),
     qbittorrent: () => new QBittorrentRuntime(),
     rtorrent: () => new RtorrentRuntime(),
     deluge: () => new DelugeRuntime(),

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -4,6 +4,7 @@
 
 // Import all client implementations
 import {
+    Aria2Client,
     UtorrentClient,
     QBittorrentClient,
     TransmissionClient,
@@ -12,7 +13,7 @@ import {
     DelugeClient,
     MockBittorrentClient
 } from "@renderer/app/bittorrent"
-import { CLIENT_METADATA, type ClientId } from "@shared/client-metadata"
+import { CLIENT_METADATA, type ClientId, type ClientMetadata } from "@shared/client-metadata"
 
 const torrentApp = angular.module("torrentApp", ["ngResource", "ngAnimate", "rzTable", "infinite-scroll", "hc.marked", "ui.sortable"]);
 
@@ -26,9 +27,11 @@ interface ClientRegistration {
     name: string
     service: unknown
     icon: string
+    defaultPort?: number
 }
 
 const clientFactories = {
+    aria2: () => new Aria2Client(),
     utorrent: () => new UtorrentClient(),
     qbittorrent: () => new QBittorrentClient(),
     transmission: () => new TransmissionClient(),
@@ -45,10 +48,12 @@ for (const clientId of Object.keys(clientFactories) as ClientId[]) {
         continue
     }
 
+    const metadata: ClientMetadata = CLIENT_METADATA[clientId]
     btclients[clientId] = {
-        name: CLIENT_METADATA[clientId].name,
+        name: metadata.name,
         service: clientFactories[clientId](),
-        icon: CLIENT_METADATA[clientId].icon,
+        icon: metadata.icon,
+        defaultPort: metadata.defaultPort,
     }
 }
 

--- a/src/renderer/app/bittorrent/aria2/aria2service.ts
+++ b/src/renderer/app/bittorrent/aria2/aria2service.ts
@@ -1,0 +1,156 @@
+import { Torrent } from "@renderer/app/bittorrent/abstracttorrent"
+import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, setTorrentFileSelection, uploadTorrent } from "@renderer/app/bittorrent/ipc"
+import type { TorrentFile } from "@renderer/app/bittorrent/abstracttorrent"
+import type {
+    TorrentActionList,
+    TorrentDetailsInfoSection,
+    TorrentRatioLimitOptions,
+    TorrentSpeedLimitOptions,
+    TorrentUpdates,
+    TorrentUploadOptions,
+} from "@renderer/app/bittorrent/torrentclient"
+import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract"
+import { TorrentClient } from "@renderer/app/bittorrent/torrentclient"
+import { CLIENT_METADATA } from "@shared/client-metadata"
+import { Aria2Torrent } from "./torrentaria2"
+
+export class Aria2Client extends TorrentClient<Aria2Torrent> {
+    public name = "aria2"
+    public id = "aria2"
+    public extraColumns = [Torrent.COL_QUEUE, Torrent.COL_DOWNLIMIT, Torrent.COL_UPLIMIT]
+
+    defaultPort() { return CLIENT_METADATA.aria2.defaultPort }
+    defaultPath() { return "/jsonrpc" }
+
+    async torrents(): Promise<TorrentUpdates> {
+        const snapshot = await getSnapshot()
+        const all = Array.isArray(snapshot?.torrents) ? snapshot.torrents.map((torrent) => new Aria2Torrent(torrent)) : []
+        return {
+            labels: [],
+            all,
+            changed: [],
+            deleted: [],
+            dirty: true,
+            trackers: [...new Set(all.flatMap((torrent) => torrent.trackers).flatMap((tracker) => {
+                try {
+                    const hostname = new URL(tracker).hostname
+                    return hostname ? [hostname] : []
+                } catch {
+                    return []
+                }
+            }))],
+        }
+    }
+
+    addTorrentUrl(uri: string, options?: TorrentUploadOptions): Promise<void> {
+        return addTorrentUrl(uri, options)
+    }
+
+    uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions, sourcePath?: string): Promise<void> {
+        return uploadTorrent(buffer, filename, options, sourcePath)
+    }
+
+    resume(torrents: Aria2Torrent[]): Promise<void> {
+        return invokeAction("resume", torrents.map((torrent) => torrent.hash))
+    }
+
+    pause(torrents: Aria2Torrent[]): Promise<void> {
+        return invokeAction("pause", torrents.map((torrent) => torrent.hash))
+    }
+
+    resumeAll(): Promise<void> {
+        return invokeAction("resumeAll")
+    }
+
+    pauseAll(): Promise<void> {
+        return invokeAction("pauseAll")
+    }
+
+    remove(torrents: Aria2Torrent[]): Promise<void> {
+        return invokeAction("remove", torrents.map((torrent) => torrent.hash))
+    }
+
+    setSpeedLimits(torrents: Aria2Torrent[], options: TorrentSpeedLimitOptions): Promise<void> {
+        return invokeAction("setSpeedLimits", torrents.map((torrent) => torrent.hash), options)
+    }
+
+    setRatioLimit(torrents: Aria2Torrent[], options: TorrentRatioLimitOptions): Promise<void> {
+        return invokeAction("setRatioLimit", torrents.map((torrent) => torrent.hash), options)
+    }
+
+    setTorrentFileSelection(torrent: Aria2Torrent, files: TorrentFile[]): Promise<void> {
+        return setTorrentFileSelection(torrent.hash, files)
+    }
+
+    protected getTorrentDetailsData(torrent: Aria2Torrent): Promise<BittorrentTorrentDetailsData> {
+        return getTorrentDetails(torrent.hash)
+    }
+
+    protected getTorrentDetailsInfoSections(torrent: Aria2Torrent, details: BittorrentTorrentDetailsData): TorrentDetailsInfoSection[] {
+        const info = this.getTorrentDetailsInfo(details)
+        return this.compactTorrentDetailsSections([
+            this.createTorrentDetailsSection("overview", "Overview", [
+                this.createTorrentDetailsField("name", "Name", torrent.name),
+                this.createTorrentDetailsField("hash", "Hash", typeof info.hash === "string" ? info.hash.toLowerCase() : torrent.hash.toLowerCase()),
+                this.createTorrentDetailsField("status", "Status", torrent.statusText()),
+                this.createTorrentDetailsField("save-path", "Save Path", info.savePath as string | null, "path"),
+                this.createTorrentDetailsField("total-size", "Total Size", this.toNumber(info.totalSize) ?? torrent.size, "bytes"),
+            ]),
+            this.createTorrentDetailsSection("transfer", "Transfer", [
+                this.createTorrentDetailsField("downloaded", "Downloaded", this.toNumber(info.totalDownloaded) ?? torrent.downloaded, "bytes"),
+                this.createTorrentDetailsField("uploaded", "Uploaded", this.toNumber(info.totalUploaded) ?? torrent.uploaded, "bytes"),
+                this.createTorrentDetailsField("ratio", "Share Ratio", this.toNumber(info.shareRatio) ?? torrent.ratio, "ratio"),
+                this.createTorrentDetailsField("ratio-limit", "Ratio Limit", this.toNumber(info.ratioLimit) ?? torrent.ratioLimit, "ratio"),
+                this.createTorrentDetailsField("download-speed", "Download Speed", this.toNumber(info.downloadSpeed) ?? torrent.downloadSpeed, "speed"),
+                this.createTorrentDetailsField("upload-speed", "Upload Speed", this.toNumber(info.uploadSpeed) ?? torrent.uploadSpeed, "speed"),
+                this.createTorrentDetailsField("download-limit", "Download Limit", this.toNumber(info.downloadLimit), "speedLimit", { allowEmpty: true }),
+                this.createTorrentDetailsField("upload-limit", "Upload Limit", this.toNumber(info.uploadLimit), "speedLimit", { allowEmpty: true }),
+            ]),
+            this.createTorrentDetailsSection("content", "Content", [
+                this.createTorrentDetailsField("piece-size", "Piece Size", this.toNumber(info.pieceSize), "bytes"),
+                this.createTorrentDetailsField("pieces", "Pieces", this.toNumber(info.piecesTotal), "number"),
+                this.createTorrentDetailsField("verified", "Verified", this.toNumber(info.verifiedLength), "bytes"),
+                this.createTorrentDetailsField("verification-pending", "Verification Pending", info.verifyIntegrityPending as boolean | null, "boolean"),
+            ]),
+            this.createTorrentDetailsSection("swarm", "Swarm", [
+                this.createTorrentDetailsField("connections", "Connected Peers", this.toNumber(info.connections), "number"),
+                this.createTorrentDetailsField("connections-limit", "Peer Limit", this.toNumber(info.connectionsLimit), "number"),
+                this.createTorrentDetailsField("error-code", "Error Code", info.errorCode as string | null),
+                this.createTorrentDetailsField("error", "Error", info.errorString as string | null, "text", { multiline: true }),
+            ]),
+        ])
+    }
+
+    deleteTorrents(torrents: Aria2Torrent[]): Promise<void> {
+        return this.remove(torrents)
+    }
+
+    public actionHeader: TorrentActionList<Aria2Torrent> = [
+        {
+            label: "Start",
+            type: "button",
+            color: "green",
+            click: this.resume,
+            icon: "play",
+            role: "resume",
+        },
+        {
+            label: "Pause",
+            type: "button",
+            color: "red",
+            click: this.pause,
+            icon: "pause",
+            role: "stop",
+        },
+        {
+            label: "More",
+            type: "dropdown",
+            color: "blue",
+            icon: "plus",
+            actions: [
+                { label: "Pause All", click: this.pauseAll },
+                { label: "Resume All", click: this.resumeAll },
+            ],
+        },
+    ]
+}

--- a/src/renderer/app/bittorrent/aria2/index.ts
+++ b/src/renderer/app/bittorrent/aria2/index.ts
@@ -1,0 +1,2 @@
+export { Aria2Client } from "./aria2service"
+export { Aria2Torrent } from "./torrentaria2"

--- a/src/renderer/app/bittorrent/aria2/torrentaria2.ts
+++ b/src/renderer/app/bittorrent/aria2/torrentaria2.ts
@@ -1,0 +1,62 @@
+import { Torrent } from "@renderer/app/bittorrent/abstracttorrent"
+
+function number(value: unknown) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+}
+
+export class Aria2Torrent extends Torrent {
+    readonly aria2Status: string
+    readonly trackers: string[]
+
+    constructor(data: Record<string, any>) {
+        const total = number(data.totalLength)
+        const completed = number(data.completedLength)
+        const downloadSpeed = number(data.downloadSpeed)
+        const remaining = Math.max(0, total - completed)
+        const ratio = completed > 0 ? number(data.uploadLength) / completed : 0
+        const percent = total > 0 ? completed / total * 1000 : 0
+        const options = data.options && typeof data.options === "object" ? data.options : {}
+
+        super({
+            hash: typeof data.hash === "string" ? data.hash.toLowerCase() : String(data.gid || "").toLowerCase(),
+            name: typeof data.name === "string" ? data.name : String(data.gid || "Unknown"),
+            size: total,
+            percent: number(percent),
+            downloaded: completed,
+            uploaded: number(data.uploadLength),
+            ratio: number(ratio),
+            ratioLimit: number(options["seed-ratio"]),
+            uploadSpeed: number(data.uploadSpeed),
+            downloadSpeed,
+            uploadLimit: number(options["max-upload-limit"]),
+            downloadLimit: number(options["max-download-limit"]),
+            eta: number(downloadSpeed > 0 ? Math.ceil(remaining / downloadSpeed) : 0),
+            peersConnected: number(data.peersConnected),
+            peersInSwarm: number(data.peersInSwarm),
+            seedsConnected: number(data.seedsConnected),
+            seedsInSwarm: number(data.seedsInSwarm),
+            torrentQueueOrder: number(data.queuePosition),
+            statusMessage: typeof data.errorMessage === "string" ? data.errorMessage : "",
+            dateAdded: number(data.dateAdded) || undefined,
+            dateCompleted: number(data.dateCompleted) || undefined,
+            savePath: typeof data.dir === "string" ? data.dir : "",
+            props: {
+                trackers: Array.isArray(data.trackers) ? data.trackers.join("\r\n") : "",
+                gid: data.gid,
+            },
+        })
+        this.aria2Status = typeof data.status === "string" ? data.status : "unknown"
+        this.trackers = Array.isArray(data.trackers)
+            ? data.trackers.filter((tracker): tracker is string => typeof tracker === "string" && tracker.length > 0)
+            : []
+    }
+
+    isStatusError() { return this.aria2Status === "error" }
+    isStatusPaused() { return false }
+    isStatusQueued() { return this.aria2Status === "waiting" }
+    isStatusCompleted() { return this.aria2Status === "complete" }
+    isStatusDownloading() { return this.aria2Status === "active" && !this.isStatusSeeding() }
+    isStatusSeeding() { return this.aria2Status === "active" && this.percent >= 1000 }
+    isStatusStopped() { return this.aria2Status === "paused" || this.aria2Status === "removed" }
+}

--- a/src/renderer/app/bittorrent/index.ts
+++ b/src/renderer/app/bittorrent/index.ts
@@ -2,6 +2,7 @@ export { Torrent } from "./abstracttorrent"
 export { TorrentClient } from "./torrentclient"
 
 // Client API implementations for bittorrent providers
+export { Aria2Client, Aria2Torrent } from "./aria2"
 export { DelugeClient, DelugeTorrent } from "./deluge"
 export { MockBittorrentClient } from "./mock"
 export { QBittorrentClient, QBittorrentTorrent } from "./qbittorrent"

--- a/src/renderer/app/directives/connection-form/connection-form.directive.ts
+++ b/src/renderer/app/directives/connection-form/connection-form.directive.ts
@@ -70,6 +70,7 @@ export class ConnectionFormDirective implements IDirective {
         scope.setPath = () => {
             if (scope.server?.client) {
                 scope.server.setPath();
+                syncHostFields();
             }
         };
 

--- a/src/renderer/app/directives/context-menu/context-menu.directive.ts
+++ b/src/renderer/app/directives/context-menu/context-menu.directive.ts
@@ -170,6 +170,20 @@ export class ContextMenuDirective implements IDirective {
                     return;
                 }
 
+                if (
+                    item.role === "set-speed-limits"
+                    && (!this.$rootScope.$btclient || !this.$rootScope.$btclient.features.speedLimits)
+                ) {
+                    return;
+                }
+
+                if (
+                    item.role === "set-ratio"
+                    && (!this.$rootScope.$btclient || !this.$rootScope.$btclient.features.ratioLimits)
+                ) {
+                    return;
+                }
+
                 appendMenuItem(list, item);
             });
 

--- a/src/renderer/app/directives/drop/drop.controller.ts
+++ b/src/renderer/app/directives/drop/drop.controller.ts
@@ -6,10 +6,12 @@ interface DropScope extends IScope {
     title: string;
     original_title: string;
     text_class: string;
+    change?: () => void;
 }
 
 export class DropDownController {
     static $inject = ["$scope"];
+    private changePending = false;
 
     constructor(private $scope: DropScope) {
         this.$scope.options = [];
@@ -35,6 +37,14 @@ export class DropDownController {
     update_model(title: string, value: any) {
         if (this.$scope.model !== value) {
             this.$scope.model = value;
+            this.changePending = true;
+        }
+    }
+
+    notifyChange() {
+        if (this.changePending) {
+            this.changePending = false;
+            this.$scope.change?.();
         }
     }
 

--- a/src/renderer/app/directives/drop/drop.directive.ts
+++ b/src/renderer/app/directives/drop/drop.directive.ts
@@ -158,9 +158,7 @@ export class DropdownElementDirective implements IDirective {
 
         scope.$watch("model", (value) => {
             controller.update_title(value);
-            if (scope.change) {
-                scope.change();
-            }
+            controller.notifyChange();
         });
         scope.$watch("disabled", () => {
             if (scope.disabled && scope.is_open) {

--- a/src/renderer/app/directives/torrent-files-tree/torrent-files-tree.controller.ts
+++ b/src/renderer/app/directives/torrent-files-tree/torrent-files-tree.controller.ts
@@ -35,6 +35,11 @@ export class TorrentFilesTreeController {
       () => scope.files,
       (files: TorrentFile[]) => {
         scope.rows = buildTorrentFileRows(files || []);
+        scope.rows.forEach((row) => {
+          if (row.isDirectory && !(row.path in scope.expandedFolders)) {
+            scope.expandedFolders[row.path] = true;
+          }
+        });
         this.updateVisibleRows();
       },
       true
@@ -52,9 +57,15 @@ export class TorrentFilesTreeController {
       this.scope.visibleRows = [];
       return;
     }
-    this.scope.visibleRows = rows.filter(
-      (row) => row.depth === 0 || expandedFolders[row.parentPath!]
-    );
+    const parentByPath = new Map(rows.map((row) => [row.path, row.parentPath]));
+    this.scope.visibleRows = rows.filter((row) => {
+      let parentPath = row.parentPath;
+      while (parentPath) {
+        if (!expandedFolders[parentPath]) return false;
+        parentPath = parentByPath.get(parentPath) || null;
+      }
+      return true;
+    });
     this.scope.visibleRows.forEach((row) => {
       if (row.isDirectory) {
         row._folderWanted = this.getFolderWanted(row);

--- a/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.controller.ts
+++ b/src/renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.controller.ts
@@ -93,7 +93,7 @@ export class TorrentSetRatioModalController {
       this.scope.loading = true;
       this.scope.error = null;
       const client = this.rootScope.$btclient;
-      if (!client || typeof client.setRatioLimit !== "function") {
+      if (!client?.features.ratioLimits || typeof client.setRatioLimit !== "function") {
         throw new Error("Ratio limits are not available for the current client");
       }
       await client.setRatioLimit(this.scope.torrents, { ratioLimit });

--- a/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.controller.ts
+++ b/src/renderer/app/directives/torrent-speed-modal/torrent-speed-modal.controller.ts
@@ -98,7 +98,7 @@ export class TorrentSpeedModalController {
       this.scope.loading = true;
       this.scope.error = null;
       const client = this.rootScope.$btclient;
-      if (!client || typeof client.setSpeedLimits !== "function") {
+      if (!client?.features.speedLimits || typeof client.setSpeedLimits !== "function") {
         throw new Error("Speed limits are not available for the current client");
       }
       await client.setSpeedLimits(this.scope.torrents, options);

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -232,6 +232,10 @@ export let serverService = ['$q', 'notificationService', '$bittorrent', '$btclie
             } else {
                 this.path = "/"
             }
+            const defaultPort = $btclients[this.client]?.defaultPort
+            if (defaultPort) {
+                this.port = defaultPort
+            }
         };
 
         Server.prototype.connect = function() {

--- a/src/renderer/styles/app/partials/icons.less
+++ b/src/renderer/styles/app/partials/icons.less
@@ -19,6 +19,7 @@
 }
 
 .deluge:before{content:'\EA01'}
+.aria2:before{content:'\EA07'}
 .downloadstation:before{content:'\EA02';}
 .qbittorrent:before{content:'\EA03';}
 .rtorrent:before{content:'\EA04';}

--- a/src/renderer/styles/assets/fonts/bittorrent.font.json
+++ b/src/renderer/styles/assets/fonts/bittorrent.font.json
@@ -13,6 +13,7 @@
   "normalize": true,
   "fontHeight": 1024,
   "codepoints": {
+    "aria2": 59911,
     "deluge": 59905,
     "downloadstation": 59906,
     "qbittorrent": 59907,

--- a/src/renderer/styles/assets/fonts/icons/aria2.svg
+++ b/src/renderer/styles/assets/fonts/icons/aria2.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 250 250">
+  <path d="M125 8a117 117 0 1 0 0 234 117 117 0 0 0 0-234Zm0 35 54 92h-34v58h-40v-58H71l54-92Z"/>
+</svg>

--- a/src/shared/client-metadata.ts
+++ b/src/shared/client-metadata.ts
@@ -2,9 +2,16 @@ export interface ClientMetadata {
     name: string
     icon: string
     showAdvancedUploadMenu: boolean
+    defaultPort?: number
 }
 
 export const CLIENT_METADATA = {
+    aria2: {
+        name: 'aria2',
+        icon: 'aria2',
+        showAdvancedUploadMenu: true,
+        defaultPort: 6800,
+    },
     utorrent: {
         name: 'µTorrent',
         icon: 'utorrent',

--- a/test/clients/aria2/aria2.conf
+++ b/test/clients/aria2/aria2.conf
@@ -1,0 +1,24 @@
+# Persist active downloads so daemon restarts retain their GIDs and state.
+save-session=/config/aria2.session
+input-file=/config/aria2.session
+save-session-interval=1
+max-download-result=10000
+
+dir=/downloads
+auto-file-renaming=false
+
+enable-rpc=true
+rpc-listen-port=6800
+rpc-listen-all=true
+rpc-allow-origin-all=true
+rpc-secret=password
+
+# Keep BitTorrent behavior deterministic inside the isolated test network.
+listen-port=6881
+dht-listen-port=6881
+enable-dht=false
+enable-dht6=false
+bt-enable-lpd=false
+bt-save-metadata=true
+bt-load-saved-metadata=true
+

--- a/test/clients/aria2/index.ts
+++ b/test/clients/aria2/index.ts
@@ -1,0 +1,46 @@
+import type { TorrentClientFeatures } from "../../../src/shared/ipc-contract"
+import type { TestClient } from "../types"
+import { defineClient } from "../define"
+
+const features = {
+  magnetLinks: true,
+  labels: false,
+  fileSelection: true,
+  uploadFileSelection: true,
+  setLocation: false,
+  torrentDetails: true,
+  torrentPeers: true,
+  trackerFilter: true,
+  alternativeSpeedLimits: false,
+  speedLimits: true,
+  ratioLimits: true,
+  freeDiskSpace: false,
+  uploadOptions: {
+    saveLocation: true,
+    renameTorrent: false,
+    category: false,
+    startTorrent: true,
+    skipCheck: true,
+    peerLimit: true,
+    sequentialDownload: false,
+    firstAndLastPiecePrio: true,
+    downloadSpeedLimit: true,
+    uploadSpeedLimit: true,
+  },
+} satisfies TorrentClientFeatures
+
+export default {
+  aria2: defineClient({
+    key: "aria2",
+    clientId: "aria2",
+    features,
+    fixture: "clients/aria2",
+    version: "edge",
+    port: 16800,
+    containerPort: 6800,
+    username: "",
+    password: "password",
+    acceptHttpStatus: 400,
+    acceptHttpPath: "/jsonrpc",
+  }),
+} satisfies Record<string, TestClient>

--- a/test/clients/index.ts
+++ b/test/clients/index.ts
@@ -1,3 +1,4 @@
+import aria2 from "./aria2"
 import deluge from "./deluge"
 import qbittorrent from "./qbittorrent"
 import mock from "./mock"
@@ -9,6 +10,7 @@ import type { TestClient } from "./types"
 export type { TestClient, TestClientInput } from "./types"
 
 export const TEST_CLIENTS = {
+  ...aria2,
   ...deluge,
   ...qbittorrent,
   ...mock,

--- a/test/clients/types.ts
+++ b/test/clients/types.ts
@@ -16,6 +16,7 @@ export interface TestClient {
   proxyPort?: number
   authProxyHostPort?: number
   acceptHttpStatus: number
+  acceptHttpPath?: string
   stopLabel: string
   downloadLabel: string
   downloadRoot?: string

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -41,6 +41,15 @@ services:
       - PROXY_PORT=${PROXY_PORT}
       - NGINX_AUTH_PORT=${NGINX_AUTH_PORT:-8081}
 
+  aria2:
+    image: opengg/aria2:${VERSION:-edge}
+    ports:
+      - ${CLIENT_HOST_PORT:-6800}:6800
+    volumes:
+      - ./clients/aria2/aria2.conf:/config/aria2.conf
+    tmpfs:
+      - /downloads:mode=1777
+
   deluge:
     image: linuxserver/deluge:${VERSION:-latest}
     environment:

--- a/test/framework/fixture.ts
+++ b/test/framework/fixture.ts
@@ -7,6 +7,8 @@ import { App, Torrent } from "../e2e"
 import { DockerComposeService } from "../shared/compose"
 import { setupMochaHooks, waitUntil } from "../testutil"
 import type { TestClient } from "../clients"
+import type { ElectorrentBridge } from "../../src/shared/ipc-contract"
+import { createDefaultSettings } from "../../src/shared/settings-defaults"
 
 export interface TestFixture {
   client: TestClient
@@ -41,9 +43,13 @@ export function configureSpec(options: { login?: boolean, clearTorrents?: boolea
     const userDataPath = await waitUntil(async () => {
         return await browser.electron.execute((electron) => electron.app.getPath("userData"))
     }, 10 * 1000)
-    fs.rmSync(path.join(userDataPath, "config.json"), { force: true })
+    await browser.execute((settings) => {
+      const rendererWindow = window as unknown as Window & { electorrent: ElectorrentBridge }
+      return rendererWindow.electorrent.settings.saveAll(settings)
+    }, createDefaultSettings())
     fs.rmSync(path.join(userDataPath, "certs"), { recursive: true, force: true })
     await browser.execute(() => window.localStorage.clear())
+    await browser.refresh()
 
     current.app = new App()
     this.app = current.app

--- a/test/framework/service.ts
+++ b/test/framework/service.ts
@@ -35,7 +35,7 @@ export default class ElectorrentTestService {
           composeOptions,
         )
         await waitForHttp({
-          url: `http://${client.host}:${client.containerHostPort ?? client.port}`,
+          url: `http://${client.host}:${client.containerHostPort ?? client.port}${client.acceptHttpPath ?? ""}`,
           statusCode: client.acceptHttpStatus,
         })
       }),

--- a/test/shared/nginx/rootfs/etc/nginx/templates/default.conf.template
+++ b/test/shared/nginx/rootfs/etc/nginx/templates/default.conf.template
@@ -7,6 +7,8 @@ server {
 
 server {
   listen ${NGINX_AUTH_PORT} default_server;
+  resolver 127.0.0.11 ipv6=off;
+  set $upstream http://${PROXY_HOST}:${PROXY_PORT};
 
   location / {
     auth_basic "Electorrent test fixture";
@@ -17,12 +19,14 @@ server {
     proxy_set_header   X-Forwarded-Host   $http_host;
     proxy_set_header   X-Forwarded-For    $remote_addr;
     proxy_set_header   Referer            '';
-    proxy_pass http://${PROXY_HOST}:${PROXY_PORT};
+    proxy_pass $upstream;
   }
 }
 
 server {
   listen 443 ssl default_server;
+  resolver 127.0.0.11 ipv6=off;
+  set $upstream http://${PROXY_HOST}:${PROXY_PORT};
 
   ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers         HIGH:!aNULL:!MD5;
@@ -51,6 +55,6 @@ server {
     proxy_set_header   X-Forwarded-Host   $http_host;
     proxy_set_header   X-Forwarded-For    $remote_addr;
     proxy_set_header   Referer            '';
-    proxy_pass http://${PROXY_HOST}:${PROXY_PORT};
+    proxy_pass $upstream;
   }
 }

--- a/test/specs/standard/layout.spec.ts
+++ b/test/specs/standard/layout.spec.ts
@@ -14,7 +14,7 @@ describe("layout", function () {
     await this.app.setTorrentSidebarCollapsed(true)
 
     assert.isTrue(await this.app.isTorrentSidebarCollapsed())
-    await $("[data-role='torrent-sidebar-labels-toggle']").waitForDisplayed()
+    await $("torrent-sidebar .nav li[data-state='all']").waitForDisplayed()
 
     await restartApplication(this)
     await this.app.torrentsPageIsVisible()


### PR DESCRIPTION
## Summary

- add aria2 as a fully registered JSON-RPC BitTorrent client
- support authenticated connections, TLS, O(1)-request snapshots, uploads, lifecycle actions, limits, ratios, file selection, details, peers, and tracker filtering
- add an `opengg/aria2:edge` integration fixture and include aria2 in the CI client matrix
- harden shared fixture startup/state isolation without client-specific test branches
- normalize aria2 paths so the download root is hidden while the torrent content hierarchy is preserved and initially expanded

## Why

Electorrent had no aria2 backend. aria2 exposes BitTorrent operations through JSON-RPC with string-valued fields, token authentication, GID transitions for magnets, and immutable completed results, requiring a dedicated adapter and renderer mapping.

## Validation

- `npm run build`
- `npm run test -- --client "aria2"` — 26/26 spec files passed
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/layout.spec.ts"` — 3/3 passed
- scoped ESLint for all changed TypeScript files passed
- `git diff --check`

`npm run lint` completes ESLint but the repository-wide TypeScript build currently reports pre-existing Angular typing errors in unrelated renderer directives/controllers.