### PR TITLE
fix(test): run Electron tests headlessly

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -207,7 +207,7 @@ async function bootstrap() {
         menu.setWindow(torrentWindow)
 
         torrentWindow.once('ready-to-show', () => {
-            if (!startInBackground) {
+            if (!startInBackground && !app.commandLine.hasSwitch('headless')) {
                 torrentWindow?.show()
             }
         })

--- a/test/specs/mock/headless-window.spec.ts
+++ b/test/specs/mock/headless-window.spec.ts
@@ -1,0 +1,22 @@
+import chai from "chai"
+import { browser } from "@wdio/globals"
+import { configureSpec } from "../../framework/fixture"
+
+const assert: Chai.AssertStatic = chai.assert
+
+describe("headless window", function () {
+  configureSpec({ login: false })
+
+  it("keeps the application window hidden when Electron is launched headless", async function () {
+    const state = await browser.electron.execute((electron) => ({
+      isHeadless: electron.app.commandLine.hasSwitch("headless"),
+      isVisible: electron.BrowserWindow.getAllWindows().some((window) => window.isVisible()),
+    }))
+
+    if (!state.isHeadless) {
+      return this.skip()
+    }
+
+    assert.isFalse(state.isVisible)
+  })
+})

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -11,6 +11,7 @@ const standardSpecs = [
     'test/specs/standard/**/*.spec.ts',
 ]
 const useDistribution = process.argv.includes('--dist')
+const useHeadless = process.argv.includes('--headless')
 
 function requestedClients() {
     return process.argv.flatMap((argument, index, arguments_) => {
@@ -41,7 +42,10 @@ function electronCapability(client: (typeof selectedClients)[number]): Webdriver
         'electorrent:client': client,
         'wdio:electronServiceOptions': {
             ...useDistribution ? {} : { appEntryPoint: 'app/main.js' },
-            appArgs: client.appArgs ?? [],
+            appArgs: [
+                ...(client.appArgs ?? []),
+                ...(useHeadless ? ['--headless'] : []),
+            ],
         },
         'goog:chromeOptions': {
             args: [


### PR DESCRIPTION
## Summary

- forward WDIO's `--headless` CLI option to Electron through `appArgs`
- preserve client-specific application arguments
- keep Electorrent's `BrowserWindow` hidden during headless execution
- cover hidden-window behavior with a regression spec

## Root cause

WDIO accepts `--headless`, but its generic capability handling does not inject the flag for capabilities declared with `browserName: "electron"`. After forwarding the flag, Electorrent's `ready-to-show` handler still explicitly called `BrowserWindow.show()`, producing a visible blurred window on macOS.

## Impact

The macOS WDIO suite can render and receive WebDriver interactions without opening or focusing an application window. Headed behavior remains unchanged when `--headless` is omitted.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --client mock --spec test/specs/mock/headless-window.spec.ts --headless` (1 passing)
- `npm test -- --client mock --spec test/specs/mock/actions-menu.spec.ts --headless` (6 passing)