### PR TITLE
fix(qbittorrent): support legacy v1 API

### DIFF
--- a/src/main/lib/bittorrent/clients/aria2/index.ts
+++ b/src/main/lib/bittorrent/clients/aria2/index.ts
@@ -251,6 +251,7 @@ export class Aria2Runtime implements BittorrentRuntime {
                 uploadFileSelection: true,
                 torrentDetails: true,
                 torrentPeers: true,
+                torrentTrackers: true,
                 trackerFilter: true,
                 speedLimits: true,
                 ratioLimits: true,

--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -273,6 +273,7 @@ export class DelugeRuntime implements BittorrentRuntime {
                 uploadFileSelection: true,
                 torrentDetails: true,
                 torrentPeers: true,
+                torrentTrackers: true,
                 speedLimits: true,
                 ratioLimits: true,
                 freeDiskSpace: true,

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -114,6 +114,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
                 setLocation: true,
                 torrentDetails: true,
                 torrentPeers: true,
+                torrentTrackers: true,
                 ratioLimits: true,
                 freeDiskSpace: true,
                 uploadOptions: {

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v1.ts
@@ -2,6 +2,13 @@ import { urlPath } from "@main/lib/bittorrent/helpers"
 import { AUTH_ERRORS, QBittorrentBaseApi, TORRENT_ERRORS } from "./base-api"
 
 export class QBittorrentApiV1 extends QBittorrentBaseApi {
+    readonly supportsAlternativeSpeedLimits = false
+    readonly supportsRatioLimits = false
+    readonly supportsTrackerFilter = false
+    readonly supportsTorrentPeers = false
+    readonly supportsTorrentTrackers = false
+    readonly supportsUploadFileSelection = false
+
     protected buildPath(name: string) {
         return urlPath(this.basePath, name)
     }
@@ -47,6 +54,32 @@ export class QBittorrentApiV1 extends QBittorrentBaseApi {
         this.getJson(`query/propertiesPeers/${hash}`, {}, (err, res, body) => {
             this.handleError(cb, TORRENT_ERRORS)(err, res, body)
         })
+    }
+
+    getTorrentProperties(hash: string, cb: (err?: any, body?: any) => void) {
+        this.getJson(`query/propertiesGeneral/${hash}`, {}, (err, res, body) => {
+            this.handleError(cb, TORRENT_ERRORS)(err, res, body)
+        })
+    }
+
+    getTorrentFiles(hash: string, cb: (err?: any, body?: any) => void) {
+        this.getJson(`query/propertiesFiles/${hash}`, {}, (err, res, body) => {
+            this.handleError(cb, TORRENT_ERRORS)(err, res, body)
+        })
+    }
+
+    setTorrentFilePriority(hash: string, ids: number[], priority: number, cb: (err?: any, body?: any) => void) {
+        Promise.all(ids.map((id) => new Promise<void>((resolve, reject) => {
+            this.post("command/setFilePrio", {
+                form: {
+                    hash,
+                    id: String(id),
+                    priority: String(priority),
+                },
+            }, (err, res, body) => {
+                this.handleError((actionErr) => actionErr ? reject(actionErr) : resolve(), TORRENT_ERRORS)(err, res, body)
+            })
+        }))).then(() => cb()).catch((err) => cb(err))
     }
 
     addTorrentFileContent(content: Buffer | Uint8Array, filename: string, options: Record<string, any> | undefined, cb: (err?: any, body?: any) => void) {
@@ -152,11 +185,11 @@ export class QBittorrentApiV1 extends QBittorrentBaseApi {
     }
 
     setDownloadLimit(hashes: string[], limit: number, cb: (err?: any, body?: any) => void) {
-        this.performPostAction("setDownloadLimit", hashes, { limit }, cb)
+        this.performPostAction("setTorrentsDlLimit", hashes, { limit }, cb)
     }
 
     setUploadLimit(hashes: string[], limit: number, cb: (err?: any, body?: any) => void) {
-        this.performPostAction("setUploadLimit", hashes, { limit }, cb)
+        this.performPostAction("setTorrentsUpLimit", hashes, { limit }, cb)
     }
 
     createCategory(category: string, _savePath: string, cb: (err?: any, body?: any) => void) {

--- a/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/api-v2.ts
@@ -2,6 +2,13 @@ import { urlPath } from "@main/lib/bittorrent/helpers"
 import { AUTH_ERRORS, QBittorrentBaseApi, TORRENT_ERRORS } from "./base-api"
 
 export class QBittorrentApiV2 extends QBittorrentBaseApi {
+    readonly supportsAlternativeSpeedLimits = true
+    readonly supportsRatioLimits = true
+    readonly supportsTrackerFilter = true
+    readonly supportsTorrentPeers = true
+    readonly supportsTorrentTrackers = true
+    readonly supportsUploadFileSelection = true
+
     private useStartStopEndpoints = false
 
     protected buildPath(name: string) {
@@ -56,6 +63,28 @@ export class QBittorrentApiV2 extends QBittorrentBaseApi {
         this.getJson("sync/torrentPeers", { qs: { hash } }, (err, res, body) => {
             this.handleError(cb, TORRENT_ERRORS)(err, res, body)
         })
+    }
+
+    getTorrentProperties(hash: string, cb: (err?: any, body?: any) => void) {
+        this.getJson("torrents/properties", { qs: { hash } }, (err, res, body) => {
+            this.handleError(cb, TORRENT_ERRORS)(err, res, body)
+        })
+    }
+
+    getTorrentFiles(hash: string, cb: (err?: any, body?: any) => void) {
+        this.getJson("torrents/files", { qs: { hash } }, (err, res, body) => {
+            this.handleError(cb, TORRENT_ERRORS)(err, res, body)
+        })
+    }
+
+    setTorrentFilePriority(hash: string, ids: number[], priority: number, cb: (err?: any, body?: any) => void) {
+        this.post("torrents/filePrio", {
+            form: {
+                hash,
+                id: ids.join("|"),
+                priority: String(priority),
+            },
+        }, (err, res, body) => this.handleError(cb, TORRENT_ERRORS)(err, res, body))
     }
 
     addTorrentFileContent(content: Buffer | Uint8Array, filename: string, options: Record<string, any> | undefined, cb: (err?: any, body?: any) => void) {

--- a/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
@@ -24,6 +24,13 @@ export type QBittorrentApiOptions = {
 }
 
 export abstract class QBittorrentBaseApi {
+    abstract readonly supportsAlternativeSpeedLimits: boolean
+    abstract readonly supportsRatioLimits: boolean
+    abstract readonly supportsTrackerFilter: boolean
+    abstract readonly supportsTorrentPeers: boolean
+    abstract readonly supportsTorrentTrackers: boolean
+    abstract readonly supportsUploadFileSelection: boolean
+
     protected readonly basePath: string
 
     protected readonly user: string
@@ -144,6 +151,9 @@ export abstract class QBittorrentBaseApi {
 
     abstract getTorrentTrackers(hash: string, cb: (err?: any, body?: any) => void): void
     abstract getTorrentPeers(hash: string, cb: (err?: any, body?: any) => void): void
+    abstract getTorrentProperties(hash: string, cb: (err?: any, body?: any) => void): void
+    abstract getTorrentFiles(hash: string, cb: (err?: any, body?: any) => void): void
+    abstract setTorrentFilePriority(hash: string, ids: number[], priority: number, cb: (err?: any, body?: any) => void): void
 
     abstract addTorrentFileContent(content: Buffer | Uint8Array, filename: string, options: Record<string, any> | undefined, cb: (err?: any, body?: any) => void): void
 

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -208,14 +208,15 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 magnetLinks: true,
                 labels: true,
                 fileSelection: true,
-                uploadFileSelection: true,
+                uploadFileSelection: api.supportsUploadFileSelection,
                 setLocation: true,
                 torrentDetails: true,
-                torrentPeers: true,
-                trackerFilter: true,
-                alternativeSpeedLimits: true,
+                torrentPeers: api.supportsTorrentPeers,
+                torrentTrackers: api.supportsTorrentTrackers,
+                trackerFilter: api.supportsTrackerFilter,
+                alternativeSpeedLimits: api.supportsAlternativeSpeedLimits,
                 speedLimits: true,
-                ratioLimits: true,
+                ratioLimits: api.supportsRatioLimits,
                 freeDiskSpace: true,
                 uploadOptions: {
                     saveLocation: true,
@@ -253,7 +254,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         this.mergeTorrentCache(data)
         this.prepareTrackerData(data, changedTrackerHashes)
 
-        if (data?.server_state && data.server_state.use_alt_speed_limits === undefined) {
+        if (api.supportsAlternativeSpeedLimits && data?.server_state && data.server_state.use_alt_speed_limits === undefined) {
             data.server_state.use_alt_speed_limits = await defer<boolean>((done) => api.getSpeedLimitsMode(done))
         }
 
@@ -585,7 +586,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
     async getTorrentDetails(hash: string): Promise<BittorrentTorrentDetailsData> {
         const api = this.getApi()
         const properties = await new Promise<Record<string, any>>((resolve, reject) => {
-            api.getJson("torrents/properties", { qs: { hash } }, (err: any, _res: any, body: any) => {
+            api.getTorrentProperties(hash, (err: any, body: any) => {
                 if (err) {
                     reject(err)
                     return
@@ -641,7 +642,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
     private fetchTorrentFiles(hash: string): Promise<unknown> {
         const api = this.getApi()
         return new Promise((resolve, reject) => {
-            api.getJson("torrents/files", { qs: { hash } }, (err: unknown, _res: unknown, body: unknown) => {
+            api.getTorrentFiles(hash, (err: unknown, body: unknown) => {
                 if (err) {
                     reject(err)
                     return
@@ -694,13 +695,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 return
             }
 
-            api.post("torrents/filePrio", {
-                form: {
-                    hash,
-                    id: ids.join("|"),
-                    priority: String(priority),
-                },
-            }, (err: any) => {
+            api.setTorrentFilePriority(hash, ids, priority, (err: any) => {
                 if (err) {
                     reject(err)
                     return

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -235,6 +235,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
                 uploadFileSelection: true,
                 torrentDetails: true,
                 torrentPeers: true,
+                torrentTrackers: true,
                 trackerFilter: true,
                 speedLimits: true,
                 uploadOptions: {

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -228,6 +228,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
                 setLocation: true,
                 torrentDetails: true,
                 torrentPeers: true,
+                torrentTrackers: true,
                 trackerFilter: true,
                 speedLimits: true,
                 ratioLimits: true,

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -62,6 +62,7 @@ const DEFAULT_FEATURES: ResolvedTorrentClientFeatures = Object.freeze({
     setLocation: false,
     torrentDetails: false,
     torrentPeers: false,
+    torrentTrackers: false,
     trackerFilter: false,
     alternativeSpeedLimits: false,
     speedLimits: false,
@@ -386,8 +387,8 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
     }
 
     async getTorrentDetailsTrackers(torrent: T): Promise<TorrentDetailsTrackersData> {
-        if (!this.features.torrentDetails) {
-            throw new Error("Torrent details not supported for this client")
+        if (!this.features.torrentTrackers) {
+            throw new Error("Torrent trackers not supported for this client")
         }
 
         return {

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -94,6 +94,10 @@ export class TorrentDetailsPanelController {
     return !!this.rootScope.$btclient?.features.torrentPeers;
   }
 
+  canShowTrackers() {
+    return !!this.rootScope.$btclient?.features.torrentTrackers;
+  }
+
   startResizing(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -32,6 +32,7 @@
     <a
       class="item"
       data-role="torrent-details-tab-trackers"
+      ng-if="ctl.canShowTrackers()"
       ng-class="{ active: ctl.isActiveTab('trackers') }"
       ng-click="ctl.showTab('trackers')"
     >
@@ -71,12 +72,12 @@
     ></torrent-details-files-tab>
 
     <torrent-details-peers-tab
-      ng-if="ctl.scope.torrent && ctl.isActiveTab('peers')"
+      ng-if="ctl.scope.torrent && ctl.canShowPeers() && ctl.isActiveTab('peers')"
       torrent="ctl.scope.torrent"
       refresh="ctl.scope.refresh"
     ></torrent-details-peers-tab>
     <torrent-details-trackers-tab
-      ng-if="ctl.scope.torrent && ctl.isActiveTab('trackers')"
+      ng-if="ctl.scope.torrent && ctl.canShowTrackers() && ctl.isActiveTab('trackers')"
       torrent="ctl.scope.torrent"
       refresh="ctl.scope.refresh"
     ></torrent-details-trackers-tab>

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -237,6 +237,7 @@ export interface TorrentClientFeatures {
     readonly setLocation?: boolean
     readonly torrentDetails?: boolean
     readonly torrentPeers?: boolean
+    readonly torrentTrackers?: boolean
     readonly trackerFilter?: boolean
     readonly alternativeSpeedLimits?: boolean
     readonly speedLimits?: boolean
@@ -279,6 +280,7 @@ export interface ResolvedTorrentClientFeatures {
     readonly setLocation: boolean
     readonly torrentDetails: boolean
     readonly torrentPeers: boolean
+    readonly torrentTrackers: boolean
     readonly trackerFilter: boolean
     readonly alternativeSpeedLimits: boolean
     readonly speedLimits: boolean

--- a/test/clients/aria2/index.ts
+++ b/test/clients/aria2/index.ts
@@ -10,6 +10,7 @@ const features = {
   setLocation: false,
   torrentDetails: true,
   torrentPeers: true,
+  torrentTrackers: true,
   trackerFilter: true,
   alternativeSpeedLimits: false,
   speedLimits: true,

--- a/test/clients/deluge/index.ts
+++ b/test/clients/deluge/index.ts
@@ -7,6 +7,7 @@ const baseFeatures = {
   uploadFileSelection: true,
   torrentDetails: true,
   torrentPeers: true,
+  torrentTrackers: true,
   speedLimits: true,
   ratioLimits: true,
   freeDiskSpace: true,

--- a/test/clients/mock/index.ts
+++ b/test/clients/mock/index.ts
@@ -9,6 +9,7 @@ const features = {
   setLocation: true,
   torrentDetails: true,
   torrentPeers: true,
+  torrentTrackers: true,
   freeDiskSpace: true,
   uploadOptions: {
     saveLocation: true,

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -10,6 +10,7 @@ const features = {
   setLocation: true,
   torrentDetails: true,
   torrentPeers: true,
+  torrentTrackers: true,
   trackerFilter: true,
   alternativeSpeedLimits: true,
   speedLimits: true,
@@ -28,7 +29,29 @@ const features = {
   },
 } satisfies TorrentClientFeatures
 
+const legacyFeatures = {
+  ...features,
+  alternativeSpeedLimits: false,
+  ratioLimits: false,
+  trackerFilter: false,
+  torrentPeers: false,
+  torrentTrackers: false,
+  uploadFileSelection: false,
+} satisfies TorrentClientFeatures
+
 export default {
+  "qbittorrent:4.1": defineClient({
+    key: "qbittorrent:4.1",
+    clientId: "qbittorrent",
+    features: legacyFeatures,
+    fixture: "clients/qbittorrent",
+    version: "amd64-4.1.5.99201812282032-6681-264b689ubuntu18.04.1-ls1",
+    port: 48080,
+    containerPort: 8080,
+    username: "admin",
+    password: "adminadmin",
+    downloadRoot: "/downloads",
+  }),
   "qbittorrent:4": defineClient({
     key: "qbittorrent:4",
     clientId: "qbittorrent",

--- a/test/clients/rtorrent/index.ts
+++ b/test/clients/rtorrent/index.ts
@@ -8,6 +8,7 @@ const features = {
   uploadFileSelection: true,
   torrentDetails: true,
   torrentPeers: true,
+  torrentTrackers: true,
   trackerFilter: true,
   speedLimits: true,
   uploadOptions: {

--- a/test/clients/transmission/index.ts
+++ b/test/clients/transmission/index.ts
@@ -9,6 +9,7 @@ const features = {
   setLocation: true,
   torrentDetails: true,
   torrentPeers: true,
+  torrentTrackers: true,
   trackerFilter: true,
   speedLimits: true,
   ratioLimits: true,

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -78,6 +78,22 @@ describe("torrent details", function () {
     }
   })
 
+  it("hides unsupported peer and tracker tabs", async function () {
+    if (getTestFixture().client.features.torrentPeers === true || getTestFixture().client.features.torrentTrackers === true) {
+      return this.skip()
+    }
+
+    const panel = await torrent.openDetailsPanel()
+    try {
+      const peersTabExists = await panel.$("[data-role='torrent-details-tab-peers']").isExisting()
+      const trackersTabExists = await panel.$("[data-role='torrent-details-tab-trackers']").isExisting()
+      peersTabExists.should.equal(false)
+      trackersTabExists.should.equal(false)
+    } finally {
+      await torrent.closeDetailsPanel()
+    }
+  })
+
   it("shows expected torrent information in the info tab", async function () {
     this.timeout(60 * 1000)
 
@@ -144,6 +160,10 @@ describe("torrent details", function () {
 
   it("shows every torrent tracker in the trackers tab", async function () {
     this.timeout(60 * 1000)
+
+    if (getTestFixture().client.features.torrentTrackers !== true) {
+      return this.skip()
+    }
 
     const panel = await torrent.openDetailsPanel()
     await torrent.openDetailsTab("trackers")


### PR DESCRIPTION
## Summary

- Make qBittorrent Web API v1 feature-capability aware.
- Hide unsupported v1 controls: alternative speed limits, ratio limits, tracker filtering, peers, trackers, and upload-time file selection.
- Preserve v1 support where compatible routes exist: Info, Files, post-add file selection, and torrent speed limits.

## Root cause

qBittorrent 4.1 Web API v1 lacks or cannot reliably serve several v2-era endpoints. The application advertised them unconditionally, causing 404s.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:4.1"` (full suite)