### PR TITLE
feat(actions): add start and pause torrent controls

### DIFF
--- a/src/main/lib/bittorrent/clients/aria2/index.ts
+++ b/src/main/lib/bittorrent/clients/aria2/index.ts
@@ -229,8 +229,8 @@ export class Aria2Runtime implements BittorrentRuntime {
         { role: "files", label: "Files", icon: "file" },
         { role: "set-speed-limits", label: "Set Speed Limits", icon: "dashboard" },
         { role: "set-ratio", label: "Set Ratio", icon: "percent" },
-        { label: "Start", action: "resume", icon: "play" },
-        { label: "Pause", action: "pause", icon: "pause" },
+        { role: "start", label: "Start", action: "resume", icon: "play" },
+        { role: "stop", label: "Pause", action: "pause", icon: "pause" },
         { role: "delete", label: "Remove", action: "remove", icon: "remove" },
     ]
 

--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -62,6 +62,8 @@ const DELUGE_TORRENT_FILES_FIELDS = ["files", "file_progress", "file_priorities"
 
 export class DelugeRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
+        { role: "start", label: "Start", action: "resume", icon: "play" },
+        { role: "stop", label: "Pause", action: "pause", icon: "pause" },
         { role: "details", label: "Details", icon: "info circle" },
         { role: "verify", label: "Verify", action: "verify", icon: "checkmark" },
         { label: "Move Queue Up", action: "queueUp", icon: "arrow up" },

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -64,6 +64,8 @@ type MockTorrentInput = Partial<MockTorrent> & {
 
 export class MockBittorrentRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
+        { role: "start", label: "Start", action: "resume", icon: "play" },
+        { role: "stop", label: "Pause", action: "pause", icon: "pause" },
         { role: "details", label: "Details", icon: "info circle" },
         { role: "files", label: "Files", icon: "file" },
         { role: "verify", label: "Recheck", action: "recheck", icon: "checkmark" },

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -118,6 +118,8 @@ function normalizeTorrentTrackers(body: unknown): BittorrentTorrentDetailsTracke
 
 export class QBittorrentRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
+        { role: "start", label: "Start", action: "resume", icon: "play" },
+        { role: "stop", label: "Pause", action: "pause", icon: "pause" },
         { role: "details", label: "Details", icon: "info circle" },
         { role: "files", label: "Files", icon: "file" },
         { role: "verify", label: "Recheck", action: "recheck", icon: "checkmark" },

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -23,6 +23,8 @@ type RtorrentMulticallCommand = string | [string, ...any[]]
 
 export class RtorrentRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
+        { role: "start", label: "Start", action: "start", icon: "play" },
+        { role: "stop", label: "Pause", action: "stop", icon: "pause" },
         { role: "details", label: "Details", icon: "info circle" },
         { role: "verify", label: "Recheck", action: "recheck", icon: "checkmark" },
         { label: "Priority", menu: [

--- a/src/main/lib/bittorrent/clients/synology.ts
+++ b/src/main/lib/bittorrent/clients/synology.ts
@@ -50,6 +50,8 @@ const ERR_TASK: Record<number, string> = {
 
 export class SynologyRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
+        { role: "start", label: "Start", action: "start", icon: "play" },
+        { role: "stop", label: "Pause", action: "pause", icon: "pause" },
         { role: "set-location", label: "Set Location", icon: "folder open" },
         { role: "remove", label: "Remove Torrent", action: "remove", icon: "remove" },
     ]

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -101,8 +101,8 @@ const TRANSMISSION_TORRENT_FILES_FIELDS = ['files', 'fileStats', 'priorities', '
 export class TransmissionRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
         { role: "details", label: "Details", icon: "info circle" },
-        { label: "Start", action: "start", icon: "play" },
-        { label: "Pause", action: "stop", icon: "pause" },
+        { role: "start", label: "Start", action: "start", icon: "play" },
+        { role: "stop", label: "Pause", action: "stop", icon: "pause" },
         { role: "verify", label: "Verify", action: "verify", icon: "checkmark" },
         { label: "Move Up Queue", action: "queueUp", icon: "arrow up" },
         { label: "Move Queue Down", action: "queueDown", icon: "arrow down" },

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -16,6 +16,8 @@ import type { TorrentActionItem } from '@shared/torrent-actions'
 
 export class UtorrentRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
+        { role: "start", label: "Start", action: "start", icon: "play" },
+        { role: "stop", label: "Pause", action: "pause", icon: "pause" },
         { role: "verify", label: "Recheck", action: "recheck", icon: "checkmark" },
         { label: "Force Start", action: "forcestart", icon: "flag" },
         { label: "Move Up Queue", action: "queueup", icon: "arrow up" },

--- a/src/shared/torrent-actions.ts
+++ b/src/shared/torrent-actions.ts
@@ -1,4 +1,6 @@
 export type TorrentActionRole =
+    | "start"
+    | "stop"
     | "details"
     | "files"
     | "verify"
@@ -20,6 +22,8 @@ export interface TorrentActionItem {
 }
 
 const COMMON_ACCELERATORS: Partial<Record<TorrentActionRole, string>> = {
+    start: "CmdOrCtrl+Alt+S",
+    stop: "CmdOrCtrl+Alt+P",
     details: "CmdOrCtrl+D",
     files: "CmdOrCtrl+Shift+D",
     verify: "CmdOrCtrl+Shift+R",

--- a/test/specs/mock/actions-menu.spec.ts
+++ b/test/specs/mock/actions-menu.spec.ts
@@ -21,6 +21,8 @@ describe("mock Actions menu", function () {
   it("contains the mock client's context actions and follows torrent selection", async function () {
     const initial = await getActionsMenu()
     assert.includeMembers(initial.labels, [
+      "Start",
+      "Pause",
       "Details",
       "Files",
       "Recheck",
@@ -50,6 +52,21 @@ describe("mock Actions menu", function () {
     const detailsShortcut = $("//button[contains(@class, 'title-bar-menu-item')][.//span[normalize-space(.)='Details']]//span[contains(@class, 'title-bar-menu-accelerator')]")
     await detailsShortcut.waitForDisplayed()
     assert.notInclude(await detailsShortcut.getText(), "CmdOrCtrl")
+  })
+
+  it("exposes common start and pause shortcuts in the title menu", async function () {
+    await browser.keys("Escape")
+
+    const actionsMenu = $("//button[contains(@class, 'title-bar-menu-trigger') and normalize-space(.)='Actions']")
+    await actionsMenu.waitForClickable()
+    await actionsMenu.click()
+
+    const startShortcut = $("//button[contains(@class, 'title-bar-menu-item')][.//span[normalize-space(.)='Start']]//span[contains(@class, 'title-bar-menu-accelerator')]")
+    const pauseShortcut = $("//button[contains(@class, 'title-bar-menu-item')][.//span[normalize-space(.)='Pause']]//span[contains(@class, 'title-bar-menu-accelerator')]")
+    await startShortcut.waitForDisplayed()
+    await pauseShortcut.waitForDisplayed()
+    assert.include(await startShortcut.getText(), "S")
+    assert.include(await pauseShortcut.getText(), "P")
   })
 
   it("exposes the label action and shortcut in the title menu", async function () {


### PR DESCRIPTION
## Summary
- add semantic start and stop/pause torrent actions for every supported client
- expose the actions in context and title action menus
- assign shared CmdOrCtrl+Alt+S and CmdOrCtrl+Alt+P shortcuts

## Validation
- npm run lint
- npm run build
- npm run test -- --client mock --spec actions-menu.spec.ts