### PR TITLE
refactor(context-menu): use HTML templates

### DIFF
--- a/src/renderer/app/directives/context-menu/context-menu.directive.ts
+++ b/src/renderer/app/directives/context-menu/context-menu.directive.ts
@@ -14,12 +14,19 @@ interface ContextMenuItem {
 
 interface ContextMenuScope extends IScope {
     menu: ContextMenuItem[];
+    isDebug: boolean;
+    selectedItems: any[];
     bind: {
         show: (event: MouseEvent, items: any[]) => void;
         hide: () => void;
     };
     click: (...args: any[]) => void;
     debug?: () => void;
+    isItemVisible: (item: ContextMenuItem) => boolean;
+    isItemChecked: (item: ContextMenuItem) => boolean;
+    runMenuItem: (item: ContextMenuItem) => void;
+    runDebugItem: () => void;
+    toggleSubmenu: (event: Event, visible: boolean) => void;
 }
 
 export class ContextMenuDirective implements IDirective {
@@ -32,7 +39,6 @@ export class ContextMenuDirective implements IDirective {
     };
     controller = ContextMenuController;
     template = html;
-    private isDebug = false
 
     static getInstance(): IDirectiveFactory {
         const factory = (
@@ -54,166 +60,41 @@ export class ContextMenuDirective implements IDirective {
         element.addClass("torrent context menu");
         element.data("contextmenu", true);
 
-        const checkboxes: Array<{ checkbox: HTMLInputElement; predicate: (item: any) => boolean }> = [];
-
-        const cloneTemplate = (name: string) => {
-            const template = element[0].querySelector<HTMLTemplateElement>(`template[data-context-menu-template="${name}"]`);
-            const templateElement = template?.content.firstElementChild;
-
-            if (!templateElement) {
-                throw new Error(`Missing context menu template: ${name}`);
+        scope.isDebug = false;
+        scope.selectedItems = [];
+        scope.isItemVisible = (item) => {
+            if (item.menu) {
+                return true;
             }
 
-            return angular.element(templateElement.cloneNode(true)) as IAugmentedJQuery;
-        };
-
-        const setLabel = (item: IAugmentedJQuery, label: string) => {
-            const labelElement = item[0].querySelector<HTMLElement>("[data-context-menu-label]");
-            if (labelElement) {
-                labelElement.textContent = label;
+            const features = this.$rootScope.$btclient?.features;
+            switch (item.role) {
+                case "details":
+                    return !!features?.torrentDetails;
+                case "set-speed-limits":
+                    return !!features?.speedLimits;
+                case "set-ratio":
+                    return !!features?.ratioLimits;
+                default:
+                    return true;
             }
         };
-
-        const addIcon = (item: IAugmentedJQuery, iconName: string) => {
-            const icon = angular.element(item[0].querySelector("[data-context-menu-icon]"));
-            icon.addClass(`ui ${iconName} icon`);
+        scope.isItemChecked = (item) => {
+            return !!item.check && scope.selectedItems.every((entry) => item.check!(entry));
         };
-
-        const addCheckbox = (item: IAugmentedJQuery, predicate: (menuItem: any) => boolean) => {
-            const checkbox = item[0].querySelector<HTMLInputElement>("input[type=checkbox]");
-
-            if (!checkbox) {
-                throw new Error("Missing checkbox in context menu item template");
-            }
-
-            checkboxes.push({
-                checkbox,
-                predicate,
-            });
+        scope.runMenuItem = (item) => {
+            element.hide();
+            scope.click(item.click, item.label, item);
         };
-
-        const appendMenuItem = (list: IAugmentedJQuery, item: ContextMenuItem) => {
-            const menuItem = cloneTemplate("item");
-            const icon = menuItem[0].querySelector("[data-context-menu-icon]");
-            const checkbox = menuItem[0].querySelector("[data-context-menu-checkbox]");
-
-            if (item.role) {
-                menuItem.attr("data-role", item.role);
-            }
-
-            if (item.icon) {
-                addIcon(menuItem, item.icon);
-                checkbox?.remove();
-            } else if (item.check) {
-                icon?.remove();
-                addCheckbox(menuItem, item.check);
-            } else {
-                icon?.remove();
-                checkbox?.remove();
-            }
-
-            menuItem.on("click", () => {
-                element.hide();
-                scope.click(item.click, item.label, item);
-            });
-
-            setLabel(menuItem, item.label);
-            list.append(menuItem);
-        };
-
-        const appendSubmenu = (list: IAugmentedJQuery, submenu: ContextMenuItem) => {
-            const item = cloneTemplate("submenu");
-            const menu = angular.element(item[0].querySelector("[data-context-menu-items]"));
-
-            submenu.menu?.forEach((subItem) => {
-                appendMenuItem(menu, subItem);
-            });
-
-            addIcon(item, "dropdown");
-            setLabel(item, submenu.label);
-            list.append(item);
-        };
-
-        const appendDebugItem = (list: IAugmentedJQuery) => {
-            if (typeof scope.debug !== "function") {
-                return;
-            }
-
-            appendMenuItem(list, {
+        scope.runDebugItem = () => {
+            scope.runMenuItem({
                 label: "Debug",
                 icon: "help",
                 click: scope.debug,
             });
         };
-
-        const bindMenuActions = () => {
-            $(element)
-                .find(".context.dropdown")
-                .each(function () {
-                    $(this)
-                        .mouseenter(function () {
-                            $(this).find(".menu").show();
-                        })
-                        .mouseleave(function () {
-                            $(this).find(".menu").hide();
-                        });
-                });
-        };
-
-        const render = () => {
-            if (!scope.menu) {
-                return;
-            }
-
-            checkboxes.length = 0;
-
-            const existingList = element[0].querySelector("[data-context-menu-items]");
-            existingList?.remove();
-
-            const list = cloneTemplate("menu");
-            element.prepend(list);
-
-            if (this.isDebug) {
-                appendDebugItem(list);
-            }
-
-            scope.menu.forEach((item) => {
-                if (item.menu) {
-                    appendSubmenu(list, item);
-                    return;
-                }
-
-                if (
-                    item.role === "details"
-                    && (!this.$rootScope.$btclient || !this.$rootScope.$btclient.features.torrentDetails)
-                ) {
-                    return;
-                }
-
-                if (
-                    item.role === "set-speed-limits"
-                    && (!this.$rootScope.$btclient || !this.$rootScope.$btclient.features.speedLimits)
-                ) {
-                    return;
-                }
-
-                if (
-                    item.role === "set-ratio"
-                    && (!this.$rootScope.$btclient || !this.$rootScope.$btclient.features.ratioLimits)
-                ) {
-                    return;
-                }
-
-                appendMenuItem(list, item);
-            });
-
-            bindMenuActions();
-        };
-
-        const updateCheckboxes = (items: any[]) => {
-            checkboxes.forEach((item) => {
-                item.checkbox.checked = items.every((entry) => item.predicate(entry));
-            });
+        scope.toggleSubmenu = (event, visible) => {
+            $(event.currentTarget).find(".menu").toggle(visible);
         };
 
         const bindCloseOperations = () => {
@@ -229,7 +110,7 @@ export class ContextMenuDirective implements IDirective {
         scope.bind = {
             show: (event: MouseEvent, items: any[]) => {
                 bindCloseOperations();
-                updateCheckboxes(items);
+                scope.selectedItems = items;
 
                 const totalWidth = $(window).width() || 0;
                 const totalHeight = $(window).height() || 0;
@@ -267,21 +148,10 @@ export class ContextMenuDirective implements IDirective {
         document.body.addEventListener("click", onBodyClick);
         document.addEventListener("keyup", onKeyUp);
 
-        render();
-
         window.electorrent.app.getMeta().then((meta) => {
-            this.isDebug = !!meta.isDebug
-            scope.$evalAsync(render)
+            scope.isDebug = !!meta.isDebug;
+            scope.$applyAsync();
         });
-
-        scope.$watch(
-            () => this.$rootScope.$btclient,
-            (client) => {
-                if (client) {
-                    render();
-                }
-            },
-        );
 
         scope.$on("$destroy", () => {
             document.body.removeEventListener("click", onBodyClick);

--- a/src/renderer/app/directives/context-menu/context-menu.directive.ts
+++ b/src/renderer/app/directives/context-menu/context-menu.directive.ts
@@ -1,5 +1,6 @@
 import { IAugmentedJQuery, IDirective, IDirectiveFactory, IDocumentService, IRootScopeService, IScope, IWindowService } from "angular";
 import { ContextMenuController } from "./context-menu.controller";
+import html from "./context-menu.template.html";
 
 interface ContextMenuItem {
     id?: string;
@@ -30,6 +31,7 @@ export class ContextMenuDirective implements IDirective {
         debug: "=?",
     };
     controller = ContextMenuController;
+    template = html;
     private isDebug = false
 
     static getInstance(): IDirectiveFactory {
@@ -54,27 +56,46 @@ export class ContextMenuDirective implements IDirective {
 
         const checkboxes: Array<{ checkbox: HTMLInputElement; predicate: (item: any) => boolean }> = [];
 
+        const cloneTemplate = (name: string) => {
+            const template = element[0].querySelector<HTMLTemplateElement>(`template[data-context-menu-template="${name}"]`);
+            const templateElement = template?.content.firstElementChild;
+
+            if (!templateElement) {
+                throw new Error(`Missing context menu template: ${name}`);
+            }
+
+            return angular.element(templateElement.cloneNode(true)) as IAugmentedJQuery;
+        };
+
+        const setLabel = (item: IAugmentedJQuery, label: string) => {
+            const labelElement = item[0].querySelector<HTMLElement>("[data-context-menu-label]");
+            if (labelElement) {
+                labelElement.textContent = label;
+            }
+        };
+
         const addIcon = (item: IAugmentedJQuery, iconName: string) => {
-            const icon = angular.element("<i></i>");
+            const icon = angular.element(item[0].querySelector("[data-context-menu-icon]"));
             icon.addClass(`ui ${iconName} icon`);
-            item.append(icon);
         };
 
         const addCheckbox = (item: IAugmentedJQuery, predicate: (menuItem: any) => boolean) => {
-            const check = angular.element('<div class="ui checkbox"></div>');
-            const checkbox = angular.element('<input type="checkbox">');
-            const label = angular.element("<label></label>");
-            check.append(checkbox);
-            check.append(label);
-            item.append(check);
+            const checkbox = item[0].querySelector<HTMLInputElement>("input[type=checkbox]");
+
+            if (!checkbox) {
+                throw new Error("Missing checkbox in context menu item template");
+            }
+
             checkboxes.push({
-                checkbox: checkbox[0] as HTMLInputElement,
+                checkbox,
                 predicate,
             });
         };
 
         const appendMenuItem = (list: IAugmentedJQuery, item: ContextMenuItem) => {
-            const menuItem = angular.element('<a class="item"></a>');
+            const menuItem = cloneTemplate("item");
+            const icon = menuItem[0].querySelector("[data-context-menu-icon]");
+            const checkbox = menuItem[0].querySelector("[data-context-menu-checkbox]");
 
             if (item.role) {
                 menuItem.attr("data-role", item.role);
@@ -82,8 +103,13 @@ export class ContextMenuDirective implements IDirective {
 
             if (item.icon) {
                 addIcon(menuItem, item.icon);
+                checkbox?.remove();
             } else if (item.check) {
+                icon?.remove();
                 addCheckbox(menuItem, item.check);
+            } else {
+                icon?.remove();
+                checkbox?.remove();
             }
 
             menuItem.on("click", () => {
@@ -91,21 +117,20 @@ export class ContextMenuDirective implements IDirective {
                 scope.click(item.click, item.label, item);
             });
 
-            menuItem.append(item.label);
+            setLabel(menuItem, item.label);
             list.append(menuItem);
         };
 
         const appendSubmenu = (list: IAugmentedJQuery, submenu: ContextMenuItem) => {
-            const item = angular.element('<div class="ui context dropdown item"></div>');
-            const menu = angular.element('<div class="menu"></div>');
+            const item = cloneTemplate("submenu");
+            const menu = angular.element(item[0].querySelector("[data-context-menu-items]"));
 
             submenu.menu?.forEach((subItem) => {
                 appendMenuItem(menu, subItem);
             });
 
             addIcon(item, "dropdown");
-            item.append(submenu.label);
-            item.append(menu);
+            setLabel(item, submenu.label);
             list.append(item);
         };
 
@@ -140,11 +165,13 @@ export class ContextMenuDirective implements IDirective {
                 return;
             }
 
-            element.empty();
             checkboxes.length = 0;
 
-            const list = angular.element('<div class="ui vertical menu"></div>');
-            element.append(list);
+            const existingList = element[0].querySelector("[data-context-menu-items]");
+            existingList?.remove();
+
+            const list = cloneTemplate("menu");
+            element.prepend(list);
 
             if (this.isDebug) {
                 appendDebugItem(list);

--- a/src/renderer/app/directives/context-menu/context-menu.template.html
+++ b/src/renderer/app/directives/context-menu/context-menu.template.html
@@ -1,1 +1,22 @@
+<template data-context-menu-template="menu">
+    <div class="ui vertical menu" data-context-menu-items></div>
+</template>
 
+<template data-context-menu-template="item">
+    <a class="item">
+        <i data-context-menu-icon></i>
+        <div class="ui checkbox" data-context-menu-checkbox>
+            <input type="checkbox">
+            <label></label>
+        </div>
+        <span data-context-menu-label></span>
+    </a>
+</template>
+
+<template data-context-menu-template="submenu">
+    <div class="ui context dropdown item">
+        <i data-context-menu-icon></i>
+        <span data-context-menu-label></span>
+        <div class="menu" data-context-menu-items></div>
+    </div>
+</template>

--- a/src/renderer/app/directives/context-menu/context-menu.template.html
+++ b/src/renderer/app/directives/context-menu/context-menu.template.html
@@ -1,22 +1,44 @@
-<template data-context-menu-template="menu">
-    <div class="ui vertical menu" data-context-menu-items></div>
-</template>
+<div class="ui vertical menu">
+    <a class="item" ng-if="isDebug && debug" ng-click="runDebugItem()">
+        <i class="ui help icon"></i>
+        Debug
+    </a>
 
-<template data-context-menu-template="item">
-    <a class="item">
-        <i data-context-menu-icon></i>
-        <div class="ui checkbox" data-context-menu-checkbox>
-            <input type="checkbox">
+    <a
+        class="item"
+        ng-repeat-start="item in menu track by $index"
+        ng-if="!item.menu && isItemVisible(item)"
+        ng-attr-data-role="{{item.role}}"
+        ng-click="runMenuItem(item)">
+        <i class="ui icon" ng-if="item.icon" ng-class="item.icon"></i>
+        <div class="ui checkbox" ng-if="item.check">
+            <input type="checkbox" ng-checked="isItemChecked(item)">
             <label></label>
         </div>
-        <span data-context-menu-label></span>
+        {{item.label}}
     </a>
-</template>
 
-<template data-context-menu-template="submenu">
-    <div class="ui context dropdown item">
-        <i data-context-menu-icon></i>
-        <span data-context-menu-label></span>
-        <div class="menu" data-context-menu-items></div>
+    <div
+        class="ui context dropdown item"
+        ng-if="item.menu"
+        ng-mouseenter="toggleSubmenu($event, true)"
+        ng-mouseleave="toggleSubmenu($event, false)"
+        ng-repeat-end>
+        <i class="ui dropdown icon"></i>
+        {{item.label}}
+        <div class="menu">
+            <a
+                class="item"
+                ng-repeat="child in item.menu track by $index"
+                ng-attr-data-role="{{child.role}}"
+                ng-click="runMenuItem(child)">
+                <i class="ui icon" ng-if="child.icon" ng-class="child.icon"></i>
+                <div class="ui checkbox" ng-if="child.check">
+                    <input type="checkbox" ng-checked="isItemChecked(child)">
+                    <label></label>
+                </div>
+                {{child.label}}
+            </a>
+        </div>
     </div>
-</template>
+</div>


### PR DESCRIPTION
## Summary
- move context-menu DOM structures into HTML template fragments
- clone template fragments for menu items, submenus, icons, and checkboxes
- preserve context-menu interactions and positioning

## Validation
- npm run lint
- npm run build
- focused context-menu browser test