### PR TITLE
feat(settings): encrypt server passwords

### DIFF
--- a/src/main/lib/bittorrent/clients/aria2/index.ts
+++ b/src/main/lib/bittorrent/clients/aria2/index.ts
@@ -2,7 +2,6 @@ import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { HTTP_LOGIN_TIMEOUT } from "@main/lib/bittorrent/helpers"
 import type {
     BittorrentFileSelection,
-    BittorrentServerConfig,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentDetailsTracker,
@@ -10,6 +9,7 @@ import type {
     TorrentClientConnection,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
+import type { ResolvedServerConfig } from '@main/lib/bittorrent/server-config'
 import type { TorrentActionItem } from "@shared/torrent-actions"
 import { Aria2JsonRpcTransport, Aria2RpcError, type Aria2RpcCall } from "./json-rpc"
 
@@ -235,7 +235,7 @@ export class Aria2Runtime implements BittorrentRuntime {
 
     private rpc?: Aria2JsonRpcTransport
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.rpc = new Aria2JsonRpcTransport(server)
         const result = await this.rpc.call<{ version?: string }>("aria2.getVersion", [], HTTP_LOGIN_TIMEOUT)
         if (typeof result?.version !== "string" || !result.version.trim()) {

--- a/src/main/lib/bittorrent/clients/aria2/json-rpc.ts
+++ b/src/main/lib/bittorrent/clients/aria2/json-rpc.ts
@@ -3,7 +3,7 @@ import httpAdapter from "axios/lib/adapters/http.js"
 import https from "node:https"
 
 import { HTTP_REQUEST_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
-import type { BittorrentServerConfig } from "@shared/ipc-contract"
+import type { ResolvedServerConfig } from '@main/lib/bittorrent/server-config'
 
 export interface Aria2RpcCall {
     method: string
@@ -66,7 +66,7 @@ export class Aria2JsonRpcTransport {
     private readonly endpoint: string
     private readonly secret: string
 
-    constructor(server: BittorrentServerConfig) {
+    constructor(server: ResolvedServerConfig) {
         this.endpoint = serverUrl(server)
         this.secret = server.password || ""
         this.http = axios.create({

--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,8 @@
 import request from "request"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { ResolvedServerConfig } from '@main/lib/bittorrent/server-config'
 import {
     defer,
     HTTP_LOGIN_TIMEOUT,
@@ -75,7 +76,7 @@ export class DelugeRuntime implements BittorrentRuntime {
         { role: "remove", label: "Remove", action: "remove", icon: "remove" },
         { label: "Remove and delete", action: "removeAndDelete", icon: "trash", role: "delete" },
     ]
-    private url(server: BittorrentServerConfig, endpoint?: string) {
+    private url(server: ResolvedServerConfig, endpoint?: string) {
         return serverUrl(server, endpoint)
     }
 
@@ -224,7 +225,7 @@ export class DelugeRuntime implements BittorrentRuntime {
         return defer<any[]>((done) => this.rpc("web.get_hosts", [], done))
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.rpcUrl = this.url(server, "json")
         this.uploadUrl = this.url(server, "upload")
         this.requestId = 0

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -1,12 +1,12 @@
 import type {
     BittorrentFileSelection,
-    BittorrentServerConfig,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
     BittorrentTorrentDetailsTracker,
     TorrentClientConnection,
 } from "@shared/ipc-contract"
+import type { ResolvedServerConfig } from '@main/lib/bittorrent/server-config'
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import type { TorrentActionItem } from "@shared/torrent-actions"
 import parseTorrent from "parse-torrent"
@@ -87,7 +87,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
     private connected = false
     private store?: MockRuntimeStore
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         const key = this.getServerKey(server)
         let store = MockBittorrentRuntime.stores.get(key)
         if (!store) {
@@ -584,7 +584,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         return this.store!.removedHashes
     }
 
-    private getServerKey(server: BittorrentServerConfig) {
+    private getServerKey(server: ResolvedServerConfig) {
         return server.id || `${server.client}:${server.proto}://${server.ip}:${server.port}${server.path || ""}`
     }
 }

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -4,13 +4,13 @@ import parseTorrent from "parse-torrent"
 
 import type {
     BittorrentFileSelection,
-    BittorrentServerConfig,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
     BittorrentTorrentDetailsTracker,
     TorrentClientConnection,
 } from "@shared/ipc-contract"
+import type { ResolvedServerConfig } from '@main/lib/bittorrent/server-config'
 import { defer, HTTP_LOGIN_TIMEOUT, HTTP_REQUEST_TIMEOUT, serverOriginUrl, serverUrl, urlPath } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import type { TorrentActionItem } from "@shared/torrent-actions"
@@ -136,7 +136,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         { role: "remove", label: "Remove", action: "delete", icon: "remove" },
         { label: "Remove And Delete", action: "deleteAndRemove", icon: "trash", role: "delete" },
     ]
-    private url(server: BittorrentServerConfig, endpoint?: string) {
+    private url(server: ResolvedServerConfig, endpoint?: string) {
         return serverUrl(server, endpoint)
     }
 
@@ -146,7 +146,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
 
     private torrentCache = new Map<string, Record<string, any>>()
 
-    private async selectApi(server: BittorrentServerConfig) {
+    private async selectApi(server: ResolvedServerConfig) {
         const origin = serverOriginUrl(server)
         const requestOptions = {
             timeout: HTTP_LOGIN_TIMEOUT,
@@ -191,7 +191,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         return this.api
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         const api = await this.selectApi(server)
         this.api = api
         await defer((done) => api.login(done))

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -3,7 +3,8 @@ import { URL } from "node:url"
 import xmlrpc from "@electorrent/xmlrpc"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { ResolvedServerConfig } from '@main/lib/bittorrent/server-config'
 import { defer, HTTP_LOGIN_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import type { TorrentActionItem } from "@shared/torrent-actions"
@@ -40,7 +41,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
     ]
     private client: any
 
-    private url(server: BittorrentServerConfig) {
+    private url(server: ResolvedServerConfig) {
         return server.path ? serverUrl(server) : serverUrl(server, "RPC2")
     }
 
@@ -197,7 +198,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         await this.getMulticallHashes(hashes, commands, params)
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         const rpcUrl = new URL(this.url(server))
         const options: Record<string, any> = {
             host: rpcUrl.hostname.replace(/^\[|\]$/g, ""),

--- a/src/main/lib/bittorrent/clients/synology.ts
+++ b/src/main/lib/bittorrent/clients/synology.ts
@@ -3,7 +3,8 @@ import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
 import https from 'https'
 
-import type { BittorrentServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
+import type { TorrentClientConnection } from '@shared/ipc-contract'
+import type { ResolvedServerConfig } from '@main/lib/bittorrent/server-config'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -55,7 +56,7 @@ export class SynologyRuntime implements BittorrentRuntime {
         { role: "set-location", label: "Set Location", icon: "folder open" },
         { role: "remove", label: "Remove Torrent", action: "remove", icon: "remove" },
     ]
-    private server!: BittorrentServerConfig
+    private server!: ResolvedServerConfig
     private http!: AxiosInstance
     private authPath = ''
     private authVersion = ''
@@ -180,7 +181,7 @@ export class SynologyRuntime implements BittorrentRuntime {
         return !!data?.success
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.server = server
         this.http = axios.create({
             httpsAgent: new https.Agent({

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -2,7 +2,8 @@ import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import https from 'https'
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from '@shared/ipc-contract'
+import type { BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from '@shared/ipc-contract'
+import type { ResolvedServerConfig } from '@main/lib/bittorrent/server-config'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -115,7 +116,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
             { label: "Torrent and Local Data", action: "removeAndLocal", icon: "remove", role: "delete" },
         ] },
     ]
-    private server!: BittorrentServerConfig
+    private server!: ResolvedServerConfig
     private session?: string
 
     private url(endpoint = '') {
@@ -196,7 +197,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
         return http
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.server = server
         this.session = undefined
 

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -5,7 +5,8 @@ import FormData from 'form-data'
 import https from 'https'
 import qs from 'qs'
 
-import type { BittorrentServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
+import type { TorrentClientConnection } from '@shared/ipc-contract'
+import type { ResolvedServerConfig } from '@main/lib/bittorrent/server-config'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -31,7 +32,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
             { label: "Delete All", action: "removedatatorrent", role: "delete" },
         ] },
     ]
-    private server!: BittorrentServerConfig
+    private server!: ResolvedServerConfig
     private http!: AxiosInstance
     private data = {
         username: '',
@@ -104,7 +105,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
         }
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.server = server
 
         this.http = axios.create({

--- a/src/main/lib/bittorrent/helpers.ts
+++ b/src/main/lib/bittorrent/helpers.ts
@@ -1,5 +1,5 @@
 import { URL } from "node:url"
-import type { BittorrentServerConfig } from "@shared/ipc-contract"
+import type { ResolvedServerConfig } from './server-config'
 import { sanitizeServerAddress } from "@shared/server-address"
 import type { CallbackFunc } from "./types"
 
@@ -27,7 +27,7 @@ export function urlPath(...pathValues: Array<string | undefined>) {
     return path ? `/${path}` : ""
 }
 
-export function serverOriginUrl(server: BittorrentServerConfig) {
+export function serverOriginUrl(server: ResolvedServerConfig) {
     const sanitizedServer = sanitizeServerAddress(server)
     const url = new URL("http://localhost")
     url.protocol = `${sanitizedServer.proto.replace(/:$/, "")}:`
@@ -36,7 +36,7 @@ export function serverOriginUrl(server: BittorrentServerConfig) {
     return url.origin
 }
 
-export function serverUrl(server: BittorrentServerConfig, endpoint?: string) {
+export function serverUrl(server: ResolvedServerConfig, endpoint?: string) {
     const url = new URL(serverOriginUrl(server))
     url.pathname = urlPath(server.path, endpoint) || "/"
 
@@ -49,4 +49,3 @@ export function appendUrlPath(baseUrl: string, endpoint?: string) {
 
     return url.pathname === "/" ? url.origin : url.toString()
 }
-

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -5,7 +5,6 @@ import { lookup as lookupCountry } from "geoip-country"
 import type {
     BittorrentAddTorrentUrlRequest,
     BittorrentInvokeActionRequest,
-    BittorrentServerConfig,
     BittorrentSetTorrentFileSelectionRequest,
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
@@ -18,6 +17,7 @@ import logger from "../logger"
 import * as settings from "../settings"
 import { createRuntime } from "./registry"
 import type { BittorrentRuntime } from "./types"
+import type { ResolvedServerConfig } from './server-config'
 import { withTorrentActionAccelerators } from "@shared/torrent-actions"
 
 export interface BittorrentSessionState {
@@ -76,7 +76,7 @@ class BittorrentManager {
         return sourceBasename === filename && sourceBasename.toLowerCase().endsWith(".torrent")
     }
 
-    async connect(sender: WebContents, server: BittorrentServerConfig): Promise<TorrentClientConnection | null> {
+    async connect(sender: WebContents, server: ResolvedServerConfig): Promise<TorrentClientConnection | null> {
         const senderId = sender.id
         this.setSessionState(senderId, {
             activeServerId: server.id || null,

--- a/src/main/lib/bittorrent/server-config.ts
+++ b/src/main/lib/bittorrent/server-config.ts
@@ -1,0 +1,7 @@
+import type { ServerConfigBase } from '@shared/ipc-contract'
+
+/** Fully resolved main-process configuration passed to BitTorrent runtimes. */
+export interface ResolvedServerConfig extends ServerConfigBase {
+    password: string
+    certificateData?: Uint8Array
+}

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -1,6 +1,5 @@
 import type {
     BittorrentFileSelection,
-    BittorrentServerConfig,
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
@@ -9,12 +8,14 @@ import type {
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
 import type { TorrentActionItem } from "@shared/torrent-actions"
+import type { ResolvedServerConfig } from './server-config'
+export type { ResolvedServerConfig } from './server-config'
 
 export type CallbackFunc<T = unknown> = (err: unknown, val: T) => void
 
 export interface BittorrentRuntime {
     readonly actions: TorrentActionItem[]
-    connect(server: BittorrentServerConfig): Promise<TorrentClientConnection>
+    connect(server: ResolvedServerConfig): Promise<TorrentClientConnection>
     getSnapshot(fullUpdate?: boolean): Promise<any>
     addTorrentUrl(uri: string, options?: TorrentUploadOptions): Promise<void>
     uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions): Promise<void>

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -223,7 +223,7 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
 
     ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }) {
         try {
-            const connection = await bittorrentManager.connect(event.sender, server)
+            const connection = await bittorrentManager.connect(event.sender, settings.resolveConnectionServer(server))
             if (!connection) {
                 return {
                     ok: false,

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, clipboard, dialog, ipcMain, nativeTheme, shell, typ
 import is from 'electron-is'
 
 import { IPC_CHANNELS } from '@shared/ipc'
-import type { AppSettings, EditCommand, PendingTorrentUploadLink, WindowCommand } from '@shared/ipc-contract'
+import type { AppSettings, BittorrentConnectRequest, EditCommand, PendingTorrentUploadLink, RendererServerConfig, SettingsSaveAllRequest, WindowCommand } from '@shared/ipc-contract'
 import { getAppVersion } from './app-meta'
 import { bittorrentManager } from './bittorrent'
 import { normalizeConnectionError } from './bittorrent/connection-error'
@@ -21,7 +21,7 @@ interface RegisterHandlersOptions {
         magnets: PendingTorrentUploadLink[]
         torrentFiles: unknown[]
     }>
-    onSettingsSaved?: (settings: AppSettings) => void | Promise<void>
+    onSettingsSaved?: (settings: AppSettings<RendererServerConfig>) => void | Promise<void>
     onSystemThemeChanged?: () => void
     onBittorrentConnected?: () => void | Promise<void>
 }
@@ -159,7 +159,7 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
         return settings.getAllSettings()
     })
 
-    ipcMain.handle(IPC_CHANNELS.settings.saveAll, async function(_event: IpcMainInvokeEvent, { settings: newSettings }) {
+    ipcMain.handle(IPC_CHANNELS.settings.saveAll, async function(_event: IpcMainInvokeEvent, { settings: newSettings }: SettingsSaveAllRequest) {
         await new Promise<void>((resolve, reject) => {
             settings.saveAll(newSettings, function(err: Error) {
                 if (err) {
@@ -221,7 +221,7 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
         return torrents.parse(request)
     })
 
-    ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }) {
+    ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }: BittorrentConnectRequest) {
         try {
             const connection = await bittorrentManager.connect(event.sender, settings.resolveConnectionServer(server))
             if (!connection) {

--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -2,25 +2,18 @@ import { app, dialog, safeStorage, shell, type BrowserWindow, type MessageBoxOpt
 import fs from 'fs'
 import path from 'path'
 
-import type { AppSettings, BittorrentServerConfig, StoredServerConfig } from '@shared/ipc-contract'
+import { PASSWORD_MASK, type AppSettings, type BittorrentConnectServer, type RendererServerConfig, type ServerConfigBase } from '@shared/ipc-contract'
 import { createDefaultSettings, normalizeSettings } from '@shared/settings-defaults'
+import type { ResolvedServerConfig } from './bittorrent/types'
 import * as electorrent from './electorrent'
 import type { StoredWindowState } from './window-state'
 
-const ENCRYPTED_PASSWORD_VERSION = 1
-const ENCRYPTED_PASSWORD_PROVIDER = 'electron-safe-storage'
-export const PASSWORD_MASK = '••••••••'
+export type PersistedPassword =
+    | { cipher: 'plaintext'; value: string }
+    | { cipher: 'electron-safe-storage'; value: string }
 
-export interface EncryptedPassword {
-    version: typeof ENCRYPTED_PASSWORD_VERSION
-    provider: typeof ENCRYPTED_PASSWORD_PROVIDER
-    data: string
-}
-
-export interface PersistedServerConfig extends Omit<StoredServerConfig, 'password' | 'hasPassword'> {
-    /** Backwards-compatible fallback used only when Electron safeStorage is unavailable. */
-    password?: string
-    encryptedPassword?: EncryptedPassword
+export interface PersistedServerConfig extends ServerConfigBase {
+    encryptedPassword?: PersistedPassword
 }
 
 export interface PersistedSettings extends AppSettings<PersistedServerConfig> {
@@ -28,6 +21,7 @@ export interface PersistedSettings extends AppSettings<PersistedServerConfig> {
 }
 
 let data: PersistedSettings | null = null
+let needsSettingsRewrite = false
 const changeListeners = new Set<() => void>()
 
 const CONF_PATH = path.join(app.getPath('userData'), 'config.json')
@@ -37,6 +31,53 @@ load()
 function deleteConfig() {
     if (fs.existsSync(CONF_PATH)) {
         fs.unlinkSync(CONF_PATH)
+    }
+}
+
+function decodeSettings(raw: unknown): PersistedSettings {
+    const normalized = normalizeSettings(raw) as AppSettings<RendererServerConfig>
+    return {
+        ...normalized,
+        servers: normalized.servers.map((server) => {
+            const input = server as RendererServerConfig & {
+                password?: unknown
+                encryptedPassword?: unknown
+            }
+            const {
+                password: legacyPassword,
+                encryptedPassword: encodedPassword,
+                hasPassword: _hasPassword,
+                newPassword: _newPassword,
+                ...publicServer
+            } = input
+
+            if (isPersistedPassword(encodedPassword)) {
+                return { ...publicServer, encryptedPassword: encodedPassword }
+            }
+
+            // Decode configs written by the short-lived versioned safeStorage format.
+            if (encodedPassword && typeof encodedPassword === 'object') {
+                const legacyEncrypted = encodedPassword as { version?: unknown; provider?: unknown; data?: unknown }
+                if (legacyEncrypted.version === 1
+                    && legacyEncrypted.provider === 'electron-safe-storage'
+                    && typeof legacyEncrypted.data === 'string'
+                    && legacyEncrypted.data.length > 0) {
+                    needsSettingsRewrite = true
+                    return {
+                        ...publicServer,
+                        encryptedPassword: { cipher: 'electron-safe-storage', value: legacyEncrypted.data },
+                    }
+                }
+            }
+
+            if (typeof legacyPassword === 'string') {
+                needsSettingsRewrite = true
+                return legacyPassword.length > 0
+                    ? { ...publicServer, encryptedPassword: { cipher: 'plaintext', value: legacyPassword } }
+                    : publicServer
+            }
+            return publicServer
+        }),
     }
 }
 
@@ -83,7 +124,7 @@ function load(): PersistedSettings {
     }
 
     try {
-        data = normalizeSettings(JSON.parse(file)) as PersistedSettings
+        data = decodeSettings(JSON.parse(file))
     } catch (_e) {
         data = createDefaultSettings() as PersistedSettings
         if (app.isReady()) {
@@ -147,7 +188,7 @@ export function put<K extends keyof PersistedSettings>(key: K, value: PersistedS
     }
 }
 
-export function getAllSettings(): AppSettings {
+export function getAllSettings(): AppSettings<RendererServerConfig> {
     const settings = normalizeSettings(load()) as PersistedSettings
     return {
         ...settings,
@@ -163,7 +204,7 @@ export function write() {
     saveSync()
 }
 
-export function saveAll(settings: AppSettings, callback?: (err?: Error | null) => void) {
+export function saveAll(settings: AppSettings<RendererServerConfig>, callback?: (err?: Error | null) => void) {
     const previousSettings = load()
     const previousServers = new Map(previousSettings.servers.map((server) => [server.id, server]))
     const normalized = normalizeSettings(settings)
@@ -178,16 +219,15 @@ export function saveAll(settings: AppSettings, callback?: (err?: Error | null) =
     }
 }
 
-function hasEncryptedPassword(value: unknown): value is EncryptedPassword {
+function isPersistedPassword(value: unknown): value is PersistedPassword {
     if (!value || typeof value !== 'object') {
         return false
     }
 
-    const encrypted = value as Partial<EncryptedPassword>
-    return encrypted.version === ENCRYPTED_PASSWORD_VERSION
-        && encrypted.provider === ENCRYPTED_PASSWORD_PROVIDER
-        && typeof encrypted.data === 'string'
-        && encrypted.data.length > 0
+    const password = value as Partial<PersistedPassword>
+    return (password.cipher === 'plaintext' || password.cipher === 'electron-safe-storage')
+        && typeof password.value === 'string'
+        && password.value.length > 0
 }
 
 function encryptionAvailable() {
@@ -198,125 +238,113 @@ function encryptionAvailable() {
     }
 }
 
-function encryptPassword(password: string): EncryptedPassword | null {
+function encryptSecurely(password: string): PersistedPassword | null {
     if (!encryptionAvailable()) {
         return null
     }
 
     try {
         return {
-            version: ENCRYPTED_PASSWORD_VERSION,
-            provider: ENCRYPTED_PASSWORD_PROVIDER,
-            data: safeStorage.encryptString(password).toString('base64'),
+            cipher: 'electron-safe-storage',
+            value: safeStorage.encryptString(password).toString('base64'),
         }
     } catch {
         return null
     }
 }
 
+function encryptPassword(password: string): PersistedPassword {
+    return encryptSecurely(password) || { cipher: 'plaintext', value: password }
+}
+
 function decryptPassword(server: PersistedServerConfig): string {
-    if (hasEncryptedPassword(server.encryptedPassword)) {
-        if (encryptionAvailable()) {
-            try {
-                return safeStorage.decryptString(Buffer.from(server.encryptedPassword.data, 'base64'))
-            } catch {
-                if (typeof server.password !== 'string') {
-                    throw new Error(`Could not decrypt the password for server ${server.id}`)
-                }
-            }
-        }
-
-        if (typeof server.password !== 'string') {
-            throw new Error(`Secure password storage is unavailable for server ${server.id}`)
-        }
+    const password = server.encryptedPassword
+    if (!password) {
+        return ''
     }
-
-    return typeof server.password === 'string' ? server.password : ''
+    if (password.cipher === 'plaintext') {
+        return password.value
+    }
+    if (!encryptionAvailable()) {
+        throw new Error('Stored password is unavailable; please re-enter it.')
+    }
+    try {
+        return safeStorage.decryptString(Buffer.from(password.value, 'base64'))
+    } catch {
+        throw new Error('Stored password is unavailable; please re-enter it.')
+    }
 }
 
 function hasPassword(server: PersistedServerConfig) {
-    return hasEncryptedPassword(server.encryptedPassword)
-        || (typeof server.password === 'string' && server.password.length > 0)
+    return isPersistedPassword(server.encryptedPassword)
 }
 
-function toRendererServer(server: PersistedServerConfig): StoredServerConfig {
+function toRendererServer(server: PersistedServerConfig): RendererServerConfig {
     const { encryptedPassword: _encryptedPassword, ...publicServer } = server
-    const passwordStored = hasPassword(server)
     return {
         ...publicServer,
-        password: passwordStored ? PASSWORD_MASK : '',
-        hasPassword: passwordStored,
+        hasPassword: hasPassword(server),
     }
 }
 
-function withStoredPassword(server: Omit<PersistedServerConfig, 'password' | 'encryptedPassword'>, password: string): PersistedServerConfig {
+function withStoredPassword(server: ServerConfigBase, password: string): PersistedServerConfig {
     if (!password) {
         return server
     }
 
-    const encryptedPassword = encryptPassword(password)
-    if (encryptedPassword) {
-        return { ...server, encryptedPassword }
-    }
-
-    return { ...server, password }
+    return { ...server, encryptedPassword: encryptPassword(password) }
 }
 
-function toPersistedServer(server: StoredServerConfig, previous?: PersistedServerConfig): PersistedServerConfig {
+function toPersistedServer(server: RendererServerConfig, previous?: PersistedServerConfig): PersistedServerConfig {
     const {
-        password,
+        newPassword,
         hasPassword: _hasPassword,
         encryptedPassword: _untrustedEncryptedPassword,
+        password: _untrustedPassword,
         ...publicServer
-    } = server as StoredServerConfig & { encryptedPassword?: unknown }
+    } = server as RendererServerConfig & { encryptedPassword?: unknown; password?: unknown }
 
-    if ((password === PASSWORD_MASK || password === undefined) && previous) {
-        const persisted = { ...publicServer } as PersistedServerConfig
-        if (hasEncryptedPassword(previous.encryptedPassword)) {
-            persisted.encryptedPassword = previous.encryptedPassword
-        }
-        if (typeof previous.password === 'string') {
-            persisted.password = previous.password
-        }
-        return persisted
+    if ((newPassword === PASSWORD_MASK || newPassword === undefined) && previous?.encryptedPassword) {
+        return { ...publicServer, encryptedPassword: previous.encryptedPassword }
     }
 
-    return withStoredPassword(publicServer, typeof password === 'string' ? password : '')
+    return withStoredPassword(publicServer, typeof newPassword === 'string' ? newPassword : '')
 }
 
 /** Encrypts legacy plaintext credentials once safeStorage becomes available after app ready. */
 export function migratePasswords(): boolean {
-    if (!encryptionAvailable()) {
-        return false
-    }
-
     const settings = load()
-    let changed = false
-    settings.servers = settings.servers.map((server) => {
-        if (typeof server.password !== 'string') {
+    let changed = needsSettingsRewrite
+    const servers = settings.servers.map((server) => {
+        if (server.encryptedPassword?.cipher !== 'plaintext') {
             return server
         }
 
-        const encryptedPassword = server.password ? encryptPassword(server.password) : server.encryptedPassword
-        if (server.password && !encryptedPassword) {
+        const encryptedPassword = encryptSecurely(server.encryptedPassword.value)
+        if (!encryptedPassword) {
             return server
         }
-
-        const { password: _password, ...publicServer } = server
         changed = true
-        return encryptedPassword ? { ...publicServer, encryptedPassword } : publicServer
+        return { ...server, encryptedPassword }
     })
 
     if (changed) {
-        saveSync()
-        notifyChanged()
+        const migrated = { ...settings, servers }
+        try {
+            fs.writeFileSync(CONF_PATH, JSON.stringify(migrated, null, 4))
+            data = migrated
+            needsSettingsRewrite = false
+            notifyChanged()
+        } catch {
+            return false
+        }
     }
     return changed
 }
 
 /** Resolves a renderer-safe server request into credentials only inside the main process. */
-export function resolveConnectionServer(server: BittorrentServerConfig): BittorrentServerConfig {
-    let password = server.password
+export function resolveConnectionServer(server: BittorrentConnectServer): ResolvedServerConfig {
+    let password = server.newPassword
     if (password === PASSWORD_MASK || password === undefined) {
         const persistedServer = load().servers.find((candidate) => candidate.id === server.id)
         password = persistedServer ? decryptPassword(persistedServer) : ''
@@ -324,9 +352,11 @@ export function resolveConnectionServer(server: BittorrentServerConfig): Bittorr
 
     const {
         hasPassword: _hasPassword,
+        newPassword: _newPassword,
         encryptedPassword: _untrustedEncryptedPassword,
+        password: _untrustedPassword,
         ...connectionServer
-    } = server as BittorrentServerConfig & { encryptedPassword?: unknown }
+    } = server as BittorrentConnectServer & { encryptedPassword?: unknown; password?: unknown }
     return { ...connectionServer, password }
 }
 

--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -1,13 +1,29 @@
-import { app, dialog, shell, type BrowserWindow, type MessageBoxOptions } from 'electron'
+import { app, dialog, safeStorage, shell, type BrowserWindow, type MessageBoxOptions } from 'electron'
 import fs from 'fs'
 import path from 'path'
 
-import type { AppSettings } from '@shared/ipc-contract'
+import type { AppSettings, BittorrentServerConfig, StoredServerConfig } from '@shared/ipc-contract'
 import { createDefaultSettings, normalizeSettings } from '@shared/settings-defaults'
 import * as electorrent from './electorrent'
 import type { StoredWindowState } from './window-state'
 
-export interface PersistedSettings extends AppSettings {
+const ENCRYPTED_PASSWORD_VERSION = 1
+const ENCRYPTED_PASSWORD_PROVIDER = 'electron-safe-storage'
+export const PASSWORD_MASK = '••••••••'
+
+export interface EncryptedPassword {
+    version: typeof ENCRYPTED_PASSWORD_VERSION
+    provider: typeof ENCRYPTED_PASSWORD_PROVIDER
+    data: string
+}
+
+export interface PersistedServerConfig extends Omit<StoredServerConfig, 'password' | 'hasPassword'> {
+    /** Backwards-compatible fallback used only when Electron safeStorage is unavailable. */
+    password?: string
+    encryptedPassword?: EncryptedPassword
+}
+
+export interface PersistedSettings extends AppSettings<PersistedServerConfig> {
     windowsize?: StoredWindowState
 }
 
@@ -55,21 +71,21 @@ function load(): PersistedSettings {
     }
 
     if (!fs.existsSync(CONF_PATH)) {
-        data = createDefaultSettings()
+        data = createDefaultSettings() as PersistedSettings
         return data
     }
 
     const file = fs.readFileSync(CONF_PATH, 'utf-8')
 
     if (!file) {
-        data = createDefaultSettings()
+        data = createDefaultSettings() as PersistedSettings
         return data
     }
 
     try {
-        data = normalizeSettings(JSON.parse(file))
+        data = normalizeSettings(JSON.parse(file)) as PersistedSettings
     } catch (_e) {
-        data = createDefaultSettings()
+        data = createDefaultSettings() as PersistedSettings
         if (app.isReady()) {
             showCorruptDialog()
         } else {
@@ -132,7 +148,11 @@ export function put<K extends keyof PersistedSettings>(key: K, value: PersistedS
 }
 
 export function getAllSettings(): AppSettings {
-    return normalizeSettings(load())
+    const settings = normalizeSettings(load()) as PersistedSettings
+    return {
+        ...settings,
+        servers: settings.servers.map(toRendererServer),
+    }
 }
 
 export function getDefaultSettings(): AppSettings {
@@ -144,11 +164,170 @@ export function write() {
 }
 
 export function saveAll(settings: AppSettings, callback?: (err?: Error | null) => void) {
-    data = normalizeSettings(settings)
+    const previousSettings = load()
+    const previousServers = new Map(previousSettings.servers.map((server) => [server.id, server]))
+    const normalized = normalizeSettings(settings)
+    data = {
+        ...normalized,
+        servers: normalized.servers.map((server) => toPersistedServer(server, previousServers.get(server.id))),
+        windowsize: previousSettings.windowsize,
+    }
     notifyChanged()
     if (callback !== undefined) {
         save(callback)
     }
+}
+
+function hasEncryptedPassword(value: unknown): value is EncryptedPassword {
+    if (!value || typeof value !== 'object') {
+        return false
+    }
+
+    const encrypted = value as Partial<EncryptedPassword>
+    return encrypted.version === ENCRYPTED_PASSWORD_VERSION
+        && encrypted.provider === ENCRYPTED_PASSWORD_PROVIDER
+        && typeof encrypted.data === 'string'
+        && encrypted.data.length > 0
+}
+
+function encryptionAvailable() {
+    try {
+        return safeStorage.isEncryptionAvailable()
+    } catch {
+        return false
+    }
+}
+
+function encryptPassword(password: string): EncryptedPassword | null {
+    if (!encryptionAvailable()) {
+        return null
+    }
+
+    try {
+        return {
+            version: ENCRYPTED_PASSWORD_VERSION,
+            provider: ENCRYPTED_PASSWORD_PROVIDER,
+            data: safeStorage.encryptString(password).toString('base64'),
+        }
+    } catch {
+        return null
+    }
+}
+
+function decryptPassword(server: PersistedServerConfig): string {
+    if (hasEncryptedPassword(server.encryptedPassword)) {
+        if (encryptionAvailable()) {
+            try {
+                return safeStorage.decryptString(Buffer.from(server.encryptedPassword.data, 'base64'))
+            } catch {
+                if (typeof server.password !== 'string') {
+                    throw new Error(`Could not decrypt the password for server ${server.id}`)
+                }
+            }
+        }
+
+        if (typeof server.password !== 'string') {
+            throw new Error(`Secure password storage is unavailable for server ${server.id}`)
+        }
+    }
+
+    return typeof server.password === 'string' ? server.password : ''
+}
+
+function hasPassword(server: PersistedServerConfig) {
+    return hasEncryptedPassword(server.encryptedPassword)
+        || (typeof server.password === 'string' && server.password.length > 0)
+}
+
+function toRendererServer(server: PersistedServerConfig): StoredServerConfig {
+    const { encryptedPassword: _encryptedPassword, ...publicServer } = server
+    const passwordStored = hasPassword(server)
+    return {
+        ...publicServer,
+        password: passwordStored ? PASSWORD_MASK : '',
+        hasPassword: passwordStored,
+    }
+}
+
+function withStoredPassword(server: Omit<PersistedServerConfig, 'password' | 'encryptedPassword'>, password: string): PersistedServerConfig {
+    if (!password) {
+        return server
+    }
+
+    const encryptedPassword = encryptPassword(password)
+    if (encryptedPassword) {
+        return { ...server, encryptedPassword }
+    }
+
+    return { ...server, password }
+}
+
+function toPersistedServer(server: StoredServerConfig, previous?: PersistedServerConfig): PersistedServerConfig {
+    const {
+        password,
+        hasPassword: _hasPassword,
+        encryptedPassword: _untrustedEncryptedPassword,
+        ...publicServer
+    } = server as StoredServerConfig & { encryptedPassword?: unknown }
+
+    if ((password === PASSWORD_MASK || password === undefined) && previous) {
+        const persisted = { ...publicServer } as PersistedServerConfig
+        if (hasEncryptedPassword(previous.encryptedPassword)) {
+            persisted.encryptedPassword = previous.encryptedPassword
+        }
+        if (typeof previous.password === 'string') {
+            persisted.password = previous.password
+        }
+        return persisted
+    }
+
+    return withStoredPassword(publicServer, typeof password === 'string' ? password : '')
+}
+
+/** Encrypts legacy plaintext credentials once safeStorage becomes available after app ready. */
+export function migratePasswords(): boolean {
+    if (!encryptionAvailable()) {
+        return false
+    }
+
+    const settings = load()
+    let changed = false
+    settings.servers = settings.servers.map((server) => {
+        if (typeof server.password !== 'string') {
+            return server
+        }
+
+        const encryptedPassword = server.password ? encryptPassword(server.password) : server.encryptedPassword
+        if (server.password && !encryptedPassword) {
+            return server
+        }
+
+        const { password: _password, ...publicServer } = server
+        changed = true
+        return encryptedPassword ? { ...publicServer, encryptedPassword } : publicServer
+    })
+
+    if (changed) {
+        saveSync()
+        notifyChanged()
+    }
+    return changed
+}
+
+/** Resolves a renderer-safe server request into credentials only inside the main process. */
+export function resolveConnectionServer(server: BittorrentServerConfig): BittorrentServerConfig {
+    let password = server.password
+    if (password === PASSWORD_MASK || password === undefined) {
+        const persistedServer = load().servers.find((candidate) => candidate.id === server.id)
+        password = persistedServer ? decryptPassword(persistedServer) : ''
+    }
+
+    const {
+        hasPassword: _hasPassword,
+        encryptedPassword: _untrustedEncryptedPassword,
+        ...connectionServer
+    } = server as BittorrentServerConfig & { encryptedPassword?: unknown }
+    return { ...connectionServer, password }
 }
 
 export function get<K extends keyof PersistedSettings>(key: K): PersistedSettings[K] | null {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -452,6 +452,7 @@ async function bootstrap() {
     })
 
     app.on('ready', function() {
+        settings.migratePasswords()
         queuePendingLaunchArgs(process.argv)
         configureSystemStartup(settings.getAllSettings().systemStartup)
         startedInBackground = shouldStartInBackground(settings.getAllSettings().systemStartup)

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,7 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 
 import { IPC_CHANNELS } from '@shared/ipc'
-import type { ColorTheme, ElectorrentBridge, PendingTorrentUploadFile, PendingTorrentUploadLink } from '@shared/ipc-contract'
+import type { AppSettings, BittorrentConnectRequest, BittorrentConnectResult, ColorTheme, ElectorrentBridge, PendingTorrentUploadFile, PendingTorrentUploadLink, RendererServerConfig, SettingsSaveAllRequest } from '@shared/ipc-contract'
 import type { TitleMenuItem } from '@shared/title-menu'
 
 const INITIAL_THEME_ARGUMENT = '--theme='
@@ -34,8 +34,8 @@ const electorrentBridge: ElectorrentBridge = {
         openExternal: (url: string) => invoke(IPC_CHANNELS.shell.openExternal, { url }),
     },
     settings: {
-        getAll: () => invoke(IPC_CHANNELS.settings.getAll),
-        saveAll: (settings) => invoke(IPC_CHANNELS.settings.saveAll, { settings }),
+        getAll: () => invoke<AppSettings<RendererServerConfig>>(IPC_CHANNELS.settings.getAll),
+        saveAll: (settings) => invoke<void>(IPC_CHANNELS.settings.saveAll, { settings } satisfies SettingsSaveAllRequest),
         listThemes: () => invoke(IPC_CHANNELS.settings.listThemes),
         getSystemTheme: () => invoke(IPC_CHANNELS.settings.getSystemTheme),
         onSystemThemeChanged: (callback: (theme: ColorTheme) => void) => subscribe(IPC_CHANNELS.settings.systemThemeChanged, callback),
@@ -52,7 +52,7 @@ const electorrentBridge: ElectorrentBridge = {
         getPathForFile: (file) => webUtils.getPathForFile(file),
     },
     bittorrent: {
-        connect: (server) => invoke(IPC_CHANNELS.bittorrent.connect, { server }),
+        connect: (server) => invoke<BittorrentConnectResult>(IPC_CHANNELS.bittorrent.connect, { server } satisfies BittorrentConnectRequest),
         disconnect: () => invoke(IPC_CHANNELS.bittorrent.disconnect),
         getSnapshot: (request) => invoke(IPC_CHANNELS.bittorrent.getSnapshot, request || {}),
         addTorrentUrl: (request) => invoke(IPC_CHANNELS.bittorrent.addTorrentUrl, request),

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -3,7 +3,7 @@ import type {
     ElectorrentBridge,
     BittorrentFileSelection,
     BittorrentTorrentPeer,
-    BittorrentServerConfig,
+    BittorrentConnectServer,
     TorrentClientConnection,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
@@ -15,7 +15,7 @@ function bridge() {
     return window.electorrent.bittorrent
 }
 
-export function serializeServer(server: any): BittorrentServerConfig {
+export function serializeServer(server: any): BittorrentConnectServer {
     const data = typeof server?.json === "function" ? server.json() : { ...server }
     const certificateData = typeof server?.getCertificate === "function"
         ? server.getCertificate()

--- a/src/renderer/app/directives/connection-form/connection-form.template.html
+++ b/src/renderer/app/directives/connection-form/connection-form.template.html
@@ -34,7 +34,7 @@
             <label ng-if="showLabels">Password</label>
             <div class="ui left icon input">
                 <i class="lock icon"></i>
-                <input type="password" id="connection-password" name="password" ng-model="server.password" placeholder="Password" />
+                <input type="password" id="connection-password" name="password" ng-model="server.newPassword" placeholder="Password" />
             </div>
         </div>
     </div>

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -4,10 +4,10 @@ import { Torrent } from "@renderer/app/bittorrent"
 import type { ColumnProps } from "@renderer/app/services/column"
 import { parseServerAddressInput, sanitizeServerAddress } from "@shared/server-address"
 import type { CertificateResponseService } from "@renderer/app/services/certificate-response"
-import type { LabelColorHue, LabelColorOverrides, SavedLocationConfig, StoredServerConfig, TorrentUploadOptions } from "@shared/ipc-contract"
+import { PASSWORD_MASK, type LabelColorHue, type LabelColorOverrides, type RendererServerConfig, type SavedLocationConfig, type TorrentUploadOptions } from "@shared/ipc-contract"
 import { normalizeLabelColorHue } from "@renderer/app/services/label-colors"
 
-export interface Server extends Omit<StoredServerConfig, "columns"> {
+export interface Server extends Omit<RendererServerConfig, "columns"> {
     columns: ColumnProps[]
     certificateData?: Uint8Array
     isConnected: boolean
@@ -30,7 +30,8 @@ export interface Server extends Omit<StoredServerConfig, "columns"> {
     defaultColumns(): ColumnProps[]
     addCustomColumns(columns: ColumnProps[]): ColumnProps[]
     bootstrap(): void
-    json(): StoredServerConfig
+    json(): RendererServerConfig
+    markPasswordSaved(): void
 }
 
 export const serverService = ['$q', 'notificationService', '$bittorrent', '$btclients', 'certificateResponseService',
@@ -89,7 +90,8 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
                 this.proto = proto
                 this.port = port
                 this.user = user || ''
-                this.password = password || ''
+                this.hasPassword = false
+                this.newPassword = password || undefined
                 this.client = client
                 this.path = path
                 this.lastused = -1
@@ -140,7 +142,8 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
             this.proto = data.proto || "http"
             this.port = data.port
             this.user = data.user || ''
-            this.password = data.password || ''
+            this.hasPassword = data.hasPassword === true
+            this.newPassword = this.hasPassword ? PASSWORD_MASK : undefined
             this.client = data.client
             this.path = data.path || ''
             this.default = data.default
@@ -156,14 +159,14 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
         };
 
         Server.prototype.json = function() {
-            return {
+            const server: RendererServerConfig = {
                 name: this.name,
                 id: this.id,
                 ip: this.ip,
                 proto: this.proto,
                 port: this.port,
                 user: this.user,
-                password: this.password,
+                hasPassword: this.hasPassword === true,
                 client: this.client,
                 path: this.path,
                 default: this.default,
@@ -176,7 +179,18 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
                 defaultUploadOptions: normalizeDefaultUploadOptions(this.defaultUploadOptions),
                 labelColors: normalizeLabelColors(this.labelColors),
             }
+            if (typeof this.newPassword === 'string' && this.newPassword !== PASSWORD_MASK) {
+                server.newPassword = this.newPassword
+            }
+            return server
         };
+
+        Server.prototype.markPasswordSaved = function() {
+            if (typeof this.newPassword === 'string' && this.newPassword !== PASSWORD_MASK) {
+                this.hasPassword = this.newPassword.length > 0
+            }
+            this.newPassword = this.hasPassword ? PASSWORD_MASK : undefined
+        }
 
         Server.prototype.getName = function() {
             return $btclients[this.client]?.name || `Unknown client (${this.client || "missing client ID"})`
@@ -285,9 +299,10 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
         Server.prototype.askForCertificate = function() {
             const self = this
             const response = certificateResponseService.wait(self.id)
+            const { newPassword: _newPassword, ...server } = self.json()
 
             electorrent.certificates.fetch({
-                server: self.json() as StoredServerConfig,
+                server,
             }).catch((err: unknown) => {
                 certificateResponseService.reject(self.id, err)
             })
@@ -318,7 +333,7 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
                 this.proto === other.proto &&
                 this.port === other.port &&
                 this.user === other.user &&
-                this.password === other.password &&
+                this.newPassword === other.newPassword &&
                 this.client === other.client &&
                 this.path === other.path &&
                 this.certificate === other.certificate &&

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -1,5 +1,5 @@
 import { IRootScopeService } from "angular";
-import type { AppSettings, StoredServerConfig } from "@shared/ipc-contract";
+import type { AppSettings, RendererServerConfig } from "@shared/ipc-contract";
 import { createDefaultSettings } from "@shared/settings-defaults";
 import type { Server } from "@renderer/app/services/server";
 
@@ -68,7 +68,7 @@ export const settingsService = ['$rootScope', '$bittorrent', 'notificationServic
         }
     }
 
-    const readyPromise = electorrent.settings.getAll().then((org: AppSettings<StoredServerConfig>) => {
+    const readyPromise = electorrent.settings.getAll().then((org: AppSettings<RendererServerConfig>) => {
         mergeSettings(org)
         return loadServerCertificates(settings.servers).then(() => settings)
     });
@@ -150,6 +150,7 @@ export const settingsService = ['$rootScope', '$bittorrent', 'notificationServic
             mergeSettings(newSettings)
         }
         return loadServerCertificates(settings.servers).then(() => electorrent.settings.saveAll(settingsToJson())).then(function() {
+            settings.servers.forEach((server) => server.markPasswordSaved())
             updateServerReference()
         });
     }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -71,7 +71,9 @@ export type ParseTorrentRequest =
 
 export type TlsSecurity = "default" | "insecure"
 
-export interface BittorrentServerConfig extends StoredServerConfig {
+export const PASSWORD_MASK = '••••••••'
+
+export interface BittorrentConnectServer extends RendererServerConfig {
     certificateData?: Uint8Array
 }
 
@@ -182,16 +184,13 @@ export type LabelColorHue = number
 
 export type LabelColorOverrides = Partial<Record<string, LabelColorHue>>
 
-export interface StoredServerConfig {
+export interface ServerConfigBase {
     name?: string
     id: string
     ip: string
     proto: string
     port: number
     user: string
-    password: string
-    /** True when the masked password represents a credential held by the main process. */
-    hasPassword?: boolean
     client: string
     path: string
     default?: boolean
@@ -203,6 +202,12 @@ export interface StoredServerConfig {
     defaultUploadOptionsEnabled?: boolean
     defaultUploadOptions?: TorrentUploadOptions
     labelColors?: LabelColorOverrides
+}
+
+/** Renderer-safe server data. `newPassword` is submission-only and never returned by main. */
+export interface RendererServerConfig extends ServerConfigBase {
+    hasPassword: boolean
+    newPassword?: string
 }
 
 export interface SavedLocationConfig {
@@ -274,6 +279,10 @@ export type BittorrentConnectResult =
     | { readonly ok: true; readonly connection: TorrentClientConnection }
     | { readonly ok: false; readonly error: BittorrentConnectionError }
 
+export interface BittorrentConnectRequest {
+    server: BittorrentConnectServer
+}
+
 export interface ResolvedTorrentClientFeatures {
     readonly magnetLinks: boolean
     readonly labels: boolean
@@ -291,7 +300,7 @@ export interface ResolvedTorrentClientFeatures {
     readonly uploadOptions: Readonly<Required<Record<keyof TorrentUploadOptions, boolean>>>
 }
 
-export interface AppSettings<TServer = StoredServerConfig> {
+export interface AppSettings<TServer = RendererServerConfig> {
     startup: string
     systemStartup: SystemStartupOption
     refreshRate: number
@@ -313,6 +322,10 @@ export interface AppSettings<TServer = StoredServerConfig> {
     }
     servers: TServer[]
     certificates: string[]
+}
+
+export interface SettingsSaveAllRequest {
+    settings: AppSettings<RendererServerConfig>
 }
 
 export interface UpdateEvent {
@@ -349,7 +362,7 @@ export interface CertificatePrompt {
 }
 
 export interface CertificateFetchRequest {
-    server: StoredServerConfig
+    server: RendererServerConfig
 }
 
 export interface CertificateInstallRequest {
@@ -405,8 +418,8 @@ export interface ElectorrentBridge {
         openExternal(url: string): Promise<void>
     }
     settings: {
-        getAll(): Promise<AppSettings>
-        saveAll(settings: AppSettings): Promise<void>
+        getAll(): Promise<AppSettings<RendererServerConfig>>
+        saveAll(settings: AppSettings<RendererServerConfig>): Promise<void>
         listThemes(): Promise<ThemeInfo[]>
         getSystemTheme(): Promise<ColorTheme>
         onSystemThemeChanged(callback: (theme: ColorTheme) => void): Unsubscribe
@@ -423,7 +436,7 @@ export interface ElectorrentBridge {
         getPathForFile(file: File): string
     }
     bittorrent: {
-        connect(server: BittorrentServerConfig): Promise<BittorrentConnectResult>
+        connect(server: BittorrentConnectServer): Promise<BittorrentConnectResult>
         disconnect(): Promise<void>
         getSnapshot(request?: BittorrentSnapshotRequest): Promise<any>
         addTorrentUrl(request: BittorrentAddTorrentUrlRequest): Promise<void>

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -190,6 +190,8 @@ export interface StoredServerConfig {
     port: number
     user: string
     password: string
+    /** True when the masked password represents a credential held by the main process. */
+    hasPassword?: boolean
     client: string
     path: string
     default?: boolean

--- a/src/shared/title-menu.ts
+++ b/src/shared/title-menu.ts
@@ -1,5 +1,5 @@
 import { CLIENT_METADATA } from "./client-metadata"
-import type { AppSettings, EditCommand, MenuAction, StoredServerConfig, Unsubscribe, WindowCommand } from "./ipc-contract"
+import type { AppSettings, EditCommand, MenuAction, RendererServerConfig, Unsubscribe, WindowCommand } from "./ipc-contract"
 import type { TorrentActionItem } from "./torrent-actions"
 
 export type TitleMenuPlatform = "darwin" | "linux" | "win32"
@@ -80,7 +80,7 @@ function serverAccelerator(index: number, platform: TitleMenuPlatform) {
     return `${platform === "darwin" ? "CmdOrCtrl" : "Ctrl"}+${index % 10}`
 }
 
-function getServerLabel(server: StoredServerConfig) {
+function getServerLabel(server: RendererServerConfig) {
     const clientName = CLIENT_METADATA[server.client as keyof typeof CLIENT_METADATA]?.name || server.client || "Server"
     return server.name || `${clientName} @ ${server.ip || "unknown host"}`
 }

--- a/test/specs/standard/connection.spec.ts
+++ b/test/specs/standard/connection.spec.ts
@@ -1,5 +1,7 @@
 import chai from "chai"
-import { $ } from "@wdio/globals"
+import fs from "node:fs"
+import path from "node:path"
+import { $, browser } from "@wdio/globals"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec, getTestFixture } from "../../framework/fixture"
 import { restartApplication } from "../../shared"
@@ -11,7 +13,7 @@ const TORRENT_PAGE_FAILURE_TEST_TIMEOUT = HTTP_REQUEST_TIMEOUT + CONNECT_FAILURE
 const CONNECT_FAILURE_TEST_TIMEOUT = CONNECT_FAILURE_TIMEOUT + CONNECT_FAILURE_BUFFER + 10 * 1000
 const CONNECTION_SPEC_TIMEOUT = Math.max(CONNECT_FAILURE_TEST_TIMEOUT, TORRENT_PAGE_FAILURE_TEST_TIMEOUT)
 
-const { assert } = chai
+const assert: Chai.AssertStatic = chai.assert
 const fixture = getTestFixture()
 const client = fixture.client
 const backend = fixture.backend
@@ -23,6 +25,36 @@ describe("connection", function () {
   it("automatically reconnects after restarting the app", async function () {
     await restartApplication(this)
     await this.app.torrentsPageIsVisible()
+  })
+
+  it("keeps stored passwords out of renderer settings", async function () {
+    const rendererServer = await browser.execute(async () => {
+      const settings = await (window as any).electorrent.settings.getAll()
+      return settings.servers[0]
+    })
+
+    assert.equal(rendererServer.password, "••••••••")
+    assert.isTrue(rendererServer.hasPassword)
+    assert.notProperty(rendererServer, "encryptedPassword")
+
+    const storage = await browser.electron.execute((electron) => ({
+      available: electron.safeStorage.isEncryptionAvailable(),
+      userDataPath: electron.app.getPath("userData"),
+    }))
+    const persistedSettings = JSON.parse(fs.readFileSync(path.join(storage.userDataPath, "config.json"), "utf8"))
+    const persistedServer = persistedSettings.servers[0]
+
+    if (storage.available) {
+      assert.notProperty(persistedServer, "password")
+      assert.deepInclude(persistedServer.encryptedPassword, {
+        version: 1,
+        provider: "electron-safe-storage",
+      })
+      assert.isNotEmpty(persistedServer.encryptedPassword.data)
+    } else {
+      assert.equal(persistedServer.password, client.password)
+      assert.notProperty(persistedServer, "encryptedPassword")
+    }
   })
 
   it("shows a connection indicator before the disconnect overlay on the torrent page", async function () {
@@ -55,7 +87,7 @@ describe("connection", function () {
       assert.equal(await $("#page-settings-connection input[name='ip']").getValue(), client.host)
       assert.equal(await $("#page-settings-connection input[name='port']").getValue(), String(client.port))
       assert.equal(await $("#page-settings-connection input[name='username']").getValue(), client.username)
-      assert.equal(await $("#page-settings-connection input[name='password']").getValue(), client.password)
+      assert.equal(await $("#page-settings-connection input[name='password']").getValue(), "••••••••")
     } finally {
       await backend.unpause()
     }

--- a/test/specs/standard/connection.spec.ts
+++ b/test/specs/standard/connection.spec.ts
@@ -17,6 +17,7 @@ const assert: Chai.AssertStatic = chai.assert
 const fixture = getTestFixture()
 const client = fixture.client
 const backend = fixture.backend
+const expectedPassword = client.password ? "••••••••" : ""
 
 describe("connection", function () {
   this.timeout(CONNECTION_SPEC_TIMEOUT)
@@ -33,8 +34,8 @@ describe("connection", function () {
       return settings.servers[0]
     })
 
-    assert.equal(rendererServer.password, "••••••••")
-    assert.isTrue(rendererServer.hasPassword)
+    assert.equal(rendererServer.password, expectedPassword)
+    assert.equal(rendererServer.hasPassword, Boolean(client.password))
     assert.notProperty(rendererServer, "encryptedPassword")
 
     const storage = await browser.electron.execute((electron) => ({
@@ -44,7 +45,10 @@ describe("connection", function () {
     const persistedSettings = JSON.parse(fs.readFileSync(path.join(storage.userDataPath, "config.json"), "utf8"))
     const persistedServer = persistedSettings.servers[0]
 
-    if (storage.available) {
+    if (!client.password) {
+      assert.notProperty(persistedServer, "password")
+      assert.notProperty(persistedServer, "encryptedPassword")
+    } else if (storage.available) {
       assert.notProperty(persistedServer, "password")
       assert.deepInclude(persistedServer.encryptedPassword, {
         version: 1,
@@ -87,7 +91,7 @@ describe("connection", function () {
       assert.equal(await $("#page-settings-connection input[name='ip']").getValue(), client.host)
       assert.equal(await $("#page-settings-connection input[name='port']").getValue(), String(client.port))
       assert.equal(await $("#page-settings-connection input[name='username']").getValue(), client.username)
-      assert.equal(await $("#page-settings-connection input[name='password']").getValue(), "••••••••")
+      assert.equal(await $("#page-settings-connection input[name='password']").getValue(), expectedPassword)
     } finally {
       await backend.unpause()
     }

--- a/test/specs/standard/connection.spec.ts
+++ b/test/specs/standard/connection.spec.ts
@@ -34,8 +34,9 @@ describe("connection", function () {
       return settings.servers[0]
     })
 
-    assert.equal(rendererServer.password, expectedPassword)
     assert.equal(rendererServer.hasPassword, Boolean(client.password))
+    assert.notProperty(rendererServer, "password")
+    assert.notProperty(rendererServer, "newPassword")
     assert.notProperty(rendererServer, "encryptedPassword")
 
     const storage = await browser.electron.execute((electron) => ({
@@ -51,14 +52,43 @@ describe("connection", function () {
     } else if (storage.available) {
       assert.notProperty(persistedServer, "password")
       assert.deepInclude(persistedServer.encryptedPassword, {
-        version: 1,
-        provider: "electron-safe-storage",
+        cipher: "electron-safe-storage",
       })
-      assert.isNotEmpty(persistedServer.encryptedPassword.data)
+      assert.isNotEmpty(persistedServer.encryptedPassword.value)
     } else {
-      assert.equal(persistedServer.password, client.password)
-      assert.notProperty(persistedServer, "encryptedPassword")
+      assert.notProperty(persistedServer, "password")
+      assert.deepEqual(persistedServer.encryptedPassword, {
+        cipher: "plaintext",
+        value: client.password,
+      })
     }
+  })
+
+  it("migrates a legacy plaintext password into the password envelope", async function () {
+    if (!client.password) {
+      this.skip()
+    }
+
+    const storage = await browser.electron.execute((electron) => ({
+      available: electron.safeStorage.isEncryptionAvailable(),
+      userDataPath: electron.app.getPath("userData"),
+    }))
+    const configPath = path.join(storage.userDataPath, "config.json")
+    const legacySettings = JSON.parse(fs.readFileSync(configPath, "utf8"))
+    delete legacySettings.servers[0].encryptedPassword
+    legacySettings.servers[0].password = client.password
+    fs.writeFileSync(configPath, JSON.stringify(legacySettings, null, 4))
+
+    await restartApplication(this)
+    await this.app.torrentsPageIsVisible()
+
+    const migratedServer = JSON.parse(fs.readFileSync(configPath, "utf8")).servers[0]
+    assert.notProperty(migratedServer, "password")
+    assert.equal(
+      migratedServer.encryptedPassword.cipher,
+      storage.available ? "electron-safe-storage" : "plaintext",
+    )
+    assert.isNotEmpty(migratedServer.encryptedPassword.value)
   })
 
   it("shows a connection indicator before the disconnect overlay on the torrent page", async function () {


### PR DESCRIPTION
## What changed

- separate server configuration into renderer-safe, persisted, and resolved main-process domains
- use renderer-only `hasPassword` state and transient `newPassword` submissions; settings responses contain no password fields
- persist every configured password under a cipher-discriminated `encryptedPassword` envelope
  - `{ cipher: "electron-safe-storage", value }` when Electron secure storage is available
  - `{ cipher: "plaintext", value }` as the unsupported-runtime fallback
- resolve required plaintext `password` values only inside main before passing configs to BitTorrent runtimes
- strongly type the settings read/save and connect IPC boundaries
- migrate legacy top-level plaintext and the earlier versioned safeStorage envelope
- retry plaintext-to-safeStorage migration non-fatally and preserve undecryptable secure values for password re-entry

## Why

Renderer, persistence, and runtime configuration previously overloaded the same password field and relied on masks as data. Distinct domain fields and types make the trust boundary explicit: renderer code can submit a replacement but cannot receive stored secrets, persisted data contains only cipher envelopes, and BitTorrent clients receive only a fully resolved main-process config.

## Impact

Existing configurations migrate automatically. Password changes are tested by connecting before they are persisted, unchanged credentials are preserved by omission, empty replacements clear the credential, and runtimes without secure storage retain interoperable plaintext envelopes for later migration.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/connection.spec.ts"` — 5 passing
- `npm run test -- --client "utorrent" --spec "test/specs/standard/connection.spec.ts"` — 4 passing
- `git diff --check`