### PR TITLE
feat(torrents): add upload total column

### DIFF
--- a/src/renderer/app/bittorrent/abstracttorrent.ts
+++ b/src/renderer/app/bittorrent/abstracttorrent.ts
@@ -253,6 +253,13 @@ export abstract class Torrent implements TorrentProps {
       attribute: 'uploadSpeed'
     })
 
+    static COL_UPLOAD_TOTAL = new Column({
+      name: 'Upload total',
+      enabled: false,
+      template: '{{torrent.uploaded | bytes}}',
+      attribute: 'uploaded'
+    })
+
     static COL_DOWNLIMIT = new Column({
       name: 'Down Limit',
       enabled: false,
@@ -345,6 +352,7 @@ export abstract class Torrent implements TorrentProps {
         Torrent.COL_SIZE,
         Torrent.COL_DOWNSPEED,
         Torrent.COL_UPSPEED,
+        Torrent.COL_UPLOAD_TOTAL,
         Torrent.COL_PROGRESS,
         Torrent.COL_LABEL,
         Torrent.COL_DATEADDED,

--- a/src/renderer/app/bittorrent/qbittorrent/torrentq.ts
+++ b/src/renderer/app/bittorrent/qbittorrent/torrentq.ts
@@ -59,7 +59,7 @@ export class QBittorrentTorrent extends Torrent {
             size: data.size || data.total_size,
             percent: data.progress && (data.progress * 1000),
             downloaded: data.total_downloaded,
-            uploaded: data.total_uploaded,
+            uploaded: data.total_uploaded ?? data.uploaded,
             ratio: data.share_ration || data.ratio,
             ratioLimit: data.ratio_limit,
             uploadSpeed: data.up_speed || data.upspeed,
@@ -84,7 +84,7 @@ export class QBittorrentTorrent extends Torrent {
         this.pieceSize = data.piece_size;
         this.comment = data.comment;
         this.totalWasted = data.total_wasted;
-        this.uploadedSession = data.total_uploaded_session;
+        this.uploadedSession = data.total_uploaded_session ?? data.uploaded_session;
         this.downloadedSession = data.total_downloaded_session;
         this.upLimit = data.up_limit;
         this.downLimit = data.dl_limit;

--- a/test/e2e/e2e_torrent.ts
+++ b/test/e2e/e2e_torrent.ts
@@ -4,7 +4,7 @@ import { browser, $, $$ } from '@wdio/globals'
 import { eventually } from "./eventually"
 import { waitForModalClose, waitForModalOpen } from "./modal"
 
-export type ColumnName = "decodedName" | "size" | "downloadSpeed" | "uploadSpeed" | "downloadLimit" | "uploadLimit" | "percent" | "label" | "dateAdded" | "dateCompleted" | "peersConnected" | "seedsConnected" | "torrentQueueOrder" | "eta" | "ratio" | "ratioLimit"
+export type ColumnName = "decodedName" | "size" | "downloadSpeed" | "uploadSpeed" | "uploaded" | "downloadLimit" | "uploadLimit" | "percent" | "label" | "dateAdded" | "dateCompleted" | "peersConnected" | "seedsConnected" | "torrentQueueOrder" | "eta" | "ratio" | "ratioLimit"
 
 export class Torrent {
   app: App

--- a/test/specs/standard/torrent-columns.spec.ts
+++ b/test/specs/standard/torrent-columns.spec.ts
@@ -16,6 +16,7 @@ const builtInColumns = [
   "Size",
   "Down",
   "Up",
+  "Upload total",
   "Progress",
   "Label",
   "Date Added",
@@ -81,6 +82,10 @@ describe("torrent columns", function () {
 
   it("shows a sensible Up column value", async function () {
     assertSpeed((await torrent.getColumn("uploadSpeed")).trim())
+  })
+
+  it("shows a sensible Upload total column value", async function () {
+    assert.match((await torrent.getColumn("uploaded")).trim(), /^\d+(?:\.\d+)? [KMGT]?B$/)
   })
 
   it("shows a sensible Progress column value", async function () {


### PR DESCRIPTION
## Summary

- add an optional, disabled-by-default `Upload total` torrent column
- render cumulative uploaded bytes for every client implementation that exposes the value
- support current qBittorrent `uploaded` and `uploaded_session` fields while retaining legacy fallbacks
- extend the standard torrent column test with a formatted-byte assertion

## Client mappings

- qBittorrent: `uploaded` / legacy `total_uploaded`
- µTorrent: `uploaded`
- aria2: `uploadLength`
- Deluge: `total_uploaded`
- rTorrent: `d.up.total` → `up_total`
- Transmission: `uploadedEver`
- Synology Download Station: `additional.transfer.size_uploaded`

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-columns.spec.ts"` (16 passing)