### PR TITLE
refactor(action-header): use HTML template

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -160,6 +160,8 @@ import { ModalDirective } from "@renderer/app/directives/modal/modal.directive"
 torrentApp.directive("modal", ModalDirective.getInstance())
 import { ActionHeaderDirective } from "@renderer/app/directives/action-header/action-header.directive"
 torrentApp.directive("actionHeader", ActionHeaderDirective.getInstance())
+import { ActionHeaderDropdownDirective } from "@renderer/app/directives/action-header/action-header-dropdown.directive"
+torrentApp.directive("actionHeaderDropdown", ActionHeaderDropdownDirective.getInstance())
 import { LabelsDropdownDirective } from "@renderer/app/directives/labels-dropdown/labels-dropdown.directive"
 torrentApp.directive("labelsDropdown", LabelsDropdownDirective.getInstance())
 import { LabelsMenuDirective } from "@renderer/app/directives/labels-menu/labels-menu.directive"

--- a/src/renderer/app/directives/action-header/action-header-dropdown.directive.ts
+++ b/src/renderer/app/directives/action-header/action-header-dropdown.directive.ts
@@ -1,0 +1,83 @@
+import { IAugmentedJQuery, IDirective, IDirectiveFactory, IScope } from "angular";
+import html from "./action-header-dropdown.template.html";
+
+type ActionHandler = (...args: never[]) => unknown;
+
+interface ActionHeaderDropdownAction {
+    click?: ActionHandler;
+    label: string;
+}
+
+interface ActionHeaderDropdownScope extends IScope {
+    actions: ActionHeaderDropdownAction[];
+    alwaysActive?: boolean;
+    color?: string;
+    enabled?: boolean;
+    label: string;
+    onAction: (locals: { action: ActionHeaderDropdownAction["click"]; label: string }) => void;
+    open: boolean;
+    role?: string;
+    select: (action: ActionHeaderDropdownAction, event: JQuery.ClickEvent) => void;
+    toggle: (event: JQuery.ClickEvent) => void;
+}
+
+export class ActionHeaderDropdownDirective implements IDirective {
+    restrict = "E";
+    replace = true;
+    scope = {
+        actions: "=",
+        alwaysActive: "=?",
+        color: "@",
+        enabled: "=?",
+        label: "@",
+        onAction: "&",
+        role: "@",
+    };
+    template = html;
+
+    static getInstance(): IDirectiveFactory {
+        return () => new ActionHeaderDropdownDirective();
+    }
+
+    link(scope: ActionHeaderDropdownScope, element: IAugmentedJQuery) {
+        const close = () => {
+            scope.open = false;
+        };
+
+        scope.toggle = (event) => {
+            if (scope.enabled && !scope.alwaysActive) {
+                return;
+            }
+
+            event.preventDefault();
+            scope.open = !scope.open;
+        };
+
+        scope.select = (action, event) => {
+            event.stopPropagation();
+            close();
+            scope.onAction({ action: action.click, label: action.label });
+        };
+
+        const onBodyClick = (event: MouseEvent) => {
+            if (!element[0].contains(event.target as Node) && scope.open) {
+                scope.$applyAsync(close);
+            }
+        };
+
+        const onKeyUp = (event: KeyboardEvent) => {
+            if (event.key === "Escape" && scope.open) {
+                scope.$applyAsync(close);
+                (element[0] as HTMLElement).blur();
+            }
+        };
+
+        document.body.addEventListener("click", onBodyClick);
+        window.addEventListener("keyup", onKeyUp);
+
+        scope.$on("$destroy", () => {
+            document.body.removeEventListener("click", onBodyClick);
+            window.removeEventListener("keyup", onKeyUp);
+        });
+    }
+}

--- a/src/renderer/app/directives/action-header/action-header-dropdown.template.html
+++ b/src/renderer/app/directives/action-header/action-header-dropdown.template.html
@@ -1,0 +1,15 @@
+<div
+    class="ui top left pointing labeled icon dropdown button"
+    ng-class="[color, {disabled: enabled && !alwaysActive, active: open, visible: open}]"
+    data-role="{{role}}"
+    ng-click="toggle($event)"
+    tabindex="0"
+>
+    <i class="ui plus icon"></i>
+    <span class="text">{{label}}</span>
+    <div class="menu transition" ng-class="{hidden: !open, visible: open}">
+        <div class="item" ng-repeat="action in actions track by $index" ng-click="select(action, $event)">
+            {{action.label}}
+        </div>
+    </div>
+</div>

--- a/src/renderer/app/directives/action-header/action-header.directive.ts
+++ b/src/renderer/app/directives/action-header/action-header.directive.ts
@@ -1,17 +1,34 @@
-import { IAttributes, IAugmentedJQuery, ICompileService, IDirective, IDirectiveFactory, IRootScopeService, IScope } from "angular";
+import { IDirective, IDirectiveFactory, IScope } from "angular";
 import { ActionHeaderController } from "./action-header.controller";
+import html from "./action-header.template.html";
+
+type ActionHandler = (...args: never[]) => unknown;
+
+interface ActionHeaderItem {
+    actions?: ActionHeaderItem[];
+    alwaysActive?: boolean;
+    color?: string;
+    click?: ActionHandler;
+    icon?: string;
+    label: string;
+    labelAction?: (label: string, create?: boolean) => void;
+    role?: string;
+    type?: string;
+}
 
 interface ActionHeaderScope extends IScope {
-    actions: any[];
-    click: (...args: any[]) => void;
+    actions: ActionHeaderItem[];
+    actionItems: ActionHeaderItem[];
+    click: (action: ActionHandler | undefined, ...args: unknown[]) => void;
     labels: string[];
     bind?: Record<string, never>;
     enabled?: boolean;
-    addLabel?: (label: string, create?: boolean) => void;
+    invoke: (action: ActionHeaderItem["click"], label: string) => void;
 }
 
 export class ActionHeaderDirective implements IDirective {
     restrict = "A";
+    template = html;
     scope = {
         actions: "=",
         click: "=",
@@ -22,149 +39,22 @@ export class ActionHeaderDirective implements IDirective {
     controller = ActionHeaderController;
 
     static getInstance(): IDirectiveFactory {
-        const factory = ($rootScope: IRootScopeService, $compile: ICompileService) =>
-            new ActionHeaderDirective($rootScope, $compile);
-        factory.$inject = ["$rootScope", "$compile"];
-        return factory;
+        return () => new ActionHeaderDirective();
     }
 
-    constructor(
-        private $rootScope: IRootScopeService,
-        private $compile: ICompileService,
-    ) {}
-
-    link(scope: ActionHeaderScope, element: IAugmentedJQuery, attr: IAttributes) {
+    link(scope: ActionHeaderScope) {
         scope.bind = {};
-        (scope as ActionHeaderScope & { program?: any }).program = {
-            debug: false,
-        };
+        scope.invoke = (action, label) => scope.click(action, label);
 
-        let toggleAble: IAugmentedJQuery[] = [];
-
-        const toggleActive = (disable?: boolean) => {
-            toggleAble.forEach((item) => {
-                if (disable) {
-                    item.addClass("disabled");
-                } else {
-                    item.removeClass("disabled");
-                }
-            });
-        };
-
-        const addIcon = (item: IAugmentedJQuery, iconName: string) => {
-            const icon = angular.element("<i></i>");
-            icon.addClass(`ui ${iconName} icon`);
-            item.append(icon);
-        };
-
-        const appendButton = (list: IAugmentedJQuery, item: any) => {
-            const button = angular.element('<a class="ui labeled icon button"></a>');
-            button.addClass(item.color);
-
-            if (item.role) {
-                button.attr("data-role", item.role);
-            }
-
-            addIcon(button, item.icon);
-            button.append(item.label);
-            button.on("click", () => {
-                scope.click(item.click, item.label);
-            });
-
-            if (!item.alwaysActive) {
-                toggleAble.push(button);
-            }
-
-            list.append(button);
-        };
-
-        const appendLabelsDropdown = (list: IAugmentedJQuery, item: any) => {
-            const dropdown = angular.element(
-                '<span labels-dropdown labels="labels" action="addLabel" enabled="enabled"></span>',
-            );
-
-            dropdown.attr("data-role", "labels");
-
-            scope.addLabel = (label: string, create?: boolean) => {
-                scope.click(item.click, `${item.label} ${label}`, label, create);
-            };
-
-            this.$compile(dropdown)(scope);
-            list.append(dropdown);
-        };
-
-        const appendDropdown = (list: IAugmentedJQuery, item: any) => {
-            const dropdown = angular.element(
-                '<div dropdown class="ui top left pointing labeled icon dropdown button"></div>',
-            );
-            dropdown.addClass(item.color);
-            addIcon(dropdown, "plus");
-
-            if (item.role) {
-                dropdown.attr("data-role", item.role);
-            }
-
-            const text = angular.element('<span class="text"></span>');
-            text.append(item.label);
-            dropdown.append(text);
-
-            const menu = angular.element('<div class="menu"></div>');
-            item.actions.forEach((action: any) => {
-                const option = angular.element('<div class="item"></div>');
-                option.append(action.label);
-                option.on("click", () => {
-                    scope.click(action.click, action.label);
-                });
-                menu.append(option);
-            });
-
-            dropdown.append(menu);
-            this.$compile(dropdown)(scope);
-            list.append(dropdown);
-        };
-
-        const render = () => {
-            if (!scope.actions) {
-                return;
-            }
-
-            toggleAble = [];
-            element.empty();
-
-            scope.actions.forEach((item) => {
-                if (item.type === "button") {
-                    appendButton(element, item);
-                } else if (item.type === "labels") {
-                    appendLabelsDropdown(element, item);
-                } else if (item.type === "dropdown") {
-                    appendDropdown(element, item);
-                }
-            });
-
-            toggleActive(scope.enabled);
-        };
-
-        render();
-
-        window.electorrent.app.getMeta().then((meta) => {
-            (scope as ActionHeaderScope & { program?: any }).program = {
-                debug: !!meta.isDebug,
-            }
-            scope.$evalAsync()
+        scope.$watchCollection("actions", (actions: ActionHeaderItem[] = []) => {
+            scope.actionItems = actions.map((item) => ({
+                ...item,
+                labelAction: item.type === "labels"
+                    ? (label: string, create?: boolean) => {
+                        scope.click(item.click, `${item.label} ${label}`, label, create);
+                    }
+                    : undefined,
+            }));
         });
-
-        scope.$watch(() => scope.enabled, (disable) => {
-            toggleActive(disable);
-        });
-
-        scope.$watchCollection("actions", render);
-        scope.$watch(
-            () => this.$rootScope.$btclient,
-            (client) => {
-                if (client) {
-                    render();
-                }
-            },
-        );
     }
 }

--- a/src/renderer/app/directives/action-header/action-header.template.html
+++ b/src/renderer/app/directives/action-header/action-header.template.html
@@ -1,1 +1,31 @@
+<a
+    ng-repeat-start="item in actionItems track by $index"
+    ng-if="item.type === 'button'"
+    class="ui labeled icon button"
+    ng-class="[item.color, {disabled: enabled && !item.alwaysActive}]"
+    data-role="{{item.role}}"
+    ng-click="invoke(item.click, item.label)"
+>
+    <i class="ui icon" ng-class="item.icon"></i>
+    {{item.label}}
+</a>
 
+<span
+    ng-if="item.type === 'labels'"
+    labels-dropdown
+    labels="labels"
+    action="item.labelAction"
+    enabled="enabled"
+></span>
+
+<action-header-dropdown
+    ng-repeat-end
+    ng-if="item.type === 'dropdown'"
+    actions="item.actions"
+    always-active="item.alwaysActive"
+    color="{{item.color}}"
+    enabled="enabled"
+    label="{{item.label}}"
+    on-action="invoke(action, label)"
+    role="{{item.role}}"
+></action-header-dropdown>


### PR DESCRIPTION
## Summary
- render the action header layout from its HTML template
- replace dynamic DOM construction with Angular bindings
- preserve dropdown initialization and action behavior

## Validation
- npm run lint
- npm run build
- targeted action-header mock spec
- targeted bulk torrent-actions mock spec
- git diff --check