### PR TITLE
refactor(sorting): decouple sort headers

### DIFF
--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -172,9 +172,9 @@ import { NewLabelModalDirective } from "@renderer/app/directives/new-label-modal
 torrentApp.directive("newLabelModal", NewLabelModalDirective.getInstance())
 import { DragAndDropDirective } from "@renderer/app/directives/drag-and-drop/drag-and-drop.directive"
 torrentApp.directive("dragAndDrop", DragAndDropDirective.getInstance())
-import { SortingDirective, SortDirective } from "@renderer/app/directives/sorting/sorting.directive"
+import { SortingDirective, SortHeaderDirective } from "@renderer/app/directives/sorting/sorting.directive"
 torrentApp.directive("sorting", SortingDirective.getInstance())
-torrentApp.directive("sort", SortDirective.getInstance())
+torrentApp.directive("sortHeader", SortHeaderDirective.getInstance())
 import { TorrentBodyDirective, TorrentRowDirective } from "@renderer/app/directives/torrent-table/torrent-table.directive"
 torrentApp.directive("torrentBody", TorrentBodyDirective.getInstance())
 torrentApp.directive("torrentRow", TorrentRowDirective.getInstance())

--- a/src/renderer/app/directives/sorting/sorting.controller.ts
+++ b/src/renderer/app/directives/sorting/sorting.controller.ts
@@ -148,7 +148,6 @@ export class SortHeaderController implements SortHeader {
     }
 
     $onInit() {
-        this.column.append('<i class="ui sorting icon" aria-hidden="true"></i>');
         this.column.on("mousedown", this.onMouseDown);
         this.column.on("mouseup", this.onMouseUp);
         this.render();
@@ -201,6 +200,14 @@ export class SortHeaderController implements SortHeader {
     private render() {
         const isActive = !this.disabled && this.currentState?.sortKey === this.sortKey;
         const descending = isActive && this.currentState?.descending === true;
+        const icon = this.column.children(".sorting.icon");
+
+        if (this.disabled) {
+            icon.remove();
+        } else if (!icon.length) {
+            this.column.append('<i class="ui sorting icon" aria-hidden="true"></i>');
+        }
+
         this.column.toggleClass("sorting-disabled", this.disabled === true);
         this.column.toggleClass("sortdown", descending);
         this.column.toggleClass("sortup", isActive && !descending);

--- a/src/renderer/app/directives/sorting/sorting.controller.ts
+++ b/src/renderer/app/directives/sorting/sorting.controller.ts
@@ -1,10 +1,20 @@
-import { IWindowService } from "angular";
+import { IAugmentedJQuery, IWindowService } from "angular";
 
 export interface SortingOptions {
     defaultSortKey?: string;
     defaultSortOrder?: boolean;
     sortKeyPrefix?: string;
     sortOrderPrefix?: string;
+}
+
+export interface SortChange<TSortKey = string> {
+    sortKey: TSortKey;
+    descending: boolean;
+}
+
+export interface SortHeader {
+    readonly sortKey: string;
+    setSortState(change: SortChange): void;
 }
 
 const DEFAULT_SORT_KEY = "dateAdded";
@@ -52,26 +62,62 @@ export class SortingController {
     defaultSortOrder?: boolean;
     sortKeyPrefix?: string;
     sortOrderPrefix?: string;
-    sorting!: (sortKey: string, descending: boolean) => void;
-    sortKey!: string;
-    sortOrder!: boolean;
-    last?: JQuery;
+    onSortChange?: (locals: { $event: SortChange }) => void;
+
+    private readonly headers = new Set<SortHeader>();
+    private initialized = false;
+    private state!: SortChange;
 
     constructor(private $window: IWindowService) {}
 
     $onInit() {
-        this.updateSettings();
+        this.initialized = true;
+        this.loadState();
     }
 
-    updateSettings() {
+    $onChanges() {
+        if (this.initialized) {
+            this.loadState();
+        }
+    }
+
+    register(header: SortHeader) {
+        this.headers.add(header);
+        if (this.state) {
+            header.setSortState(this.state);
+            if (header.sortKey === this.state.sortKey) {
+                this.emitState();
+            }
+        }
+    }
+
+    unregister(header: SortHeader) {
+        this.headers.delete(header);
+    }
+
+    select(sortKey: string) {
+        const descending = this.state.sortKey === sortKey ? !this.state.descending : true;
+        this.state = { sortKey, descending };
+        saveSortingState(this.$window, this.mode, sortKey, descending, this.getOptions());
+        this.renderState();
+        this.emitState();
+    }
+
+    private loadState() {
         const { sortKey, sortOrder } = loadSortingState(this.$window, this.mode, this.getOptions());
-
-        this.sortKey = sortKey;
-        this.sortOrder = sortOrder;
+        this.state = { sortKey, descending: sortOrder };
+        this.renderState();
+        if (Array.from(this.headers).some((header) => header.sortKey === sortKey)) {
+            this.emitState();
+        }
     }
 
-    save(key: string, order: boolean) {
-        saveSortingState(this.$window, this.mode, key, order, this.getOptions());
+    private renderState() {
+        this.headers.forEach((header) => header.setSortState(this.state));
+    }
+
+    private emitState() {
+        this.onSortChange?.({ $event: this.state });
     }
 
     private getOptions(): SortingOptions {
@@ -81,5 +127,84 @@ export class SortingController {
             sortKeyPrefix: this.sortKeyPrefix,
             sortOrderPrefix: this.sortOrderPrefix,
         };
+    }
+}
+
+export class SortHeaderController implements SortHeader {
+    static $inject = ["$element", "$window"];
+
+    sortKey!: string;
+    disabled?: boolean;
+
+    private sorting?: SortingController;
+    private currentState?: SortChange;
+    private isDragging = false;
+    private readonly column: JQuery;
+    private readonly windowElement: JQuery<IWindowService>;
+
+    constructor($element: IAugmentedJQuery, $window: IWindowService) {
+        this.column = $($element);
+        this.windowElement = $($window);
+    }
+
+    $onInit() {
+        this.column.append('<i class="ui sorting icon" aria-hidden="true"></i>');
+        this.column.on("mousedown", this.onMouseDown);
+        this.column.on("mouseup", this.onMouseUp);
+        this.render();
+    }
+
+    $onDestroy() {
+        this.sorting?.unregister(this);
+        this.column.off("mousedown", this.onMouseDown);
+        this.column.off("mouseup", this.onMouseUp);
+        this.windowElement.off("mousemove", this.onWindowMouseMove);
+    }
+
+    connect(sorting: SortingController) {
+        this.sorting = sorting;
+        sorting.register(this);
+    }
+
+    setInputs(sortKey: string, disabled: boolean) {
+        this.sortKey = sortKey;
+        this.disabled = disabled;
+        this.render();
+    }
+
+    setSortState(change: SortChange) {
+        this.currentState = change;
+        this.render();
+    }
+
+    private readonly onMouseDown = () => {
+        if (this.disabled) {
+            return;
+        }
+        this.isDragging = false;
+        this.windowElement.one("mousemove", this.onWindowMouseMove);
+    };
+
+    private readonly onWindowMouseMove = () => {
+        this.isDragging = true;
+    };
+
+    private readonly onMouseUp = () => {
+        const wasDragging = this.isDragging;
+        this.isDragging = false;
+        this.windowElement.off("mousemove", this.onWindowMouseMove);
+        if (!this.disabled && !wasDragging) {
+            this.sorting?.select(this.sortKey);
+        }
+    };
+
+    private render() {
+        const isActive = !this.disabled && this.currentState?.sortKey === this.sortKey;
+        const descending = isActive && this.currentState?.descending === true;
+        this.column.toggleClass("sorting-disabled", this.disabled === true);
+        this.column.toggleClass("sortdown", descending);
+        this.column.toggleClass("sortup", isActive && !descending);
+        this.column.attr("aria-disabled", this.disabled === true ? "true" : "false");
+        this.column.attr("aria-sort", isActive ? (descending ? "descending" : "ascending") : "none");
     }
 }

--- a/src/renderer/app/directives/sorting/sorting.directive.ts
+++ b/src/renderer/app/directives/sorting/sorting.directive.ts
@@ -1,17 +1,12 @@
 import { IAttributes, IAugmentedJQuery, IDirective, IDirectiveFactory, IScope } from "angular";
-import { SortingController } from "./sorting.controller";
-
-interface SortScope extends IScope {
-    sort: string;
-    update: () => void;
-}
+import { SortHeaderController, SortingController } from "./sorting.controller";
 
 export class SortingDirective implements IDirective {
     restrict = "A";
     bindToController = true;
     scope = {
-        mode: "=",
-        sorting: "=",
+        mode: "<",
+        onSortChange: "&?",
         defaultSortKey: "@?",
         defaultSortOrder: "<?",
         sortKeyPrefix: "@?",
@@ -22,105 +17,33 @@ export class SortingDirective implements IDirective {
     static getInstance(): IDirectiveFactory {
         return () => new SortingDirective();
     }
-
-    link(scope: IScope, element: IAugmentedJQuery, attr: IAttributes, controller: SortingController) {
-        const update = () => {
-            $(element)
-                .find("*[sort]")
-                .each((index, column) => {
-                    const columnScope = angular.element(column).scope() as SortScope;
-                    columnScope.update();
-                });
-        };
-
-        scope.$watch(
-            () => controller.mode,
-            (newMode, oldMode) => {
-                if (newMode !== oldMode) {
-                    controller.updateSettings();
-                    update();
-                }
-            },
-        );
-    }
 }
 
-export class SortDirective implements IDirective {
+export class SortHeaderDirective implements IDirective {
     restrict = "A";
-    require = "^^sorting";
     scope = false;
+    controller = SortHeaderController;
+    require = ["sortHeader", "^^sorting"];
 
     static getInstance(): IDirectiveFactory {
-        return () => new SortDirective();
+        return () => new SortHeaderDirective();
     }
 
-    link(scope: SortScope, element: IAugmentedJQuery, attr: IAttributes, controller: SortingController) {
-        const column = $(element);
-        scope.sort = scope.$eval(attr.sort || "");
-
-        if (attr.sortDisabled && scope.$eval(attr.sortDisabled)) {
-            scope.update = () => undefined;
-            column.addClass("sorting-disabled");
-            return;
-        }
-
-        const setSortingArrow = (sortDesc?: boolean) => {
-            if (controller.last) {
-                controller.last.removeClass("sortdown sortup");
-            }
-
-            if (sortDesc === true) {
-                column.addClass("sortdown");
-            } else if (sortDesc === false) {
-                column.addClass("sortup");
-            } else {
-                column.removeClass("sortdown sortup");
-            }
-
-            controller.last = column;
-        };
-
-        const showSortingArrows = () => {
-            if (column.is(".sortdown, .sortup")) {
-                column.toggleClass("sortdown sortup");
-            } else {
-                if (controller.last) {
-                    controller.last.removeClass("sortdown sortup");
-                }
-                column.addClass("sortdown");
-                controller.last = column;
-            }
-
-            const desc = column.hasClass("sortdown");
-            controller.sorting(scope.sort, desc);
-            controller.save(scope.sort, desc);
-        };
-
-        let isDragging = false;
-
-        column.mousedown(() => {
-            $(window).one("mousemove", () => {
-                isDragging = true;
-            });
-        });
-
-        column.mouseup(() => {
-            const wasDragging = isDragging;
-            isDragging = false;
-            $(window).off("mousemove");
-            if (!wasDragging) {
-                showSortingArrows();
-            }
-        });
-
-        scope.update = () => {
-            if (scope.sort === controller.sortKey) {
-                setSortingArrow(controller.sortOrder);
-                controller.sorting(scope.sort, controller.sortOrder);
-            }
-        };
-
-        column.append('<i class="ui sorting icon"></i>');
-        scope.update();
+    link(
+        scope: IScope,
+        element: IAugmentedJQuery,
+        attrs: IAttributes,
+        controllers: [SortHeaderController, SortingController],
+    ) {
+        const header = controllers[0];
+        header.setInputs(scope.$eval(attrs.sortKey), attrs.disabled ? scope.$eval(attrs.disabled) === true : false);
+        header.connect(controllers[1]);
+        scope.$watchGroup(
+            [
+                () => scope.$eval(attrs.sortKey),
+                () => attrs.disabled ? scope.$eval(attrs.disabled) : false,
+            ],
+            ([sortKey, disabled]) => header.setInputs(sortKey, disabled === true),
+        );
     }
 }

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
@@ -4,7 +4,7 @@ import {
   TorrentDetailsFileItem,
   TorrentDetailsPanelData,
 } from "@renderer/app/bittorrent/torrentclient";
-import { loadSortingState, SortingOptions } from "@renderer/app/directives/sorting/sorting.controller";
+import { loadSortingState, SortChange, SortingOptions } from "@renderer/app/directives/sorting/sorting.controller";
 import type { SettingsService } from "@renderer/app/services/settings";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 
@@ -101,8 +101,8 @@ export class TorrentDetailsFilesTabController {
     return !!this.rootScope.$btclient?.features.fileSelection;
   }
 
-  changeSorting = (columnId: string, descending: boolean) => {
-    this.fileSortKey = columnId;
+  changeSorting = ({ sortKey, descending }: SortChange) => {
+    this.fileSortKey = sortKey;
     this.fileSortDescending = descending;
     this.sortFiles();
   };

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
@@ -24,7 +24,8 @@
     >
       <thead>
         <tr
-          sorting="ctl.changeSorting"
+          sorting
+          on-sort-change="ctl.changeSorting($event)"
           mode="ctl.scope.resizeProfile"
           default-sort-key="name"
           default-sort-order="false"
@@ -34,8 +35,9 @@
           <th
             ng-repeat="column in ctl.scope.files.columns track by column.id"
             rz-col="column.id"
-            sort="column.id"
-            sort-disabled="column.sortable === false"
+            sort-header
+            sort-key="column.id"
+            disabled="column.sortable === false"
             ng-class="{ 'torrent-details-file-selection-column': column.id === 'wanted' }"
           >
             <div ng-if="column.id === 'wanted'" class="ui checkbox torrent-details-file-checkbox">

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
@@ -1,4 +1,5 @@
 import { IScope } from "angular"
+import type { SortChange } from "@renderer/app/directives/sorting/sorting.controller"
 import type { SettingsService } from "@renderer/app/services/settings"
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope"
 import type { BittorrentTorrentPeer } from "@shared/ipc-contract"
@@ -70,8 +71,8 @@ export class TorrentDetailsPeersTabController {
   private sortKey: TorrentDetailsPeerColumn["id"] = "ip"
   private sortDescending = false
 
-  changeSorting = (columnId: TorrentDetailsPeerColumn["id"], descending: boolean) => {
-    this.sortKey = columnId
+  changeSorting = ({ sortKey, descending }: SortChange<TorrentDetailsPeerColumn["id"]>) => {
+    this.sortKey = sortKey
     this.sortDescending = descending
     this.sortPeers()
   }

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
@@ -20,8 +20,8 @@
       columns="ctl.scope.columns"
     >
       <thead>
-        <tr sorting="ctl.changeSorting" mode="ctl.scope.resizeProfile" default-sort-key="ip" default-sort-order="false" sort-key-prefix="torrent-details-peers.sort-key" sort-order-prefix="torrent-details-peers.sort-desc">
-          <th ng-repeat="column in ctl.scope.columns track by column.id" rz-col="column.id" sort="column.id">
+        <tr sorting mode="ctl.scope.resizeProfile" on-sort-change="ctl.changeSorting($event)" default-sort-key="ip" default-sort-order="false" sort-key-prefix="torrent-details-peers.sort-key" sort-order-prefix="torrent-details-peers.sort-desc">
+          <th ng-repeat="column in ctl.scope.columns track by column.id" rz-col="column.id" sort-header sort-key="column.id">
             <span class="torrent-details-table-header-label">{{ column.label }}</span>
           </th>
         </tr>

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
@@ -1,4 +1,5 @@
 import { IScope } from "angular"
+import type { SortChange } from "@renderer/app/directives/sorting/sorting.controller"
 import type { SettingsService } from "@renderer/app/services/settings"
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope"
 import type { BittorrentTorrentDetailsTracker } from "@shared/ipc-contract"
@@ -68,8 +69,8 @@ export class TorrentDetailsTrackersTabController {
     this.scope.$on("$destroy", () => { this.requestId += 1 })
   }
 
-  changeSorting = (columnId: keyof BittorrentTorrentDetailsTracker, descending: boolean) => {
-    this.sortKey = columnId
+  changeSorting = ({ sortKey, descending }: SortChange<keyof BittorrentTorrentDetailsTracker>) => {
+    this.sortKey = sortKey
     this.sortDescending = descending
     this.sortTrackers()
   }

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
@@ -20,8 +20,8 @@
     columns="ctl.scope.columns"
   >
     <thead>
-      <tr sorting="ctl.changeSorting" mode="ctl.scope.resizeProfile" default-sort-key="url" default-sort-order="false" sort-key-prefix="torrent-details-trackers.sort-key" sort-order-prefix="torrent-details-trackers.sort-desc">
-        <th ng-repeat="column in ctl.scope.columns track by column.id" rz-col="column.id" sort="column.id">
+      <tr sorting mode="ctl.scope.resizeProfile" on-sort-change="ctl.changeSorting($event)" default-sort-key="url" default-sort-order="false" sort-key-prefix="torrent-details-trackers.sort-key" sort-order-prefix="torrent-details-trackers.sort-desc">
+        <th ng-repeat="column in ctl.scope.columns track by column.id" rz-col="column.id" sort-header sort-key="column.id">
           <span class="torrent-details-table-header-label">{{ column.label }}</span>
         </th>
       </tr>

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -2,6 +2,7 @@ import Fuse from "fuse.js";
 import { TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { PendingTorrentUploadItem, PendingTorrentUploadList } from "@renderer/app/directives/add-torrent-modal/add-torrent-modal.directive";
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
+import type { SortChange } from "@renderer/app/directives/sorting/sorting.controller";
 import { matchesLabelFilter } from "@renderer/app/directives/torrent-sidebar/torrent-label-filter";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import type { TorrentActionItem } from "@shared/torrent-actions";
@@ -776,9 +777,9 @@ export class TorrentsPageController {
             return Array.from(Object.values($scope.torrents)) as any[];
         }
 
-        $scope.changeSorting = (sortName: string, descending: boolean) => {
+        $scope.changeSorting = ({ sortKey, descending }: SortChange) => {
             $scope.torrentLimit = LIMIT;
-            $scope.filters.sort = sortName;
+            $scope.filters.sort = sortKey;
             $scope.filters.order = descending;
             refreshTorrents();
         };

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -86,11 +86,12 @@
                     class="ui single line unstackable selectable fixed torrent resize table"
                 >
                     <thead>
-                        <tr sorting="changeSorting" mode="$server.id">
+                        <tr sorting mode="$server.id" on-sort-change="changeSorting($event)">
                             <th
                                 ng-repeat="col in $server.columns | filter:{enabled: true} track by col.name"
                                 rz-col="col.attribute"
-                                sort="col.attribute"
+                                sort-header
+                                sort-key="col.attribute"
                             >
                                 {{::col.name}}
                             </th>


### PR DESCRIPTION
## Summary

- Replace sorting DOM traversal and scope introspection with explicit parent/header controller registration.
- Introduce Angular-style typed sorting state and change event contracts across all sorting consumers.
- Preserve persisted sort preferences, disabled columns, header indicators, and drag suppression.

## Why

Angular does not expose AngularJS-style scope introspection. This refactor makes the existing AngularJS directive migration-ready by communicating through explicit inputs, state, and outputs.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "mock" --spec "test/specs/mock/sorting.spec.ts"`
- `git diff --check`