### PR TITLE
fix(saved-locations): compact icon grid

### DIFF
--- a/src/renderer/app/directives/saved-location-modal/saved-location-modal.less
+++ b/src/renderer/app/directives/saved-location-modal/saved-location-modal.less
@@ -1,6 +1,7 @@
-saved-location-modal {
+saved-location-modal,
+[saved-location-modal] {
     .saved-location-icon-picker { max-height: 18rem; overflow-y: auto; }
-    .saved-location-icon-grid > .column { padding: .35rem !important; }
+    .saved-location-icon-grid > .column { padding: .2rem !important; }
     .saved-location-icon-button.ui.button { padding: .55em !important; }
     .saved-location-icon-button.ui.button > .icon { margin: 0 !important; font-size: 1.1em; }
 }

--- a/src/renderer/app/directives/saved-location-modal/saved-location-modal.template.html
+++ b/src/renderer/app/directives/saved-location-modal/saved-location-modal.template.html
@@ -1,4 +1,4 @@
-<modal
+<modal saved-location-modal
     size="small"
     id="{{ ctl.modalId }}"
     on-hidden="ctl.onHidden()"


### PR DESCRIPTION
## Summary
- reduce saved-location icon-grid column padding
- preserve the existing Semantic UI spacing override

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/upload-options.spec.ts"