### PR TITLE
feat(menu): add server selection shortcut

### DIFF
--- a/src/shared/title-menu.ts
+++ b/src/shared/title-menu.ts
@@ -159,6 +159,7 @@ export function deriveTitleMenu(state: TitleMenuState): TitleMenuItem[] {
     ]
 
     const serverItems: TitleMenuItem[] = [
+        { label: "Server selection...", action: { type: "show-servers" } },
         { label: "Add new server...", accelerator: "CmdOrCtrl+N", action: { type: "add-server" } },
         {
             label: "Set current as default",

--- a/test/specs/mock/saved-servers.spec.ts
+++ b/test/specs/mock/saved-servers.spec.ts
@@ -29,6 +29,14 @@ describe("mock saved servers", function () {
     })
     await app.torrentsPageIsVisible()
 
+    await serverMenu.click()
+    const serverSelection = $("//button[contains(@class, 'title-bar-menu-item')][.//span[normalize-space(.)='Server selection...']]")
+    await serverSelection.waitForClickable()
+    await serverSelection.click()
+    await app.serverSelectionPageIsVisible()
+    await app.connectServerSelection(0)
+    await app.torrentsPageIsVisible()
+
     await app.openSettings()
     await app.settingsGotoTab("servers")
     assert.include(await getSettingsServerHosts(), savedServerHost)


### PR DESCRIPTION
## Summary
- add a Servers-menu shortcut to the server selection page
- cover opening it and reconnecting in the saved servers spec

## Validation
- npm run lint
- npm run build
- npm run test -- --client "mock" --spec "test/specs/mock/saved-servers.spec.ts"