### PR TITLE
feat(security): protect stored passwords

### DIFF
--- a/src/main/lib/bittorrent/clients/aria2/index.ts
+++ b/src/main/lib/bittorrent/clients/aria2/index.ts
@@ -2,7 +2,7 @@ import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import { HTTP_LOGIN_TIMEOUT } from "@main/lib/bittorrent/helpers"
 import type {
     BittorrentFileSelection,
-    BittorrentServerConfig,
+    ResolvedServerConfig,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentDetailsTracker,
@@ -235,7 +235,7 @@ export class Aria2Runtime implements BittorrentRuntime {
 
     private rpc?: Aria2JsonRpcTransport
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.rpc = new Aria2JsonRpcTransport(server)
         const result = await this.rpc.call<{ version?: string }>("aria2.getVersion", [], HTTP_LOGIN_TIMEOUT)
         if (typeof result?.version !== "string" || !result.version.trim()) {

--- a/src/main/lib/bittorrent/clients/aria2/json-rpc.ts
+++ b/src/main/lib/bittorrent/clients/aria2/json-rpc.ts
@@ -3,7 +3,7 @@ import httpAdapter from "axios/lib/adapters/http.js"
 import https from "node:https"
 
 import { HTTP_REQUEST_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
-import type { BittorrentServerConfig } from "@shared/ipc-contract"
+import type { ResolvedServerConfig } from "@shared/ipc-contract"
 
 export interface Aria2RpcCall {
     method: string
@@ -66,7 +66,7 @@ export class Aria2JsonRpcTransport {
     private readonly endpoint: string
     private readonly secret: string
 
-    constructor(server: BittorrentServerConfig) {
+    constructor(server: ResolvedServerConfig) {
         this.endpoint = serverUrl(server)
         this.secret = server.password || ""
         this.http = axios.create({

--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,7 @@
 import request from "request"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, ResolvedServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
 import {
     defer,
     HTTP_LOGIN_TIMEOUT,
@@ -75,7 +75,7 @@ export class DelugeRuntime implements BittorrentRuntime {
         { role: "remove", label: "Remove", action: "remove", icon: "remove" },
         { label: "Remove and delete", action: "removeAndDelete", icon: "trash", role: "delete" },
     ]
-    private url(server: BittorrentServerConfig, endpoint?: string) {
+    private url(server: ResolvedServerConfig, endpoint?: string) {
         return serverUrl(server, endpoint)
     }
 
@@ -224,7 +224,7 @@ export class DelugeRuntime implements BittorrentRuntime {
         return defer<any[]>((done) => this.rpc("web.get_hosts", [], done))
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.rpcUrl = this.url(server, "json")
         this.uploadUrl = this.url(server, "upload")
         this.requestId = 0

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -1,6 +1,6 @@
 import type {
     BittorrentFileSelection,
-    BittorrentServerConfig,
+    ResolvedServerConfig,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
@@ -95,7 +95,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
     private connected = false
     private store?: MockRuntimeStore
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         const key = this.getServerKey(server)
         let store = MockBittorrentRuntime.stores.get(key)
         if (!store) {
@@ -665,7 +665,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
         return this.store!.removedHashes
     }
 
-    private getServerKey(server: BittorrentServerConfig) {
+    private getServerKey(server: ResolvedServerConfig) {
         return server.id || `${server.client}:${server.proto}://${server.ip}:${server.port}${server.path || ""}`
     }
 }

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -4,7 +4,7 @@ import parseTorrent from "parse-torrent"
 
 import type {
     BittorrentFileSelection,
-    BittorrentServerConfig,
+    ResolvedServerConfig,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
@@ -136,7 +136,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         { role: "remove", label: "Remove", action: "delete", icon: "remove" },
         { label: "Remove And Delete", action: "deleteAndRemove", icon: "trash", role: "delete" },
     ]
-    private url(server: BittorrentServerConfig, endpoint?: string) {
+    private url(server: ResolvedServerConfig, endpoint?: string) {
         return serverUrl(server, endpoint)
     }
 
@@ -146,7 +146,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
 
     private torrentCache = new Map<string, Record<string, any>>()
 
-    private async selectApi(server: BittorrentServerConfig) {
+    private async selectApi(server: ResolvedServerConfig) {
         const origin = serverOriginUrl(server)
         const requestOptions = {
             timeout: HTTP_LOGIN_TIMEOUT,
@@ -191,7 +191,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
         return this.api
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         const api = await this.selectApi(server)
         this.api = api
         await defer((done) => api.login(done))

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -3,7 +3,7 @@ import { URL } from "node:url"
 import xmlrpc from "@electorrent/xmlrpc"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFileSelection, ResolvedServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
 import { defer, HTTP_LOGIN_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import type { TorrentActionItem } from "@shared/torrent-actions"
@@ -40,7 +40,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
     ]
     private client: any
 
-    private url(server: BittorrentServerConfig) {
+    private url(server: ResolvedServerConfig) {
         return server.path ? serverUrl(server) : serverUrl(server, "RPC2")
     }
 
@@ -197,7 +197,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         await this.getMulticallHashes(hashes, commands, params)
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         const rpcUrl = new URL(this.url(server))
         const options: Record<string, any> = {
             host: rpcUrl.hostname.replace(/^\[|\]$/g, ""),

--- a/src/main/lib/bittorrent/clients/synology.ts
+++ b/src/main/lib/bittorrent/clients/synology.ts
@@ -3,7 +3,7 @@ import httpAdapter from 'axios/lib/adapters/http.js'
 import FormData from 'form-data'
 import https from 'https'
 
-import type { BittorrentServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
+import type { ResolvedServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -55,7 +55,7 @@ export class SynologyRuntime implements BittorrentRuntime {
         { role: "set-location", label: "Set Location", icon: "folder open" },
         { role: "remove", label: "Remove Torrent", action: "remove", icon: "remove" },
     ]
-    private server!: BittorrentServerConfig
+    private server!: ResolvedServerConfig
     private http!: AxiosInstance
     private authPath = ''
     private authVersion = ''
@@ -180,7 +180,7 @@ export class SynologyRuntime implements BittorrentRuntime {
         return !!data?.success
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.server = server
         this.http = axios.create({
             httpsAgent: new https.Agent({

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import https from 'https'
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from '@shared/ipc-contract'
+import type { ResolvedServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -115,7 +115,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
             { label: "Torrent and Local Data", action: "removeAndLocal", icon: "remove", role: "delete" },
         ] },
     ]
-    private server!: BittorrentServerConfig
+    private server!: ResolvedServerConfig
     private session?: string
 
     private url(endpoint = '') {
@@ -196,7 +196,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
         return http
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.server = server
         this.session = undefined
 

--- a/src/main/lib/bittorrent/clients/utorrent.ts
+++ b/src/main/lib/bittorrent/clients/utorrent.ts
@@ -5,7 +5,7 @@ import FormData from 'form-data'
 import https from 'https'
 import qs from 'qs'
 
-import type { BittorrentServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
+import type { ResolvedServerConfig, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -31,7 +31,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
             { label: "Delete All", action: "removedatatorrent", role: "delete" },
         ] },
     ]
-    private server!: BittorrentServerConfig
+    private server!: ResolvedServerConfig
     private http!: AxiosInstance
     private data = {
         username: '',
@@ -104,7 +104,7 @@ export class UtorrentRuntime implements BittorrentRuntime {
         }
     }
 
-    async connect(server: BittorrentServerConfig): Promise<TorrentClientConnection> {
+    async connect(server: ResolvedServerConfig): Promise<TorrentClientConnection> {
         this.server = server
 
         this.http = axios.create({

--- a/src/main/lib/bittorrent/connection-error.ts
+++ b/src/main/lib/bittorrent/connection-error.ts
@@ -14,6 +14,7 @@ const UNREACHABLE_CODES = new Set(["ECONNREFUSED", "ECONNRESET", "EHOSTUNREACH",
 
 const MESSAGES: Record<BittorrentConnectionErrorKind, string> = {
     authentication: "Incorrect username or password.",
+    credential: "The stored password could not be decrypted. Re-enter the password.",
     timeout: "Connection timed out.",
     unreachable: "Client is unreachable.",
     address: "Check the client address and path.",
@@ -71,6 +72,10 @@ export function normalizeConnectionError(error: unknown): BittorrentConnectionEr
     const details: ErrorDetails = { codes: new Set(), statuses: new Set(), messages: [] }
     collectErrorDetails(error, details, new Set())
     const message = details.messages.join(" ").toLowerCase()
+
+    if (typeof error === "object" && error !== null && (error as { kind?: unknown }).kind === "credential") {
+        return connectionError("credential", details)
+    }
 
     if (message.includes("stale bittorrent connection")) {
         return connectionError("cancelled", details)

--- a/src/main/lib/bittorrent/helpers.ts
+++ b/src/main/lib/bittorrent/helpers.ts
@@ -1,5 +1,5 @@
 import { URL } from "node:url"
-import type { BittorrentServerConfig } from "@shared/ipc-contract"
+import type { ResolvedServerConfig } from "@shared/ipc-contract"
 import { sanitizeServerAddress } from "@shared/server-address"
 import type { CallbackFunc } from "./types"
 
@@ -27,7 +27,7 @@ export function urlPath(...pathValues: Array<string | undefined>) {
     return path ? `/${path}` : ""
 }
 
-export function serverOriginUrl(server: BittorrentServerConfig) {
+export function serverOriginUrl(server: ResolvedServerConfig) {
     const sanitizedServer = sanitizeServerAddress(server)
     const url = new URL("http://localhost")
     url.protocol = `${sanitizedServer.proto.replace(/:$/, "")}:`
@@ -36,7 +36,7 @@ export function serverOriginUrl(server: BittorrentServerConfig) {
     return url.origin
 }
 
-export function serverUrl(server: BittorrentServerConfig, endpoint?: string) {
+export function serverUrl(server: ResolvedServerConfig, endpoint?: string) {
     const url = new URL(serverOriginUrl(server))
     url.pathname = urlPath(server.path, endpoint) || "/"
 
@@ -49,4 +49,3 @@ export function appendUrlPath(baseUrl: string, endpoint?: string) {
 
     return url.pathname === "/" ? url.origin : url.toString()
 }
-

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -5,7 +5,7 @@ import { lookup as lookupCountry } from "geoip-country"
 import type {
     BittorrentAddTorrentUrlRequest,
     BittorrentInvokeActionRequest,
-    BittorrentServerConfig,
+    ResolvedServerConfig,
     BittorrentSetTorrentFileSelectionRequest,
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
@@ -76,7 +76,7 @@ class BittorrentManager {
         return sourceBasename === filename && sourceBasename.toLowerCase().endsWith(".torrent")
     }
 
-    async connect(sender: WebContents, server: BittorrentServerConfig): Promise<TorrentClientConnection | null> {
+    async connect(sender: WebContents, server: ResolvedServerConfig): Promise<TorrentClientConnection | null> {
         const senderId = sender.id
         this.setSessionState(senderId, {
             activeServerId: server.id || null,

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -1,6 +1,6 @@
 import type {
     BittorrentFileSelection,
-    BittorrentServerConfig,
+    ResolvedServerConfig,
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
@@ -14,7 +14,7 @@ export type CallbackFunc<T = unknown> = (err: unknown, val: T) => void
 
 export interface BittorrentRuntime {
     readonly actions: TorrentActionItem[]
-    connect(server: BittorrentServerConfig): Promise<TorrentClientConnection>
+    connect(server: ResolvedServerConfig): Promise<TorrentClientConnection>
     getSnapshot(fullUpdate?: boolean): Promise<any>
     addTorrentUrl(uri: string, options?: TorrentUploadOptions): Promise<void>
     uploadTorrent(buffer: Uint8Array, filename: string, options?: TorrentUploadOptions): Promise<void>

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -1,8 +1,8 @@
-import { app, BrowserWindow, clipboard, dialog, ipcMain, nativeTheme, shell, type IpcMainInvokeEvent } from 'electron'
+import { app, BrowserWindow, clipboard, dialog, ipcMain, nativeTheme, safeStorage, shell, type IpcMainInvokeEvent } from 'electron'
 import is from 'electron-is'
 
 import { IPC_CHANNELS } from '@shared/ipc'
-import type { AppSettings, EditCommand, PendingTorrentUploadLink, WindowCommand } from '@shared/ipc-contract'
+import type { AppSettings, BittorrentServerConfig, EditCommand, PendingTorrentUploadLink, PublicServerConfig, WindowCommand } from '@shared/ipc-contract'
 import { getAppVersion } from './app-meta'
 import { bittorrentManager } from './bittorrent'
 import { normalizeConnectionError } from './bittorrent/connection-error'
@@ -12,6 +12,7 @@ import * as settings from './settings'
 import themes, { getSystemTheme } from './themes'
 import * as torrents from './torrents'
 import * as updater from './update'
+import { connectAndPersistPassword } from './server-credentials'
 
 interface RegisterHandlersOptions {
     isDebug: boolean
@@ -155,11 +156,14 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
         await shell.openExternal(url)
     })
 
-    ipcMain.handle(IPC_CHANNELS.settings.getAll, async function() {
+    ipcMain.handle(IPC_CHANNELS.settings.getAll, async function(): Promise<AppSettings<PublicServerConfig>> {
         return settings.getAllSettings()
     })
 
-    ipcMain.handle(IPC_CHANNELS.settings.saveAll, async function(_event: IpcMainInvokeEvent, { settings: newSettings }) {
+    ipcMain.handle(IPC_CHANNELS.settings.saveAll, async function(
+        _event: IpcMainInvokeEvent,
+        { settings: newSettings }: { settings: AppSettings<PublicServerConfig> },
+    ): Promise<void> {
         await new Promise<void>((resolve, reject) => {
             settings.saveAll(newSettings, function(err: Error) {
                 if (err) {
@@ -221,9 +225,19 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
         return torrents.parse(request)
     })
 
-    ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(event: IpcMainInvokeEvent, { server }) {
+    ipcMain.handle(IPC_CHANNELS.bittorrent.connect, async function(
+        event: IpcMainInvokeEvent,
+        { server }: { server: BittorrentServerConfig },
+    ) {
         try {
-            const connection = await bittorrentManager.connect(event.sender, server)
+            const persistedServer = settings.getPersistedServer(server.id)
+            const connection = await connectAndPersistPassword(
+                server,
+                persistedServer,
+                safeStorage,
+                (resolvedServer) => bittorrentManager.connect(event.sender, resolvedServer),
+                settings.saveConnectedPassword,
+            )
             if (!connection) {
                 return {
                     ok: false,

--- a/src/main/lib/server-credentials.ts
+++ b/src/main/lib/server-credentials.ts
@@ -1,0 +1,133 @@
+import type { PublicServerConfig, ResolvedServerConfig, ServerConfigBase } from "@shared/ipc-contract"
+
+export type PersistedPassword =
+    | { cipher: "plaintext"; value: string }
+    | { cipher: "electron-safe-storage"; value: string }
+
+export interface PersistedServerConfig extends ServerConfigBase {
+    encryptedPassword?: PersistedPassword
+}
+
+export interface SafeStorageAdapter {
+    isEncryptionAvailable(): boolean
+    encryptString(value: string): Buffer
+    decryptString(value: Buffer): string
+}
+
+export class StoredPasswordError extends Error {
+    readonly kind = "credential"
+
+    constructor() {
+        super("The stored password could not be decrypted. Re-enter the password.")
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function decodePassword(value: unknown): PersistedPassword | undefined {
+    if (!isRecord(value) || typeof value.value !== "string") {
+        return undefined
+    }
+    if (value.cipher === "plaintext" || value.cipher === "electron-safe-storage") {
+        return { cipher: value.cipher, value: value.value }
+    }
+    return undefined
+}
+
+export function decodePersistedServer(value: unknown): PersistedServerConfig {
+    const input = isRecord(value) ? value : {}
+    const { password, newPassword: _newPassword, hasPassword: _hasPassword, encryptedPassword, ...base } = input
+    const decodedPassword = decodePassword(encryptedPassword)
+        ?? (typeof password === "string" && password ? { cipher: "plaintext" as const, value: password } : undefined)
+    return {
+        ...(base as unknown as ServerConfigBase),
+        ...(decodedPassword ? { encryptedPassword: decodedPassword } : {}),
+    }
+}
+
+export function encryptPassword(password: string, storage: SafeStorageAdapter): PersistedPassword | undefined {
+    if (!password) {
+        return undefined
+    }
+    if (!storage.isEncryptionAvailable()) {
+        return { cipher: "plaintext", value: password }
+    }
+    return {
+        cipher: "electron-safe-storage",
+        value: storage.encryptString(password).toString("base64"),
+    }
+}
+
+export function upgradePassword(server: PersistedServerConfig, storage: SafeStorageAdapter): boolean {
+    if (server.encryptedPassword?.cipher !== "plaintext" || !storage.isEncryptionAvailable()) {
+        return false
+    }
+    try {
+        server.encryptedPassword = encryptPassword(server.encryptedPassword.value, storage)
+        return true
+    } catch (_error) {
+        return false
+    }
+}
+
+export function toPublicServer(server: PersistedServerConfig): PublicServerConfig {
+    const { encryptedPassword, ...base } = server
+    return {
+        ...base,
+        hasPassword: encryptedPassword !== undefined,
+    }
+}
+
+export function applyPublicPassword(
+    submitted: PublicServerConfig,
+    previous: PersistedServerConfig | undefined,
+    storage: SafeStorageAdapter,
+): PersistedPassword | undefined {
+    if (!Object.prototype.hasOwnProperty.call(submitted, "newPassword")) {
+        return previous?.encryptedPassword
+    }
+    return encryptPassword(typeof submitted.newPassword === "string" ? submitted.newPassword : "", storage)
+}
+
+function decryptPassword(password: PersistedPassword | undefined, storage: SafeStorageAdapter): string {
+    if (!password) {
+        return ""
+    }
+    if (password.cipher === "plaintext") {
+        return password.value
+    }
+    try {
+        return storage.decryptString(Buffer.from(password.value, "base64"))
+    } catch (_error) {
+        throw new StoredPasswordError()
+    }
+}
+
+export function resolveServer(
+    submitted: PublicServerConfig & { certificateData?: Uint8Array },
+    previous: PersistedServerConfig | undefined,
+    storage: SafeStorageAdapter,
+): ResolvedServerConfig {
+    const { hasPassword: _hasPassword, newPassword, ...base } = submitted
+    const password = Object.prototype.hasOwnProperty.call(submitted, "newPassword")
+        ? (typeof newPassword === "string" ? newPassword : "")
+        : decryptPassword(previous?.encryptedPassword, storage)
+    return { ...base, password }
+}
+
+export async function connectAndPersistPassword<T>(
+    submitted: PublicServerConfig & { certificateData?: Uint8Array },
+    previous: PersistedServerConfig | undefined,
+    storage: SafeStorageAdapter,
+    connect: (server: ResolvedServerConfig) => Promise<T | null>,
+    persistPassword: (id: string, password: string) => void | Promise<void>,
+): Promise<T | null> {
+    const resolvedServer = resolveServer(submitted, previous, storage)
+    const connection = await connect(resolvedServer)
+    if (connection !== null && Object.prototype.hasOwnProperty.call(submitted, "newPassword")) {
+        await persistPassword(submitted.id, typeof submitted.newPassword === "string" ? submitted.newPassword : "")
+    }
+    return connection
+}

--- a/src/main/lib/settings.ts
+++ b/src/main/lib/settings.ts
@@ -1,13 +1,21 @@
-import { app, dialog, shell, type BrowserWindow, type MessageBoxOptions } from 'electron'
+import { app, dialog, safeStorage, shell, type BrowserWindow, type MessageBoxOptions } from 'electron'
 import fs from 'fs'
 import path from 'path'
 
-import type { AppSettings } from '@shared/ipc-contract'
+import type { AppSettings, PublicServerConfig } from '@shared/ipc-contract'
 import { createDefaultSettings, normalizeSettings } from '@shared/settings-defaults'
 import * as electorrent from './electorrent'
 import type { StoredWindowState } from './window-state'
+import {
+    applyPublicPassword,
+    decodePersistedServer,
+    encryptPassword,
+    toPublicServer,
+    upgradePassword,
+    type PersistedServerConfig,
+} from './server-credentials'
 
-export interface PersistedSettings extends AppSettings {
+export interface PersistedSettings extends AppSettings<PersistedServerConfig> {
     windowsize?: StoredWindowState
 }
 
@@ -55,21 +63,35 @@ function load(): PersistedSettings {
     }
 
     if (!fs.existsSync(CONF_PATH)) {
-        data = createDefaultSettings()
+        data = createDefaultSettings() as PersistedSettings
         return data
     }
 
     const file = fs.readFileSync(CONF_PATH, 'utf-8')
 
     if (!file) {
-        data = createDefaultSettings()
+        data = createDefaultSettings() as PersistedSettings
         return data
     }
 
     try {
-        data = normalizeSettings(JSON.parse(file))
+        const parsed = JSON.parse(file)
+        const normalized = normalizeSettings(parsed) as AppSettings<unknown>
+        data = {
+            ...normalized,
+            servers: normalized.servers.map(decodePersistedServer),
+        }
+        const decodedLegacyInput = JSON.stringify(data) !== JSON.stringify(normalized)
+        const upgraded = upgradeStoredPasswords()
+        if (decodedLegacyInput || upgraded) {
+            try {
+                saveSync()
+            } catch (_error) {
+                // Migration is retried on the next settings access.
+            }
+        }
     } catch (_e) {
-        data = createDefaultSettings()
+        data = createDefaultSettings() as PersistedSettings
         if (app.isReady()) {
             showCorruptDialog()
         } else {
@@ -132,7 +154,18 @@ export function put<K extends keyof PersistedSettings>(key: K, value: PersistedS
 }
 
 export function getAllSettings(): AppSettings {
-    return normalizeSettings(load())
+    const settings = load()
+    if (upgradeStoredPasswords()) {
+        try {
+            saveSync()
+        } catch (_error) {
+            // Retain plaintext and retry when settings are accessed again.
+        }
+    }
+    return {
+        ...copy(settings),
+        servers: settings.servers.map(toPublicServer),
+    }
 }
 
 export function getDefaultSettings(): AppSettings {
@@ -143,12 +176,44 @@ export function write() {
     saveSync()
 }
 
-export function saveAll(settings: AppSettings, callback?: (err?: Error | null) => void) {
-    data = normalizeSettings(settings)
+export function saveAll(settings: AppSettings<PublicServerConfig>, callback?: (err?: Error | null) => void) {
+    const previousById = new Map(load().servers.map((server) => [server.id, server]))
+    const normalized = normalizeSettings(settings) as AppSettings<PublicServerConfig>
+    data = {
+        ...normalized,
+        servers: normalized.servers.map((server) => {
+            const persisted = decodePersistedServer(server)
+            delete persisted.encryptedPassword
+            const encryptedPassword = applyPublicPassword(server, previousById.get(server.id), safeStorage)
+            return {
+                ...persisted,
+                ...(encryptedPassword ? { encryptedPassword } : {}),
+            }
+        }),
+    }
     notifyChanged()
     if (callback !== undefined) {
         save(callback)
     }
+}
+
+export function getPersistedServer(id: string) {
+    return load().servers.find((server) => server.id === id)
+}
+
+export function saveConnectedPassword(id: string, password: string) {
+    const server = getPersistedServer(id)
+    if (!server) {
+        return
+    }
+    const encryptedPassword = encryptPassword(password, safeStorage)
+    if (encryptedPassword) {
+        server.encryptedPassword = encryptedPassword
+    } else {
+        delete server.encryptedPassword
+    }
+    saveSync()
+    notifyChanged()
 }
 
 export function get<K extends keyof PersistedSettings>(key: K): PersistedSettings[K] | null {
@@ -166,4 +231,11 @@ export function subscribe(listener: () => void) {
 
 function notifyChanged() {
     changeListeners.forEach((listener) => listener())
+}
+
+function upgradeStoredPasswords() {
+    if (!data) {
+        return false
+    }
+    return data.servers.reduce((changed, server) => upgradePassword(server, safeStorage) || changed, false)
 }

--- a/src/renderer/app/directives/connection-form/connection-form.template.html
+++ b/src/renderer/app/directives/connection-form/connection-form.template.html
@@ -34,7 +34,7 @@
             <label ng-if="showLabels">Password</label>
             <div class="ui left icon input">
                 <i class="lock icon"></i>
-                <input type="password" id="connection-password" name="password" ng-model="server.password" placeholder="Password" />
+                <input type="password" id="connection-password" name="password" ng-model="server.newPassword" placeholder="Password" />
             </div>
         </div>
     </div>

--- a/src/renderer/app/services/server.ts
+++ b/src/renderer/app/services/server.ts
@@ -4,10 +4,10 @@ import { Torrent } from "@renderer/app/bittorrent"
 import type { ColumnProps } from "@renderer/app/services/column"
 import { parseServerAddressInput, sanitizeServerAddress } from "@shared/server-address"
 import type { CertificateResponseService } from "@renderer/app/services/certificate-response"
-import type { LabelColorHue, LabelColorOverrides, SavedLocationConfig, StoredServerConfig, TorrentUploadOptions } from "@shared/ipc-contract"
+import { PASSWORD_MASK, type LabelColorHue, type LabelColorOverrides, type PublicServerConfig, type SavedLocationConfig, type TorrentUploadOptions } from "@shared/ipc-contract"
 import { normalizeLabelColorHue } from "@renderer/app/services/label-colors"
 
-export interface Server extends Omit<StoredServerConfig, "columns"> {
+export interface Server extends Omit<PublicServerConfig, "columns"> {
     columns: ColumnProps[]
     certificateData?: Uint8Array
     isConnected: boolean
@@ -30,7 +30,7 @@ export interface Server extends Omit<StoredServerConfig, "columns"> {
     defaultColumns(): ColumnProps[]
     addCustomColumns(columns: ColumnProps[]): ColumnProps[]
     bootstrap(): void
-    json(): StoredServerConfig
+    json(): PublicServerConfig
 }
 
 export const serverService = ['$q', 'notificationService', '$bittorrent', '$btclients', 'certificateResponseService',
@@ -79,7 +79,7 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
          * Constructor, with class name
          */
         function Server(...args) {
-            const [ip, proto, port, user, password, client, path] = args
+            const [ip, proto, port, user, newPassword, client, path] = args
             this.certificateData = undefined
             if(args.length === 1) {
                 this.fromJson(args[0])
@@ -89,7 +89,8 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
                 this.proto = proto
                 this.port = port
                 this.user = user || ''
-                this.password = password || ''
+                this.hasPassword = false
+                this.newPassword = newPassword || undefined
                 this.client = client
                 this.path = path
                 this.lastused = -1
@@ -140,7 +141,8 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
             this.proto = data.proto || "http"
             this.port = data.port
             this.user = data.user || ''
-            this.password = data.password || ''
+            this.hasPassword = data.hasPassword === true
+            this.newPassword = this.hasPassword ? PASSWORD_MASK : undefined
             this.client = data.client
             this.path = data.path || ''
             this.default = data.default
@@ -156,14 +158,14 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
         };
 
         Server.prototype.json = function() {
-            return {
+            const result: PublicServerConfig = {
                 name: this.name,
                 id: this.id,
                 ip: this.ip,
                 proto: this.proto,
                 port: this.port,
                 user: this.user,
-                password: this.password,
+                hasPassword: this.hasPassword || !!this.newPassword,
                 client: this.client,
                 path: this.path,
                 default: this.default,
@@ -176,6 +178,10 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
                 defaultUploadOptions: normalizeDefaultUploadOptions(this.defaultUploadOptions),
                 labelColors: normalizeLabelColors(this.labelColors),
             }
+            if (this.newPassword !== undefined && !(this.hasPassword && this.newPassword === PASSWORD_MASK)) {
+                result.newPassword = this.newPassword
+            }
+            return result
         };
 
         Server.prototype.getName = function() {
@@ -287,7 +293,7 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
             const response = certificateResponseService.wait(self.id)
 
             electorrent.certificates.fetch({
-                server: self.json() as StoredServerConfig,
+                server: self.json(),
             }).catch((err: unknown) => {
                 certificateResponseService.reject(self.id, err)
             })
@@ -318,7 +324,7 @@ export const serverService = ['$q', 'notificationService', '$bittorrent', '$btcl
                 this.proto === other.proto &&
                 this.port === other.port &&
                 this.user === other.user &&
-                this.password === other.password &&
+                this.newPassword === other.newPassword &&
                 this.client === other.client &&
                 this.path === other.path &&
                 this.certificate === other.certificate &&

--- a/src/renderer/app/services/settings.ts
+++ b/src/renderer/app/services/settings.ts
@@ -1,5 +1,5 @@
 import { IRootScopeService } from "angular";
-import type { AppSettings, StoredServerConfig } from "@shared/ipc-contract";
+import { PASSWORD_MASK, type AppSettings, type PublicServerConfig } from "@shared/ipc-contract";
 import { createDefaultSettings } from "@shared/settings-defaults";
 import type { Server } from "@renderer/app/services/server";
 
@@ -68,7 +68,7 @@ export const settingsService = ['$rootScope', '$bittorrent', 'notificationServic
         }
     }
 
-    const readyPromise = electorrent.settings.getAll().then((org: AppSettings<StoredServerConfig>) => {
+    const readyPromise = electorrent.settings.getAll().then((org: AppSettings<PublicServerConfig>) => {
         mergeSettings(org)
         return loadServerCertificates(settings.servers).then(() => settings)
     });
@@ -150,6 +150,12 @@ export const settingsService = ['$rootScope', '$bittorrent', 'notificationServic
             mergeSettings(newSettings)
         }
         return loadServerCertificates(settings.servers).then(() => electorrent.settings.saveAll(settingsToJson())).then(function() {
+            settings.servers.forEach((server) => {
+                if (server.newPassword !== undefined) {
+                    server.hasPassword = server.newPassword !== ""
+                    server.newPassword = server.hasPassword ? PASSWORD_MASK : undefined
+                }
+            })
             updateServerReference()
         });
     }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -71,7 +71,7 @@ export type ParseTorrentRequest =
 
 export type TlsSecurity = "default" | "insecure"
 
-export interface BittorrentServerConfig extends StoredServerConfig {
+export interface BittorrentServerConfig extends PublicServerConfig {
     certificateData?: Uint8Array
 }
 
@@ -182,14 +182,15 @@ export type LabelColorHue = number
 
 export type LabelColorOverrides = Partial<Record<string, LabelColorHue>>
 
-export interface StoredServerConfig {
+export const PASSWORD_MASK = "********"
+
+export interface ServerConfigBase {
     name?: string
     id: string
     ip: string
     proto: string
     port: number
     user: string
-    password: string
     client: string
     path: string
     default?: boolean
@@ -201,6 +202,16 @@ export interface StoredServerConfig {
     defaultUploadOptionsEnabled?: boolean
     defaultUploadOptions?: TorrentUploadOptions
     labelColors?: LabelColorOverrides
+}
+
+export interface PublicServerConfig extends ServerConfigBase {
+    hasPassword: boolean
+    newPassword?: string
+}
+
+export interface ResolvedServerConfig extends ServerConfigBase {
+    password: string
+    certificateData?: Uint8Array
 }
 
 export interface SavedLocationConfig {
@@ -253,6 +264,7 @@ export interface TorrentClientConnection {
 
 export type BittorrentConnectionErrorKind =
     | "authentication"
+    | "credential"
     | "timeout"
     | "unreachable"
     | "address"
@@ -289,7 +301,7 @@ export interface ResolvedTorrentClientFeatures {
     readonly uploadOptions: Readonly<Required<Record<keyof TorrentUploadOptions, boolean>>>
 }
 
-export interface AppSettings<TServer = StoredServerConfig> {
+export interface AppSettings<TServer = PublicServerConfig> {
     startup: string
     systemStartup: SystemStartupOption
     refreshRate: number
@@ -347,7 +359,7 @@ export interface CertificatePrompt {
 }
 
 export interface CertificateFetchRequest {
-    server: StoredServerConfig
+    server: PublicServerConfig
 }
 
 export interface CertificateInstallRequest {
@@ -403,8 +415,8 @@ export interface ElectorrentBridge {
         openExternal(url: string): Promise<void>
     }
     settings: {
-        getAll(): Promise<AppSettings>
-        saveAll(settings: AppSettings): Promise<void>
+        getAll(): Promise<AppSettings<PublicServerConfig>>
+        saveAll(settings: AppSettings<PublicServerConfig>): Promise<void>
         listThemes(): Promise<ThemeInfo[]>
         getSystemTheme(): Promise<ColorTheme>
         onSystemThemeChanged(callback: (theme: ColorTheme) => void): Unsubscribe

--- a/src/shared/title-menu.ts
+++ b/src/shared/title-menu.ts
@@ -1,5 +1,5 @@
 import { CLIENT_METADATA } from "./client-metadata"
-import type { AppSettings, EditCommand, MenuAction, StoredServerConfig, Unsubscribe, WindowCommand } from "./ipc-contract"
+import type { AppSettings, EditCommand, MenuAction, PublicServerConfig, Unsubscribe, WindowCommand } from "./ipc-contract"
 import type { TorrentActionItem } from "./torrent-actions"
 
 export type TitleMenuPlatform = "darwin" | "linux" | "win32"
@@ -80,7 +80,7 @@ function serverAccelerator(index: number, platform: TitleMenuPlatform) {
     return `${platform === "darwin" ? "CmdOrCtrl" : "Ctrl"}+${index % 10}`
 }
 
-function getServerLabel(server: StoredServerConfig) {
+function getServerLabel(server: PublicServerConfig) {
     const clientName = CLIENT_METADATA[server.client as keyof typeof CLIENT_METADATA]?.name || server.client || "Server"
     return server.name || `${clientName} @ ${server.ip || "unknown host"}`
 }

--- a/test/specs/mock/password-storage-integration.spec.ts
+++ b/test/specs/mock/password-storage-integration.spec.ts
@@ -1,0 +1,58 @@
+import { browser, $ } from "@wdio/globals"
+import chai from "chai"
+import fs from "node:fs"
+import path from "node:path"
+import { PASSWORD_MASK } from "../../../src/shared/ipc-contract"
+import { configureSpec, getTestFixture } from "../../framework/fixture"
+
+const assert: Chai.AssertStatic = chai.assert
+
+describe("password storage integration", function() {
+  configureSpec({ login: false, clearTorrents: false })
+
+  it("encrypts, redacts, preserves, masks, and explicitly clears a password", async function() {
+    const app = getTestFixture().app
+    await app.login({
+      host: "password-storage.local",
+      username: "credential-user",
+      password: "credential-secret",
+      port: 1,
+      clientId: "mock",
+    })
+    await app.torrentsPageIsVisible()
+
+    const { userDataPath, encryptionAvailable } = await browser.electron.execute((electron) => ({
+      userDataPath: electron.app.getPath("userData"),
+      encryptionAvailable: electron.safeStorage.isEncryptionAvailable(),
+    }))
+    const configPath = path.join(userDataPath, "config.json")
+    const persisted = JSON.parse(fs.readFileSync(configPath, "utf8"))
+    const persistedServer = persisted.servers[0]
+    assert.notProperty(persistedServer, "password")
+    assert.notProperty(persistedServer, "newPassword")
+    assert.notProperty(persistedServer, "hasPassword")
+    assert.equal(persistedServer.encryptedPassword.cipher, encryptionAvailable ? "electron-safe-storage" : "plaintext")
+    if (encryptionAvailable) {
+      assert.notInclude(JSON.stringify(persistedServer), "credential-secret")
+    }
+
+    await app.openSettings()
+    await app.settingsGotoTab("connection")
+    const passwordInput = $("#connection-password")
+    assert.equal(await passwordInput.getValue(), PASSWORD_MASK)
+
+    const originalCiphertext = persistedServer.encryptedPassword.value
+    await app.settingsSave()
+    await app.torrentsPageIsVisible()
+    const preserved = JSON.parse(fs.readFileSync(configPath, "utf8"))
+    assert.equal(preserved.servers[0].encryptedPassword.value, originalCiphertext)
+
+    await app.openSettings()
+    await app.settingsGotoTab("connection")
+    await $("#connection-password").clearValue()
+    await app.settingsSave()
+    await app.torrentsPageIsVisible()
+    const cleared = JSON.parse(fs.readFileSync(configPath, "utf8"))
+    assert.notProperty(cleared.servers[0], "encryptedPassword")
+  })
+})

--- a/test/specs/mock/server-credentials.spec.ts
+++ b/test/specs/mock/server-credentials.spec.ts
@@ -1,0 +1,153 @@
+import chai from "chai"
+import type { PublicServerConfig, ServerConfigBase } from "../../../src/shared/ipc-contract"
+import {
+  applyPublicPassword,
+  connectAndPersistPassword,
+  decodePersistedServer,
+  encryptPassword,
+  resolveServer,
+  StoredPasswordError,
+  toPublicServer,
+  upgradePassword,
+  type SafeStorageAdapter,
+} from "../../../src/main/lib/server-credentials"
+
+const assert: Chai.AssertStatic = chai.assert
+
+const base: ServerConfigBase = {
+  id: "server-1",
+  ip: "localhost",
+  proto: "http",
+  port: 8080,
+  user: "user",
+  client: "mock",
+  path: "",
+  columns: [],
+}
+
+function storage(available = true): SafeStorageAdapter {
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (value) => Buffer.from(`protected:${value}`),
+    decryptString: (value) => {
+      const decoded = value.toString()
+      if (!decoded.startsWith("protected:")) throw new Error("unavailable key")
+      return decoded.slice("protected:".length)
+    },
+  }
+}
+
+describe("server credentials", function() {
+  it("decodes legacy plaintext without retaining renderer secret fields", function() {
+    const persisted = decodePersistedServer({
+      ...base,
+      password: "legacy-secret",
+      newPassword: "transient-secret",
+      hasPassword: false,
+    })
+
+    assert.deepEqual(persisted.encryptedPassword, { cipher: "plaintext", value: "legacy-secret" })
+    assert.notProperty(persisted, "password")
+    assert.notProperty(persisted, "newPassword")
+    assert.notProperty(persisted, "hasPassword")
+  })
+
+  it("uses plaintext envelopes only while safe storage is unavailable", function() {
+    assert.deepEqual(encryptPassword("secret", storage(false)), { cipher: "plaintext", value: "secret" })
+    assert.deepEqual(encryptPassword("", storage(false)), undefined)
+    assert.deepEqual(encryptPassword("secret", storage()), {
+      cipher: "electron-safe-storage",
+      value: Buffer.from("protected:secret").toString("base64"),
+    })
+  })
+
+  it("upgrades plaintext and leaves it intact when migration fails", function() {
+    const persisted = decodePersistedServer({ ...base, encryptedPassword: { cipher: "plaintext", value: "secret" } })
+    assert.isTrue(upgradePassword(persisted, storage()))
+    assert.equal(persisted.encryptedPassword?.cipher, "electron-safe-storage")
+
+    const failing = storage()
+    failing.encryptString = () => { throw new Error("keychain unavailable") }
+    const retained = decodePersistedServer({ ...base, encryptedPassword: { cipher: "plaintext", value: "secret" } })
+    assert.isFalse(upgradePassword(retained, failing))
+    assert.deepEqual(retained.encryptedPassword, { cipher: "plaintext", value: "secret" })
+  })
+
+  it("preserves, clears, and replaces only from newPassword intent", function() {
+    const previous = decodePersistedServer({ ...base, encryptedPassword: { cipher: "plaintext", value: "old" } })
+    const publicServer: PublicServerConfig = { ...base, hasPassword: false }
+
+    assert.strictEqual(applyPublicPassword(publicServer, previous, storage()), previous.encryptedPassword)
+    assert.isUndefined(applyPublicPassword({ ...publicServer, newPassword: "" }, previous, storage()))
+    assert.equal(applyPublicPassword({ ...publicServer, newPassword: "new" }, previous, storage())?.cipher, "electron-safe-storage")
+  })
+
+  it("derives public state and never returns persisted secret representations", function() {
+    const publicServer = toPublicServer(decodePersistedServer({
+      ...base,
+      encryptedPassword: { cipher: "plaintext", value: "secret" },
+    }))
+
+    assert.isTrue(publicServer.hasPassword)
+    assert.notProperty(publicServer, "password")
+    assert.notProperty(publicServer, "newPassword")
+    assert.notProperty(publicServer, "encryptedPassword")
+  })
+
+  it("resolves plaintext for runtimes and ignores submitted hasPassword", function() {
+    const previous = decodePersistedServer({ ...base, encryptedPassword: encryptPassword("stored", storage()) })
+    assert.equal(resolveServer({ ...base, hasPassword: false }, previous, storage()).password, "stored")
+    assert.equal(resolveServer({ ...base, hasPassword: true, newPassword: "replacement" }, previous, storage()).password, "replacement")
+    assert.equal(resolveServer({ ...base, hasPassword: true, newPassword: "" }, previous, storage()).password, "")
+  })
+
+  it("retains undecryptable ciphertext and requests credential re-entry", function() {
+    const persisted = decodePersistedServer({
+      ...base,
+      encryptedPassword: { cipher: "electron-safe-storage", value: Buffer.from("invalid").toString("base64") },
+    })
+
+    assert.throws(() => resolveServer({ ...base, hasPassword: false }, persisted, storage()), StoredPasswordError)
+    assert.equal(persisted.encryptedPassword?.cipher, "electron-safe-storage")
+    assert.isTrue(toPublicServer(persisted).hasPassword)
+  })
+
+  it("persists a submitted password only after a successful connection", async function() {
+    const submitted: PublicServerConfig = { ...base, hasPassword: false, newPassword: "replacement" }
+    const persistedPasswords: string[] = []
+
+    let connectionError: unknown
+    try {
+      await connectAndPersistPassword(
+        submitted,
+        undefined,
+        storage(),
+        async () => { throw new Error("connection failed") },
+        (_id, password) => { persistedPasswords.push(password) },
+      )
+    } catch (error) {
+      connectionError = error
+    }
+    assert.equal((connectionError as Error).message, "connection failed")
+    assert.deepEqual(persistedPasswords, [])
+
+    const events: string[] = []
+    const connection = await connectAndPersistPassword(
+      submitted,
+      undefined,
+      storage(),
+      async (resolved) => {
+        assert.equal(resolved.password, "replacement")
+        events.push("connected")
+        return { version: "1.0.0" }
+      },
+      (_id, password) => {
+        assert.equal(password, "replacement")
+        events.push("persisted")
+      },
+    )
+
+    assert.deepEqual(connection, { version: "1.0.0" })
+    assert.deepEqual(events, ["connected", "persisted"])
+  })
+})

--- a/test/specs/standard/connection.spec.ts
+++ b/test/specs/standard/connection.spec.ts
@@ -1,5 +1,6 @@
 import chai from "chai"
 import { $ } from "@wdio/globals"
+import { PASSWORD_MASK } from "../../../src/shared/ipc-contract"
 import { eventually } from "../../e2e/eventually"
 import { configureSpec, getTestFixture } from "../../framework/fixture"
 import { restartApplication } from "../../shared"
@@ -55,7 +56,7 @@ describe("connection", function () {
       assert.equal(await $("#page-settings-connection input[name='ip']").getValue(), client.host)
       assert.equal(await $("#page-settings-connection input[name='port']").getValue(), String(client.port))
       assert.equal(await $("#page-settings-connection input[name='username']").getValue(), client.username)
-      assert.equal(await $("#page-settings-connection input[name='password']").getValue(), client.password)
+      assert.equal(await $("#page-settings-connection input[name='password']").getValue(), PASSWORD_MASK)
     } finally {
       await backend.unpause()
     }

--- a/test/specs/standard/connection.spec.ts
+++ b/test/specs/standard/connection.spec.ts
@@ -56,7 +56,7 @@ describe("connection", function () {
       assert.equal(await $("#page-settings-connection input[name='ip']").getValue(), client.host)
       assert.equal(await $("#page-settings-connection input[name='port']").getValue(), String(client.port))
       assert.equal(await $("#page-settings-connection input[name='username']").getValue(), client.username)
-      assert.equal(await $("#page-settings-connection input[name='password']").getValue(), PASSWORD_MASK)
+      assert.equal(await $("#page-settings-connection input[name='password']").getValue(), client.password ? PASSWORD_MASK : "")
     } finally {
       await backend.unpause()
     }


### PR DESCRIPTION
## Summary
- encrypt persisted BitTorrent credentials with Electron safeStorage
- migrate legacy plaintext credentials and retry non-fatal upgrades
- redact secrets from renderer settings and resolve credentials only in main
- preserve, clear, or replace credentials through explicit transient intent
- reject undecryptable credentials with a non-secret re-entry error

## Tests
- npm run lint
- npm run build
- npm run test -- --client mock --spec server-credentials.spec.ts --headless
- npm run test -- --client mock --spec password-storage-integration.spec.ts --headless