### PR TITLE
fix(sorting): center header icons

### DIFF
--- a/src/renderer/app/directives/sorting/sorting.less
+++ b/src/renderer/app/directives/sorting/sorting.less
@@ -1,3 +1,10 @@
 [sorting] {
-    .sorting.icon { position: absolute; right: 5px; }
+    .sorting.icon {
+        position: absolute;
+        top: 50%;
+        right: 5px;
+        margin: 0;
+        transform: translateY(-50%);
+        pointer-events: none;
+    }
 }

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
@@ -41,13 +41,6 @@ torrent-details-files-tab {
             text-align: center;
         }
 
-        > thead > tr > th .sorting.icon {
-            top: 50%;
-            margin: 0;
-            transform: translateY(-50%);
-            pointer-events: none;
-        }
-
         > tbody > tr > td { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     }
 


### PR DESCRIPTION
## Summary
- center sorting icons vertically in the shared sorting directive
- remove the duplicate files-tab alignment override
- preserve icon click-through behavior across sortable tables

## Validation
- npm run lint
- npm run build
- npm run test -- --client mock --spec sorting.spec.js