### PR TITLE
refactor(ui): use modal refs

### DIFF
--- a/src/renderer/app/directives/rename-server-modal/rename-server-modal.directive.ts
+++ b/src/renderer/app/directives/rename-server-modal/rename-server-modal.directive.ts
@@ -1,13 +1,41 @@
 import { IDirective, IDirectiveFactory } from "angular";
+import { ModalController } from "@renderer/app/directives/modal/modal.controller";
 import html from "./rename-server-modal.template.html";
+
+interface RenameServerModalScope extends angular.IScope {
+    data: {
+        server?: any;
+        name: string;
+    };
+    modalRef?: RenameServerModalController;
+}
+
+class RenameServerModalController {
+    static $inject = ["$scope"];
+
+    modalref?: ModalController;
+
+    constructor(private readonly scope: RenameServerModalScope) {
+        this.scope.modalRef = this;
+    }
+
+    open(server: any) {
+        this.scope.data.server = server;
+        this.scope.data.name = server.getDisplayName();
+        this.modalref?.showModal();
+    }
+}
 
 export class RenameServerModalDirective implements IDirective {
     restrict = "E";
     scope = {
         data: "=",
         approve: "&",
+        modalRef: "=?",
     };
     template = html;
+    controller = RenameServerModalController;
+    controllerAs = "ctl";
 
     static getInstance(): IDirectiveFactory {
         return () => new RenameServerModalDirective();

--- a/src/renderer/app/directives/rename-server-modal/rename-server-modal.template.html
+++ b/src/renderer/app/directives/rename-server-modal/rename-server-modal.template.html
@@ -1,7 +1,8 @@
 <modal
     size="small"
     approve="approve()"
-    id="renameModal">
+    id="renameModal"
+    ng-ref="ctl.modalref">
     <i class="close icon"></i>
     <div class="header">
         Rename Server

--- a/src/renderer/app/directives/set-label-modal/set-label-modal.controller.ts
+++ b/src/renderer/app/directives/set-label-modal/set-label-modal.controller.ts
@@ -1,9 +1,8 @@
-import { IScope } from "angular";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
+import type { SetLabelModalScope as SetLabelModalDirectiveScope } from "./set-label-modal.directive";
 
-export interface SetLabelModalScope extends IScope {
-  labels: string[];
+export interface SetLabelModalScope extends SetLabelModalDirectiveScope {
   label: string;
   torrents: any[];
 }
@@ -12,7 +11,6 @@ export class SetLabelModalController {
   static $inject = ["$scope", "$rootScope", "notificationService"];
 
   modalref: ModalController;
-  private unsubscribeOpen?: () => void;
 
   constructor(
     public readonly scope: SetLabelModalScope,
@@ -20,13 +18,7 @@ export class SetLabelModalController {
     private readonly notify: any,
   ) {
     this.reset();
-
-    const off = this.rootScope.$on("torrentLabel:open", (_event, torrents) => {
-      this.open(Array.isArray(torrents) ? torrents : []);
-    });
-    this.unsubscribeOpen = () => off();
-
-    this.scope.$on("$destroy", () => this.unsubscribeOpen?.());
+    this.scope.modalRef = this;
   }
 
   private reset() {
@@ -56,7 +48,7 @@ export class SetLabelModalController {
 
     try {
       await labelAction.click.call(this.rootScope.$btclient, this.scope.torrents, this.scope.label);
-      this.rootScope.$broadcast("torrentLabel:updated");
+      await this.scope.onSaved?.();
       this.modalref.hideModal();
     } catch (err) {
       console.error("Set label error", err);

--- a/src/renderer/app/directives/set-label-modal/set-label-modal.directive.ts
+++ b/src/renderer/app/directives/set-label-modal/set-label-modal.directive.ts
@@ -2,11 +2,19 @@ import { IDirective, IDirectiveFactory } from "angular";
 import { SetLabelModalController } from "./set-label-modal.controller";
 import html from "./set-label-modal.template.html";
 
+export interface SetLabelModalScope extends angular.IScope {
+  labels: string[];
+  modalRef?: SetLabelModalController;
+  onSaved?: () => Promise<void> | void;
+}
+
 export class SetLabelModalDirective implements IDirective {
   template = html;
   restrict = "E";
   scope = {
     labels: "=",
+    modalRef: "=?",
+    onSaved: "<",
   };
   controller = SetLabelModalController;
   controllerAs = "ctl";

--- a/src/renderer/app/directives/set-location-modal/set-location-modal.controller.ts
+++ b/src/renderer/app/directives/set-location-modal/set-location-modal.controller.ts
@@ -1,10 +1,10 @@
-import { IScope } from "angular";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
 import type { SettingsService } from "@renderer/app/services/settings";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import type { SavedLocationConfig } from "@shared/ipc-contract";
+import type { SetLocationModalScope as SetLocationModalDirectiveScope } from "./set-location-modal.directive";
 
-export interface SetLocationModalScope extends IScope {
+export interface SetLocationModalScope extends SetLocationModalDirectiveScope {
   torrents: any[];
   location: string;
   loading: boolean;
@@ -18,7 +18,6 @@ export class SetLocationModalController {
   rootScope: ElectorrentRootScope;
   modalref: ModalController;
   savedLocations: SavedLocationConfig[] = [];
-  private unsubscribeOpen?: () => void;
 
   constructor(
     scope: SetLocationModalScope,
@@ -31,17 +30,7 @@ export class SetLocationModalController {
     this.scope.location = "";
     this.scope.loading = false;
     this.scope.error = null;
-
-    const off = this.rootScope.$on("torrentLocation:open", (_event, torrents) => {
-      this.open(Array.isArray(torrents) ? torrents : []);
-    });
-    this.unsubscribeOpen = () => off();
-
-    this.scope.$on("$destroy", () => {
-      if (this.unsubscribeOpen) {
-        this.unsubscribeOpen();
-      }
-    });
+    this.scope.modalRef = this;
   }
 
   private getSharedLocation(torrents: any[]) {
@@ -107,7 +96,7 @@ export class SetLocationModalController {
         throw new Error("Set location is not available for the current client");
       }
       await client.setLocation(this.scope.torrents, this.scope.location);
-      this.rootScope.$broadcast("torrentLocation:updated");
+      await this.scope.onSaved?.();
       this.close();
     } catch (err: any) {
       this.scope.error = err?.message || "Failed to set location";

--- a/src/renderer/app/directives/set-location-modal/set-location-modal.directive.ts
+++ b/src/renderer/app/directives/set-location-modal/set-location-modal.directive.ts
@@ -2,10 +2,18 @@ import { IDirective, IDirectiveFactory } from "angular";
 import { SetLocationModalController } from "./set-location-modal.controller";
 import html from "./set-location-modal.template.html";
 
+export interface SetLocationModalScope extends angular.IScope {
+  modalRef?: SetLocationModalController;
+  onSaved?: () => Promise<void> | void;
+}
+
 export class SetLocationModalDirective implements IDirective {
   template = html;
   restrict = "E";
-  scope = {};
+  scope = {
+    modalRef: "=?",
+    onSaved: "<",
+  };
   controller = SetLocationModalController;
   controllerAs = "ctl";
 

--- a/src/renderer/app/directives/settings-page/settings-page.controller.ts
+++ b/src/renderer/app/directives/settings-page/settings-page.controller.ts
@@ -127,13 +127,6 @@ export class SettingsPageController {
             $scope.settings.watchDirectory = "";
         };
 
-        $scope.openRenameModal = (server: any) => {
-            $scope.renameData.server = server;
-            $scope.renameData.name = server.getDisplayName();
-            const modal: any = $("#renameModal");
-            modal.modal("show");
-        };
-
         $scope.renameServer = () => {
             if (!$scope.renameData.name) {
                 return false;

--- a/src/renderer/app/directives/settings-servers/settings-servers.template.html
+++ b/src/renderer/app/directives/settings-servers/settings-servers.template.html
@@ -59,7 +59,7 @@
                 <button ng-disabled="$first" class="circular green ui icon mini button" ng-click="moveServerUp(server)">
                     <i class="icon arrow up"></i>
                 </button>
-                <button class="circular blue ui icon mini button" ng-click="openRenameModal(server)">
+                <button class="circular blue ui icon mini button" ng-click="renameModalRef.open(server)">
                     <i class="icon tag"></i>
                 </button>
                 <button ng-if="server.proto === 'https' && server.tlsSecurity === 'insecure'" class="circular orange ui icon mini button" ng-click="disableInsecureTls(server)" title="Disable Insecure TLS">
@@ -73,4 +73,8 @@
     </tbody>
 </table>
 
-<rename-server-modal data="renameData" approve="renameServer()"></rename-server-modal>
+<rename-server-modal
+    data="renameData"
+    approve="renameServer()"
+    modal-ref="renameModalRef">
+</rename-server-modal>

--- a/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.controller.ts
+++ b/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.controller.ts
@@ -18,7 +18,6 @@ export class TorrentFilesModalController {
   rootScope: IRootScopeService;
   modalref: ModalController;
   $timeout: ng.ITimeoutService;
-  private unsubscribeOpen?: () => void;
 
   constructor(
     scope: TorrentFilesModalScope,
@@ -32,17 +31,7 @@ export class TorrentFilesModalController {
     this.scope.loading = false;
     this.scope.error = null;
     this.scope.onClose = () => this.close();
-
-    const off = this.rootScope.$on("torrentFiles:open", (_event, torrent) => {
-      this.open(torrent);
-    });
-    this.unsubscribeOpen = () => off();
-
-    this.scope.$on("$destroy", () => {
-      if (this.unsubscribeOpen) {
-        this.unsubscribeOpen();
-      }
-    });
+    this.scope.modalRef = this;
   }
 
   open(torrent: any) {

--- a/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.directive.ts
+++ b/src/renderer/app/directives/torrent-files-modal/torrent-files-modal.directive.ts
@@ -3,6 +3,7 @@ import { TorrentFilesModalController } from "./torrent-files-modal.controller";
 import html from "./torrent-files-modal.template.html";
 
 export interface TorrentFilesModalScope extends angular.IScope {
+  modalRef?: TorrentFilesModalController;
   onSaved?: () => Promise<void> | void;
 }
 
@@ -10,6 +11,7 @@ export class TorrentFilesModalDirective implements IDirective {
   template = html;
   restrict = "E";
   scope = {
+    modalRef: "=?",
     onSaved: "<",
   };
   controller = TorrentFilesModalController;

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -16,6 +16,9 @@ interface TorrentControllerScope extends angular.IScope {
     };
     speedLimitModalRef?: { open(torrents: any[]): void };
     setRatioModalRef?: { open(torrents: any[]): void };
+    torrentFilesModalRef?: { open(torrent: any): void };
+    setLocationModalRef?: { open(torrents: any[]): void };
+    setLabelModalRef?: { open(torrents: any[]): void };
     [key: string]: any;
 }
 
@@ -275,14 +278,6 @@ export class TorrentsPageController {
             if (bound && "click" in bound) {
                 $scope.doContextAction(bound.click, bound.label, bound);
             }
-        });
-
-        $scope.$on("torrentLocation:updated", () => {
-            syncAfterTorrentMutation();
-        });
-
-        $scope.$on("torrentLabel:updated", () => {
-            syncAfterTorrentMutation();
         });
 
         $scope.$on("$destroy", () => {
@@ -749,19 +744,19 @@ export class TorrentsPageController {
             }
             if (item?.role === "files") {
                 if (selected.length >= 1) {
-                    $rootScope.$emit("torrentFiles:open", selected[0]);
+                    $scope.torrentFilesModalRef?.open(selected[0]);
                 }
                 return $q.resolve();
             }
             if (item?.role === "set-location") {
                 if (selected.length >= 1) {
-                    $rootScope.$emit("torrentLocation:open", selected.slice());
+                    $scope.setLocationModalRef?.open(selected.slice());
                 }
                 return $q.resolve();
             }
             if (item?.role === "set-label") {
                 if (selected.length >= 1) {
-                    $rootScope.$emit("torrentLabel:open", selected.slice());
+                    $scope.setLabelModalRef?.open(selected.slice());
                 }
                 return $q.resolve();
             }

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -152,7 +152,11 @@
     <context-menu id="contextmenu" bind="contextMenu" menu="$btclient.contextMenu" click="doContextAction" debug="debug">
     </context-menu>
 
-    <set-label-modal labels="labels"></set-label-modal>
+    <set-label-modal
+        labels="labels"
+        modal-ref="setLabelModalRef"
+        on-saved="syncAfterTorrentMutation">
+    </set-label-modal>
 
     <modal
         id="deleteTorrentModal"
@@ -189,6 +193,12 @@
         upload-torrent-url-action="uploadTorrentURL">
     </add-torrent-modal>
 
-    <torrent-files-modal on-saved="syncAfterTorrentMutation"></torrent-files-modal>
-    <set-location-modal></set-location-modal>
+    <torrent-files-modal
+        modal-ref="torrentFilesModalRef"
+        on-saved="syncAfterTorrentMutation">
+    </torrent-files-modal>
+    <set-location-modal
+        modal-ref="setLocationModalRef"
+        on-saved="syncAfterTorrentMutation">
+    </set-location-modal>
 </div>


### PR DESCRIPTION
## Summary

Refactor UI modal interactions to use controller refs and bound callbacks instead of AngularJS event signals.

- Open Files, Set Location, Set Label, and Rename Server modals through refs
- Bind save callbacks for location and label updates
- Remove the corresponding `$emit`/`$on` paths

## Validation

- `npm run lint`
- `npm run build`
- Targeted settings, label, files, and set-location tests
- `git diff --check`