### PR TITLE
fix: align trackers tab scrolling

### DIFF
--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
@@ -109,7 +109,7 @@
           </td>
         </tr>
         <tr ng-if="!ctl.scope.sortedFiles.length">
-          <td colspan="{{ ctl.scope.files.columns.length || 1 }}">No files available.</td>
+          <td class="torrent-details-empty-state" colspan="{{ ctl.scope.files.columns.length || 1 }}">No files available.</td>
         </tr>
       </tbody>
     </table>

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.less
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.less
@@ -74,5 +74,7 @@ torrent-details-panel {
         p { margin: 0; font-size: 1rem; }
     }
 
+    .torrent-details-empty-state { color: @mutedTextColor; }
+
     .torrent-details-message { color: inherit; }
 }

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
@@ -44,7 +44,7 @@
           <td data-col="flags">{{ peer.flags || '' }}</td>
         </tr>
         <tr ng-if="!ctl.scope.sortedPeers.length">
-          <td colspan="11">No peers connected.</td>
+          <td class="torrent-details-empty-state" colspan="11">No peers connected.</td>
         </tr>
       </tbody>
     </table>

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.less
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.less
@@ -1,9 +1,19 @@
 torrent-details-trackers-tab {
-    .torrent-details-trackers {
+    .torrent-details-trackers,
+    .torrent-details-trackers-content {
         flex: 1 1 auto;
         height: 100%;
         min-width: 0;
         min-height: 0;
+    }
+
+    .torrent-details-trackers {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    .torrent-details-trackers-content {
         overflow: auto;
 
         > .ui.table {

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
@@ -40,7 +40,7 @@
         <td title="{{ tracker.message }}">{{ tracker.message }}</td>
       </tr>
       <tr ng-if="!ctl.scope.sortedTrackers.length">
-        <td colspan="10">No trackers available.</td>
+        <td class="torrent-details-empty-state" colspan="10">No trackers available.</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- keep the trackers table scrollbar at the bottom of the details pane
- mute empty-state messages in Files, Peers, and Trackers

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts"