### PR TITLE
feat(torrents): add existing label action

### DIFF
--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -75,6 +75,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         ] },
         { label: "Sequential Download", action: "toggleSequentialDownload", checkProperty: "sequentialDownload" },
         { role: "set-location", label: "Set Location", icon: "folder open" },
+        { role: "set-label", label: "Set Label", icon: "tag" },
         { role: "set-speed-limits", label: "Set Speed Limits", icon: "dashboard" },
         { role: "set-ratio", label: "Set Ratio", icon: "percent" },
         { role: "remove", label: "Remove", action: "delete", icon: "remove" },

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -129,6 +129,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         ] },
         { label: "Sequential Download", action: "toggleSequentialDownload", checkProperty: "sequentialDownload" },
         { role: "set-location", label: "Set Location", icon: "folder open" },
+        { role: "set-label", label: "Set Label", icon: "tag" },
         { role: "set-speed-limits", label: "Set Speed Limits", icon: "dashboard" },
         { role: "set-ratio", label: "Set Ratio", icon: "percent" },
         { role: "remove", label: "Remove", action: "delete", icon: "remove" },

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -31,6 +31,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
             { label: "Low", action: "priorityLow" },
             { label: "Don't Download", action: "priorityOff" },
         ] },
+        { role: "set-label", label: "Set Label", icon: "tag" },
         { role: "set-speed-limits", label: "Set Speed Limits", icon: "dashboard" },
         { role: "remove", label: "Remove", action: "remove", icon: "remove" },
         { label: "Remove and Delete", action: "deleteAndErase", icon: "trash", role: "delete" },

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -107,6 +107,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
         { label: "Move Up Queue", action: "queueUp", icon: "arrow up" },
         { label: "Move Queue Down", action: "queueDown", icon: "arrow down" },
         { role: "set-location", label: "Set Location", icon: "folder open" },
+        { role: "set-label", label: "Set Label", icon: "tag" },
         { role: "set-speed-limits", label: "Set Speed Limits", icon: "dashboard" },
         { role: "set-ratio", label: "Set Ratio", icon: "percent" },
         { label: "Remove", menu: [

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -20,6 +20,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
         { label: "Force Start", action: "forcestart", icon: "flag" },
         { label: "Move Up Queue", action: "queueup", icon: "arrow up" },
         { label: "Move Queue Down", action: "queuedown", icon: "arrow down" },
+        { role: "set-label", label: "Set Label", icon: "tag" },
         { role: "set-speed-limits", label: "Set Speed Limits", icon: "dashboard" },
         { role: "remove", label: "Remove", action: "remove", icon: "remove" },
         { label: "Remove And", menu: [

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -218,6 +218,8 @@ import { TorrentDetailsTrackersTabDirective } from "@renderer/app/directives/tor
 torrentApp.directive('torrentDetailsTrackersTab', TorrentDetailsTrackersTabDirective.getInstance())
 import { SetLocationModalDirective } from "@renderer/app/directives/set-location-modal/set-location-modal.directive";
 torrentApp.directive('setLocationModal', SetLocationModalDirective.getInstance())
+import { SetLabelModalDirective } from "@renderer/app/directives/set-label-modal/set-label-modal.directive";
+torrentApp.directive('setLabelModal', SetLabelModalDirective.getInstance())
 import { TorrentSpeedModalDirective } from "@renderer/app/directives/torrent-speed-modal/torrent-speed-modal.directive";
 torrentApp.directive('torrentSpeedModal', TorrentSpeedModalDirective.getInstance())
 import { TorrentSetRatioModalDirective } from "@renderer/app/directives/torrent-set-ratio-modal/torrent-set-ratio-modal.directive";

--- a/src/renderer/app/directives/set-label-modal/set-label-modal.controller.ts
+++ b/src/renderer/app/directives/set-label-modal/set-label-modal.controller.ts
@@ -1,0 +1,66 @@
+import { IScope } from "angular";
+import { ModalController } from "@renderer/app/directives/modal/modal.controller";
+import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
+
+export interface SetLabelModalScope extends IScope {
+  labels: string[];
+  label: string;
+  torrents: any[];
+}
+
+export class SetLabelModalController {
+  static $inject = ["$scope", "$rootScope", "notificationService"];
+
+  modalref: ModalController;
+  private unsubscribeOpen?: () => void;
+
+  constructor(
+    public readonly scope: SetLabelModalScope,
+    private readonly rootScope: ElectorrentRootScope,
+    private readonly notify: any,
+  ) {
+    this.reset();
+
+    const off = this.rootScope.$on("torrentLabel:open", (_event, torrents) => {
+      this.open(Array.isArray(torrents) ? torrents : []);
+    });
+    this.unsubscribeOpen = () => off();
+
+    this.scope.$on("$destroy", () => this.unsubscribeOpen?.());
+  }
+
+  private reset() {
+    this.scope.label = "";
+    this.scope.torrents = [];
+  }
+
+  open(torrents: any[]) {
+    this.scope.label = this.scope.labels[0] || "";
+    this.scope.torrents = torrents.slice();
+    this.modalref?.showModal();
+  }
+
+  onHidden() {
+    this.reset();
+  }
+
+  async apply() {
+    if (!this.scope.label || !this.scope.torrents.length) {
+      return;
+    }
+
+    const labelAction: any = this.rootScope.$btclient?.actionHeader.find((item: any) => item.type === "labels");
+    if (!labelAction) {
+      return;
+    }
+
+    try {
+      await labelAction.click.call(this.rootScope.$btclient, this.scope.torrents, this.scope.label);
+      this.rootScope.$broadcast("torrentLabel:updated");
+      this.modalref.hideModal();
+    } catch (err) {
+      console.error("Set label error", err);
+      this.notify.alert("Invalid action", "The label could not be assigned because the server responded with a faulty reply");
+    }
+  }
+}

--- a/src/renderer/app/directives/set-label-modal/set-label-modal.directive.ts
+++ b/src/renderer/app/directives/set-label-modal/set-label-modal.directive.ts
@@ -1,0 +1,17 @@
+import { IDirective, IDirectiveFactory } from "angular";
+import { SetLabelModalController } from "./set-label-modal.controller";
+import html from "./set-label-modal.template.html";
+
+export class SetLabelModalDirective implements IDirective {
+  template = html;
+  restrict = "E";
+  scope = {
+    labels: "=",
+  };
+  controller = SetLabelModalController;
+  controllerAs = "ctl";
+
+  static getInstance(): IDirectiveFactory {
+    return () => new SetLabelModalDirective();
+  }
+}

--- a/src/renderer/app/directives/set-label-modal/set-label-modal.template.html
+++ b/src/renderer/app/directives/set-label-modal/set-label-modal.template.html
@@ -1,0 +1,37 @@
+<modal
+    id="setLabelModal"
+    size="tiny"
+    approve="ctl.apply()"
+    on-hidden="ctl.onHidden()"
+    ng-ref="ctl.modalref">
+    <div class="header">
+        <i class="tag icon"></i>
+        Set Label
+    </div>
+    <div class="content">
+        <div class="ui form">
+            <div class="field">
+                <label for="set-label-dropdown">Label</label>
+                <dropdown
+                    id="set-label-dropdown"
+                    title="Select label"
+                    class="fluid"
+                    open-on-focus="false"
+                    ng-model="ctl.scope.label">
+                    <dropdown-group ng-repeat="label in ctl.scope.labels track by label" title="label" value="label">
+                        <span class="set-label-dropdown-chip" label-chip="label">
+                            <span class="label-chip-text">{{ label }}</span>
+                        </span>
+                    </dropdown-group>
+                </dropdown>
+            </div>
+        </div>
+    </div>
+    <div class="actions">
+        <button type="button" class="ui black deny button">Cancel</button>
+        <button type="button" class="ui green right labeled icon approve button" ng-disabled="!ctl.scope.label">
+            Apply Label
+            <i class="tag icon"></i>
+        </button>
+    </div>
+</modal>

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -16,6 +16,11 @@ interface TorrentControllerScope extends angular.IScope {
     };
     speedLimitModalRef?: { open(torrents: any[]): void };
     setRatioModalRef?: { open(torrents: any[]): void };
+    setLabelModalRef?: ModalController;
+    labelAssignment?: {
+        label: string;
+        torrents: any[];
+    };
     [key: string]: any;
 }
 
@@ -72,6 +77,10 @@ export class TorrentsPageController {
         $scope.uploadAdvancedOptionsKey = "Ctrl";
         $scope.deleteConfirmation = {
             action: null,
+            label: "",
+            torrents: [],
+        };
+        $scope.labelAssignment = {
             label: "",
             torrents: [],
         };
@@ -755,6 +764,16 @@ export class TorrentsPageController {
                 }
                 return $q.resolve();
             }
+            if (item?.role === "set-label") {
+                if (selected.length >= 1) {
+                    $scope.labelAssignment = {
+                        label: $scope.labels[0] || "",
+                        torrents: selected.slice(),
+                    };
+                    $scope.setLabelModalRef?.showModal();
+                }
+                return $q.resolve();
+            }
             if (item?.role === "set-speed-limits") {
                 if (selected.length >= 1) {
                     $scope.speedLimitModalRef?.open(selected.slice());
@@ -772,6 +791,21 @@ export class TorrentsPageController {
                 return $q.resolve();
             }
             return runContextAction(action, selected);
+        };
+
+        $scope.assignExistingLabel = () => {
+            const assignment = $scope.labelAssignment;
+            const labelAction: any = $rootScope.$btclient?.actionHeader.find((item: any) => item.type === "labels");
+            if (!assignment?.label || !labelAction) {
+                return $q.resolve();
+            }
+
+            return labelAction.click.call($rootScope.$btclient, assignment.torrents, assignment.label)
+                .then(() => syncAfterTorrentMutation())
+                .catch((err: unknown) => {
+                    console.error("Set label error", err);
+                    $notify.alert("Invalid action", "The label could not be assigned because the server responded with a faulty reply");
+                });
         };
 
         function fetchTorrents(): any[] {

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -16,11 +16,6 @@ interface TorrentControllerScope extends angular.IScope {
     };
     speedLimitModalRef?: { open(torrents: any[]): void };
     setRatioModalRef?: { open(torrents: any[]): void };
-    setLabelModalRef?: ModalController;
-    labelAssignment?: {
-        label: string;
-        torrents: any[];
-    };
     [key: string]: any;
 }
 
@@ -77,10 +72,6 @@ export class TorrentsPageController {
         $scope.uploadAdvancedOptionsKey = "Ctrl";
         $scope.deleteConfirmation = {
             action: null,
-            label: "",
-            torrents: [],
-        };
-        $scope.labelAssignment = {
             label: "",
             torrents: [],
         };
@@ -287,6 +278,10 @@ export class TorrentsPageController {
         });
 
         $scope.$on("torrentLocation:updated", () => {
+            syncAfterTorrentMutation();
+        });
+
+        $scope.$on("torrentLabel:updated", () => {
             syncAfterTorrentMutation();
         });
 
@@ -766,11 +761,7 @@ export class TorrentsPageController {
             }
             if (item?.role === "set-label") {
                 if (selected.length >= 1) {
-                    $scope.labelAssignment = {
-                        label: $scope.labels[0] || "",
-                        torrents: selected.slice(),
-                    };
-                    $scope.setLabelModalRef?.showModal();
+                    $rootScope.$emit("torrentLabel:open", selected.slice());
                 }
                 return $q.resolve();
             }
@@ -791,21 +782,6 @@ export class TorrentsPageController {
                 return $q.resolve();
             }
             return runContextAction(action, selected);
-        };
-
-        $scope.assignExistingLabel = () => {
-            const assignment = $scope.labelAssignment;
-            const labelAction: any = $rootScope.$btclient?.actionHeader.find((item: any) => item.type === "labels");
-            if (!assignment?.label || !labelAction) {
-                return $q.resolve();
-            }
-
-            return labelAction.click.call($rootScope.$btclient, assignment.torrents, assignment.label)
-                .then(() => syncAfterTorrentMutation())
-                .catch((err: unknown) => {
-                    console.error("Set label error", err);
-                    $notify.alert("Invalid action", "The label could not be assigned because the server responded with a faulty reply");
-                });
         };
 
         function fetchTorrents(): any[] {

--- a/src/renderer/app/directives/torrents-page/torrents-page.less
+++ b/src/renderer/app/directives/torrents-page/torrents-page.less
@@ -38,6 +38,8 @@ torrents-page {
 
     #torrentTable:focus { outline: none; }
 
+    .set-label-dropdown-chip { padding: .35em .65em; }
+
     .status-bar {
         flex: 0 0 auto;
         display: flex;

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -152,42 +152,7 @@
     <context-menu id="contextmenu" bind="contextMenu" menu="$btclient.contextMenu" click="doContextAction" debug="debug">
     </context-menu>
 
-    <modal
-        id="setLabelModal"
-        size="tiny"
-        approve="assignExistingLabel()"
-        ng-ref="setLabelModalRef">
-        <div class="header">
-            <i class="tag icon"></i>
-            Set Label
-        </div>
-        <div class="content">
-            <div class="ui form">
-                <div class="field">
-                    <label for="set-label-dropdown">Label</label>
-                    <dropdown
-                        id="set-label-dropdown"
-                        title="Select label"
-                        class="fluid"
-                        open-on-focus="false"
-                        ng-model="labelAssignment.label">
-                        <dropdown-group ng-repeat="label in labels track by label" title="label" value="label">
-                            <span class="set-label-dropdown-chip" label-chip="label">
-                                <span class="label-chip-text">{{ label }}</span>
-                            </span>
-                        </dropdown-group>
-                    </dropdown>
-                </div>
-            </div>
-        </div>
-        <div class="actions">
-            <button type="button" class="ui black deny button">Cancel</button>
-            <button type="button" class="ui green right labeled icon approve button" ng-disabled="!labelAssignment.label">
-                Apply Label
-                <i class="tag icon"></i>
-            </button>
-        </div>
-    </modal>
+    <set-label-modal labels="labels"></set-label-modal>
 
     <modal
         id="deleteTorrentModal"

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -164,8 +164,19 @@
         <div class="content">
             <div class="ui form">
                 <div class="field">
-                    <label for="set-label-select">Label</label>
-                    <select id="set-label-select" class="ui fluid dropdown" ng-model="labelAssignment.label" ng-options="label for label in labels"></select>
+                    <label for="set-label-dropdown">Label</label>
+                    <dropdown
+                        id="set-label-dropdown"
+                        title="Select label"
+                        class="fluid"
+                        open-on-focus="false"
+                        ng-model="labelAssignment.label">
+                        <dropdown-group ng-repeat="label in labels track by label" title="label" value="label">
+                            <span class="set-label-dropdown-chip" label-chip="label">
+                                <span class="label-chip-text">{{ label }}</span>
+                            </span>
+                        </dropdown-group>
+                    </dropdown>
                 </div>
             </div>
         </div>

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -153,6 +153,32 @@
     </context-menu>
 
     <modal
+        id="setLabelModal"
+        size="tiny"
+        approve="assignExistingLabel()"
+        ng-ref="setLabelModalRef">
+        <div class="header">
+            <i class="tag icon"></i>
+            Set Label
+        </div>
+        <div class="content">
+            <div class="ui form">
+                <div class="field">
+                    <label for="set-label-select">Label</label>
+                    <select id="set-label-select" class="ui fluid dropdown" ng-model="labelAssignment.label" ng-options="label for label in labels"></select>
+                </div>
+            </div>
+        </div>
+        <div class="actions">
+            <button type="button" class="ui black deny button">Cancel</button>
+            <button type="button" class="ui green right labeled icon approve button" ng-disabled="!labelAssignment.label">
+                Apply Label
+                <i class="tag icon"></i>
+            </button>
+        </div>
+    </modal>
+
+    <modal
         id="deleteTorrentModal"
         size="tiny"
         approve="confirmDelete()"

--- a/src/shared/torrent-actions.ts
+++ b/src/shared/torrent-actions.ts
@@ -3,6 +3,7 @@ export type TorrentActionRole =
     | "files"
     | "verify"
     | "set-location"
+    | "set-label"
     | "set-speed-limits"
     | "set-ratio"
     | "remove"
@@ -22,6 +23,7 @@ const COMMON_ACCELERATORS: Partial<Record<TorrentActionRole, string>> = {
     details: "CmdOrCtrl+D",
     files: "CmdOrCtrl+Shift+D",
     verify: "CmdOrCtrl+Shift+R",
+    "set-label": "CmdOrCtrl+L",
     remove: "Delete",
     delete: "CmdOrCtrl+Delete",
 }

--- a/test/specs/mock/actions-menu.spec.ts
+++ b/test/specs/mock/actions-menu.spec.ts
@@ -27,6 +27,7 @@ describe("mock Actions menu", function () {
       "Queue",
       "Sequential Download",
       "Set Location",
+      "Set Label",
       "Set Speed Limits",
       "Set Ratio",
       "Remove",
@@ -49,6 +50,18 @@ describe("mock Actions menu", function () {
     const detailsShortcut = $("//button[contains(@class, 'title-bar-menu-item')][.//span[normalize-space(.)='Details']]//span[contains(@class, 'title-bar-menu-accelerator')]")
     await detailsShortcut.waitForDisplayed()
     assert.notInclude(await detailsShortcut.getText(), "CmdOrCtrl")
+  })
+
+  it("exposes the label action and shortcut in the title menu", async function () {
+    await browser.keys("Escape")
+
+    const actionsMenu = $("//button[contains(@class, 'title-bar-menu-trigger') and normalize-space(.)='Actions']")
+    await actionsMenu.waitForClickable()
+    await actionsMenu.click()
+
+    const labelAction = $("//button[contains(@class, 'title-bar-menu-item')][.//span[normalize-space(.)='Set Label']]")
+    await labelAction.waitForEnabled()
+    assert.include(await labelAction.$(".title-bar-menu-accelerator").getText(), "L")
   })
 
   it("opens submenu items in a flyout to the right", async function () {


### PR DESCRIPTION
## Summary
- add a Set Label action for clients that support labels
- provide a label-selection modal and CmdOrCtrl+L shortcut
- cover the title-bar menu action with the mock client spec

## Validation
- npm run lint
- npm run build
- npm run test -- --client "mock" --spec "test/specs/mock/actions-menu.spec.ts"