### PR TITLE
fix(aria2): remove magnet metadata

### DIFF
--- a/src/main/lib/bittorrent/clients/aria2/index.ts
+++ b/src/main/lib/bittorrent/clients/aria2/index.ts
@@ -21,7 +21,6 @@ const TORRENT_FIELDS = [
 ]
 
 const MAX_RESULTS = 2_147_483_647
-const REMOVABLE_STATUSES = new Set(["active", "waiting", "paused"])
 const CHANGEABLE_STATUSES = new Set(["active", "waiting", "paused"])
 const STOPPED_STATUSES = new Set(["complete", "error", "removed"])
 
@@ -29,6 +28,7 @@ interface Aria2TorrentData extends Record<string, unknown> {
     gid?: unknown
     status?: unknown
     bittorrent?: unknown
+    following?: unknown
     followedBy?: unknown
 }
 
@@ -233,7 +233,6 @@ export class Aria2Runtime implements BittorrentRuntime {
 
     private rpc?: Aria2JsonRpcTransport
     private gidByHash = new Map<string, string>()
-    private linkedGidsByHash = new Map<string, string[]>()
     private statusByGid = new Map<string, string>()
     private selectedFilesByHash = new Map<string, Set<number>>()
     private dirByHash = new Map<string, string>()
@@ -243,7 +242,6 @@ export class Aria2Runtime implements BittorrentRuntime {
     async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
         this.rpc = new Aria2JsonRpcTransport(server)
         this.gidByHash.clear()
-        this.linkedGidsByHash.clear()
         this.statusByGid.clear()
         this.selectedFilesByHash.clear()
         this.dirByHash.clear()
@@ -335,29 +333,8 @@ export class Aria2Runtime implements BittorrentRuntime {
         const nextIdentityByGid = new Map<string, string>()
 
         this.gidByHash = new Map()
-        this.linkedGidsByHash = new Map()
         this.statusByGid = new Map()
         this.dirByHash = new Map()
-        const linkedGidsByGid = new Map<string, Set<string>>()
-        const linkGids = (first: string, second: string) => {
-            const linked = new Set([
-                ...(linkedGidsByGid.get(first.toLowerCase()) || [first]),
-                ...(linkedGidsByGid.get(second.toLowerCase()) || [second]),
-            ])
-            for (const gid of linked) linkedGidsByGid.set(gid.toLowerCase(), linked)
-        }
-        for (const torrent of withOptions) {
-            const gid = nonEmptyString(torrent.gid)
-            if (!gid) continue
-            this.statusByGid.set(gid, nonEmptyString(torrent.status) || "unknown")
-            if (!linkedGidsByGid.has(gid.toLowerCase())) {
-                linkedGidsByGid.set(gid.toLowerCase(), new Set([gid]))
-            }
-            if (!Array.isArray(torrent.followedBy)) continue
-            for (const childGid of torrent.followedBy) {
-                if (typeof childGid === "string" && childGid.length > 0) linkGids(gid, childGid)
-            }
-        }
         const torrents = [...byIdentity.entries()].map(([hash, torrent]) => {
             const gid = String(torrent.gid)
             const normalizedGid = gid.toLowerCase()
@@ -388,7 +365,6 @@ export class Aria2Runtime implements BittorrentRuntime {
             nextSessionMetadata.set(hash, { dateAdded, dateCompleted, completed: isCompleted })
             nextIdentityByGid.set(normalizedGid, hash)
             this.gidByHash.set(hash, gid)
-            this.linkedGidsByHash.set(hash, [...(linkedGidsByGid.get(normalizedGid) || [gid])])
             this.statusByGid.set(gid, status)
             this.dirByHash.set(hash, nonEmptyString(torrent.dir) || "")
 
@@ -590,14 +566,19 @@ export class Aria2Runtime implements BittorrentRuntime {
     }
 
     async remove(hashes: string[]): Promise<void> {
-        const gids = [...new Set(hashes.flatMap((hash) => {
-            const normalizedHash = hash.toLowerCase()
-            const gid = this.gidByHash.get(normalizedHash)
-            if (!gid) throw new Error(`aria2 download is no longer available: ${hash}`)
-            return this.linkedGidsByHash.get(normalizedHash) || [gid]
-        }))]
-        const activeGids = gids.filter((gid) => REMOVABLE_STATUSES.has(this.statusByGid.get(gid) || ""))
-        await this.ignoreMissing(this.client().multicall(activeGids.map((gid) => ({ method: "aria2.remove", params: [gid] }))))
+        const resolvedGids = this.resolveGids(hashes)
+        const statuses = await this.client().multicall<Aria2TorrentData>(resolvedGids.map((gid) => ({
+            method: "aria2.tellStatus",
+            params: [gid, ["gid", "following", "followedBy"]],
+        })))
+        const gids = [...new Set(statuses.flatMap((status, index) => [
+            nonEmptyString(status.gid) || resolvedGids[index],
+            ...(nonEmptyString(status.following) ? [status.following as string] : []),
+            ...(Array.isArray(status.followedBy)
+                ? status.followedBy.filter((gid): gid is string => typeof gid === "string" && gid.length > 0)
+                : []),
+        ]))]
+        await this.ignoreMissing(this.client().multicall(gids.map((gid) => ({ method: "aria2.remove", params: [gid] }))))
         await this.removeDownloadResults(gids)
         hashes.forEach((hash) => this.selectedFilesByHash.delete(hash.toLowerCase()))
     }

--- a/src/main/lib/bittorrent/clients/aria2/index.ts
+++ b/src/main/lib/bittorrent/clients/aria2/index.ts
@@ -233,6 +233,7 @@ export class Aria2Runtime implements BittorrentRuntime {
 
     private rpc?: Aria2JsonRpcTransport
     private gidByHash = new Map<string, string>()
+    private linkedGidsByHash = new Map<string, string[]>()
     private statusByGid = new Map<string, string>()
     private selectedFilesByHash = new Map<string, Set<number>>()
     private dirByHash = new Map<string, string>()
@@ -242,6 +243,7 @@ export class Aria2Runtime implements BittorrentRuntime {
     async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
         this.rpc = new Aria2JsonRpcTransport(server)
         this.gidByHash.clear()
+        this.linkedGidsByHash.clear()
         this.statusByGid.clear()
         this.selectedFilesByHash.clear()
         this.dirByHash.clear()
@@ -333,8 +335,29 @@ export class Aria2Runtime implements BittorrentRuntime {
         const nextIdentityByGid = new Map<string, string>()
 
         this.gidByHash = new Map()
+        this.linkedGidsByHash = new Map()
         this.statusByGid = new Map()
         this.dirByHash = new Map()
+        const linkedGidsByGid = new Map<string, Set<string>>()
+        const linkGids = (first: string, second: string) => {
+            const linked = new Set([
+                ...(linkedGidsByGid.get(first.toLowerCase()) || [first]),
+                ...(linkedGidsByGid.get(second.toLowerCase()) || [second]),
+            ])
+            for (const gid of linked) linkedGidsByGid.set(gid.toLowerCase(), linked)
+        }
+        for (const torrent of withOptions) {
+            const gid = nonEmptyString(torrent.gid)
+            if (!gid) continue
+            this.statusByGid.set(gid, nonEmptyString(torrent.status) || "unknown")
+            if (!linkedGidsByGid.has(gid.toLowerCase())) {
+                linkedGidsByGid.set(gid.toLowerCase(), new Set([gid]))
+            }
+            if (!Array.isArray(torrent.followedBy)) continue
+            for (const childGid of torrent.followedBy) {
+                if (typeof childGid === "string" && childGid.length > 0) linkGids(gid, childGid)
+            }
+        }
         const torrents = [...byIdentity.entries()].map(([hash, torrent]) => {
             const gid = String(torrent.gid)
             const normalizedGid = gid.toLowerCase()
@@ -365,6 +388,7 @@ export class Aria2Runtime implements BittorrentRuntime {
             nextSessionMetadata.set(hash, { dateAdded, dateCompleted, completed: isCompleted })
             nextIdentityByGid.set(normalizedGid, hash)
             this.gidByHash.set(hash, gid)
+            this.linkedGidsByHash.set(hash, [...(linkedGidsByGid.get(normalizedGid) || [gid])])
             this.statusByGid.set(gid, status)
             this.dirByHash.set(hash, nonEmptyString(torrent.dir) || "")
 
@@ -566,7 +590,12 @@ export class Aria2Runtime implements BittorrentRuntime {
     }
 
     async remove(hashes: string[]): Promise<void> {
-        const gids = this.resolveGids(hashes)
+        const gids = [...new Set(hashes.flatMap((hash) => {
+            const normalizedHash = hash.toLowerCase()
+            const gid = this.gidByHash.get(normalizedHash)
+            if (!gid) throw new Error(`aria2 download is no longer available: ${hash}`)
+            return this.linkedGidsByHash.get(normalizedHash) || [gid]
+        }))]
         const activeGids = gids.filter((gid) => REMOVABLE_STATUSES.has(this.statusByGid.get(gid) || ""))
         await this.ignoreMissing(this.client().multicall(activeGids.map((gid) => ({ method: "aria2.remove", params: [gid] }))))
         await this.removeDownloadResults(gids)

--- a/src/main/lib/bittorrent/clients/aria2/index.ts
+++ b/src/main/lib/bittorrent/clients/aria2/index.ts
@@ -569,15 +569,13 @@ export class Aria2Runtime implements BittorrentRuntime {
         const resolvedGids = this.resolveGids(hashes)
         const statuses = await this.client().multicall<Aria2TorrentData>(resolvedGids.map((gid) => ({
             method: "aria2.tellStatus",
-            params: [gid, ["gid", "following", "followedBy"]],
+            params: [gid, ["gid", "following"]],
         })))
-        const gids = [...new Set(statuses.flatMap((status, index) => [
-            nonEmptyString(status.gid) || resolvedGids[index],
-            ...(nonEmptyString(status.following) ? [status.following as string] : []),
-            ...(Array.isArray(status.followedBy)
-                ? status.followedBy.filter((gid): gid is string => typeof gid === "string" && gid.length > 0)
-                : []),
-        ]))]
+        const gids = [...new Set(statuses.flatMap((status, index) => {
+            const gid = nonEmptyString(status.gid) || resolvedGids[index]
+            const following = nonEmptyString(status.following)
+            return following ? [gid, following] : [gid]
+        }))]
         await this.ignoreMissing(this.client().multicall(gids.map((gid) => ({ method: "aria2.remove", params: [gid] }))))
         await this.removeDownloadResults(gids)
         hashes.forEach((hash) => this.selectedFilesByHash.delete(hash.toLowerCase()))

--- a/test/specs/standard/upload-queue.spec.ts
+++ b/test/specs/standard/upload-queue.spec.ts
@@ -75,6 +75,14 @@ describe("upload queue", function () {
       for (const torrent of uploadedTorrents) {
         await torrent.waitForExist({ timeout: 30 * 1000 })
       }
+      const magnetTorrent = uploadedTorrents[0]
+      await eventually(() => magnetTorrent.getColumn("decodedName")).satisfies(
+        "not contain [METADATA]",
+        (name) => !/\[metadata\]/i.test(name),
+        { timeout: 30 * 1000 },
+      )
+      await magnetTorrent.waitForStates(["Seeding", "Finished"], { timeout: 120 * 1000 })
+      await magnetTorrent.delete()
     } finally {
       for (const torrent of uploadedTorrents) {
         if (await torrent.isExisting()) {


### PR DESCRIPTION
## Summary
- link aria2 magnet metadata downloads to their visible content download via `followedBy`
- remove both GIDs in the existing aria2 multicall flow

## Root cause
aria2 retains the metadata GID after deleting the visible magnet content download, which makes the metadata item appear in the queue.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client aria2 --spec test/specs/standard/upload-queue.spec.ts` (passed twice)