### PR TITLE
fix: close modals with Escape

### DIFF
--- a/src/renderer/app/directives/modal/modal.directive.ts
+++ b/src/renderer/app/directives/modal/modal.directive.ts
@@ -39,6 +39,17 @@ export class ModalDirective implements IDirective {
 
         controller.attachModal(modal)
 
+        const onKeyDown = (event: JQuery.KeyDownEvent) => {
+            if (event.key !== "Escape" || !modal.modal("is active")) {
+                return
+            }
+
+            event.preventDefault()
+            modal.modal("hide")
+        }
+
+        $(document).on("keydown", onKeyDown)
+
         modal.modal({
             onDeny: () => {
                 accepted = false
@@ -66,6 +77,7 @@ export class ModalDirective implements IDirective {
                 modal.modal('refresh')
             },
             closable: this.isTruthy(scope, attr.closable),
+            keyboardShortcuts: false,
             duration: 150
         });
 
@@ -76,6 +88,7 @@ export class ModalDirective implements IDirective {
         }.bind(this)
 
         scope.$on("$destroy", function() {
+            $(document).off("keydown", onKeyDown)
             element.remove();
         });
     }

--- a/src/renderer/app/directives/set-label-modal/set-label-modal.controller.ts
+++ b/src/renderer/app/directives/set-label-modal/set-label-modal.controller.ts
@@ -36,6 +36,15 @@ export class SetLabelModalController {
     this.reset();
   }
 
+  submitOnEnter(event: KeyboardEvent) {
+    if (event.key !== "Enter") {
+      return;
+    }
+
+    event.preventDefault();
+    void this.apply();
+  }
+
   async apply() {
     if (!this.scope.label || !this.scope.torrents.length) {
       return;

--- a/src/renderer/app/directives/set-label-modal/set-label-modal.template.html
+++ b/src/renderer/app/directives/set-label-modal/set-label-modal.template.html
@@ -1,7 +1,6 @@
 <modal
     id="setLabelModal"
     size="tiny"
-    approve="ctl.apply()"
     on-hidden="ctl.onHidden()"
     ng-ref="ctl.modalref">
     <div class="header">
@@ -9,7 +8,7 @@
         Set Label
     </div>
     <div class="content">
-        <div class="ui form">
+        <form id="set-label-form" class="ui form" ng-submit="ctl.apply()" ng-keydown="ctl.submitOnEnter($event)">
             <div class="field">
                 <label for="set-label-dropdown">Label</label>
                 <dropdown
@@ -25,11 +24,15 @@
                     </dropdown-group>
                 </dropdown>
             </div>
-        </div>
+        </form>
     </div>
     <div class="actions">
         <button type="button" class="ui black deny button">Cancel</button>
-        <button type="button" class="ui green right labeled icon approve button" ng-disabled="!ctl.scope.label">
+        <button
+            type="submit"
+            form="set-label-form"
+            class="ui green right labeled icon button"
+            ng-disabled="!ctl.scope.label">
             Apply Label
             <i class="tag icon"></i>
         </button>

--- a/test/specs/mock/actions-menu.spec.ts
+++ b/test/specs/mock/actions-menu.spec.ts
@@ -1,6 +1,7 @@
 import chai from "chai"
 import { $, browser } from "@wdio/globals"
 import { eventually } from "../../e2e/eventually"
+import { waitForModalClose, waitForModalOpen } from "../../e2e/modal"
 import { configureSpec } from "../../framework/fixture"
 
 const assert: Chai.AssertStatic = chai.assert
@@ -91,7 +92,36 @@ describe("mock Actions menu", function () {
     const flyoutX = await queueFlyout.getLocation("x")
     assert.isAtLeast(flyoutX, triggerX + triggerWidth - 2)
   })
+
+  it("closes modals with Escape and submits the Set Label form with Enter", async function () {
+    const modal = await openSetLabelModal()
+
+    await browser.keys("Escape")
+    await waitForModalClose(modal)
+
+    await openSetLabelModal()
+    await browser.keys("Enter")
+    await waitForModalClose(modal)
+
+    const label = await $("#torrentTable tbody tr[data-id] td[data-col='label']").getText()
+    assert.equal(label.trim(), "mock-label-1")
+  })
 })
+
+async function openSetLabelModal() {
+  const row = $("#torrentTable tbody tr[data-id]")
+  await row.waitForClickable()
+  await row.click({ button: "right" })
+
+  const action = $("#contextmenu a[data-role='set-label']")
+  await action.waitForDisplayed()
+  await action.waitForClickable()
+  await action.click()
+
+  const modal = $("#setLabelModal")
+  await waitForModalOpen(modal)
+  return modal
+}
 
 async function getActionsMenu() {
   return browser.electron.execute((electron) => {


### PR DESCRIPTION
## Summary
- close active modals from the shared modal directive when Escape is pressed
- submit Set Label with Enter
- cover both interactions in the mock actions-menu spec

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "mock/actions-menu.spec.ts"