### PR TITLE
perf(test): parallelize client fixtures

### DIFF
--- a/.github/workflows/electorrent-workflow.yml
+++ b/.github/workflows/electorrent-workflow.yml
@@ -15,8 +15,6 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      ELECTORRENT_TEST_CONCURRENCY: 4
 
     strategy:
       fail-fast: false
@@ -68,7 +66,7 @@ jobs:
     - name: Package application
       run: npm run pack
     - name: Run tests
-      run: xvfb-run -a -- npm test -- --dist --client "${{ matrix.client }}"
+      run: xvfb-run -a -- npm test -- --dist --client "${{ matrix.client }}" --parallel
 
   build:
     strategy:

--- a/.github/workflows/electorrent-workflow.yml
+++ b/.github/workflows/electorrent-workflow.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      ELECTORRENT_TEST_CONCURRENCY: 4
 
     strategy:
       fail-fast: false

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 # Shared test stack used by ElectorrentTestService.
-# Each WebdriverIO client capability runs this stack as its own compose project.
+# Each WebdriverIO client fixture slot runs this stack as its own compose project.
 x-peer: &peer
   build: ./shared/opentracker/peer
   volumes:

--- a/test/framework/service.ts
+++ b/test/framework/service.ts
@@ -8,14 +8,20 @@ import { waitForHttp } from "../testutil"
 
 const testDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const stackComposeFile = path.join(testDir, "docker-compose.yml")
+const fixturePortStride = 100
 
 interface ElectorrentCapabilities extends WebdriverIO.Capabilities {
   "electorrent:client"?: TestClient
+  "electorrent:fixtureSlot"?: number
 }
 
 export default class ElectorrentTestService {
+  private readonly workerFixtures = new Map<string, { clientKey: string, slot: number }>()
+  private readonly leasedSlots = new Map<string, Set<number>>()
+  private readonly fixtureCounts = new Map<string, number>()
+
   async onPrepare(
-    _config: WebdriverIO.Config,
+    config: WebdriverIO.Config,
     capabilities: ElectorrentCapabilities[],
   ) {
     const clients = new Map(
@@ -26,20 +32,62 @@ export default class ElectorrentTestService {
         .map((client) => [client.key, client]),
     )
 
+    const fixtureCount = config.maxInstancesPerCapability ?? 1
+
     await Promise.all(
       [...clients.values()].map(async (client) => {
-        const { composeOptions } = this.getClientEnvironment(client)
+        this.fixtureCounts.set(client.key, fixtureCount)
 
-        await compose.upMany(
-          ["tracker", "peer", this.getClientServiceName(client), "nginx"],
-          composeOptions,
-        )
-        await waitForHttp({
-          url: `http://${client.host}:${client.containerHostPort ?? client.port}${client.acceptHttpPath ?? ""}`,
-          statusCode: client.acceptHttpStatus,
-        })
+        // Start a bounded pool once, then reuse each fixture as WDIO schedules specs.
+        for (let slot = 0; slot < fixtureCount; slot += 1) {
+          const { client: isolatedClient, composeOptions } = this.getClientEnvironment(client, slot)
+
+          await compose.upMany(
+            ["tracker", "peer", this.getClientServiceName(client), "nginx"],
+            composeOptions,
+          )
+          await waitForHttp({
+            url: `http://${isolatedClient.host}:${isolatedClient.containerHostPort ?? isolatedClient.port}${isolatedClient.acceptHttpPath ?? ""}`,
+            statusCode: isolatedClient.acceptHttpStatus,
+          })
+        }
       }),
     )
+  }
+
+  onWorkerStart(cid: string, capabilities: ElectorrentCapabilities) {
+    const client = capabilities["electorrent:client"]
+    if (!client?.fixture) {
+      return
+    }
+
+    const fixtureCount = this.fixtureCounts.get(client.key)
+    if (fixtureCount == null) {
+      throw new Error(`Test fixture pool was not prepared for ${client.key}`)
+    }
+
+    const leasedSlots = this.leasedSlots.get(client.key) ?? new Set<number>()
+    const slot = Array.from({ length: fixtureCount }, (_, index) => index)
+      .find((candidate) => !leasedSlots.has(candidate))
+
+    if (slot == null) {
+      throw new Error(`No test fixture available for ${client.key}`)
+    }
+
+    leasedSlots.add(slot)
+    this.leasedSlots.set(client.key, leasedSlots)
+    this.workerFixtures.set(cid, { clientKey: client.key, slot })
+    capabilities["electorrent:fixtureSlot"] = slot
+  }
+
+  onWorkerEnd(cid: string) {
+    const fixture = this.workerFixtures.get(cid)
+    if (!fixture) {
+      return
+    }
+
+    this.leasedSlots.get(fixture.clientKey)?.delete(fixture.slot)
+    this.workerFixtures.delete(cid)
   }
 
   async beforeSession(
@@ -56,10 +104,15 @@ export default class ElectorrentTestService {
       return
     }
 
-    const { composeOptions, proxyPort } = this.getClientEnvironment(client)
+    const slot = capabilities["electorrent:fixtureSlot"]
+    if (slot == null) {
+      throw new Error(`Test fixture slot was not assigned for ${client.key}`)
+    }
+
+    const { client: isolatedClient, composeOptions, proxyPort } = this.getClientEnvironment(client, slot)
 
     initializeTestFixture({
-      client,
+      client: isolatedClient,
       backend: new DockerComposeService(
         testDir,
         { serviceName: this.getClientServiceName(client) },
@@ -74,26 +127,33 @@ export default class ElectorrentTestService {
     })
   }
 
-  private getClientEnvironment(client: TestClient) {
+  private getClientEnvironment(client: TestClient, slot: number) {
+    const portOffset = slot * fixturePortStride
+    const isolatedClient = {
+      ...client,
+      port: client.port + portOffset,
+      ...(client.containerHostPort == null ? {} : { containerHostPort: client.containerHostPort + portOffset }),
+      ...(client.authProxyHostPort == null ? {} : { authProxyHostPort: client.authProxyHostPort + portOffset }),
+    }
     const suffix = client.key.replace(/[^a-z0-9]+/gi, "-").toLowerCase()
     const clientIndex = Object.keys(TEST_CLIENTS).indexOf(client.key)
-    const proxyPort = 50000 + clientIndex
-    const trackerPort = 51000 + clientIndex
-    const authProxyPort = client.authProxyHostPort ?? 55000 + clientIndex
+    const proxyPort = 50000 + clientIndex + portOffset
+    const trackerPort = 51000 + clientIndex + portOffset
+    const authProxyPort = isolatedClient.authProxyHostPort ?? 55000 + clientIndex + portOffset
     const env = {
       ...process.env,
-      COMPOSE_PROJECT_NAME: `electorrent-${suffix}`,
+      COMPOSE_PROJECT_NAME: `electorrent-${suffix}${slot ? `-${slot + 1}` : ""}`,
       VERSION: client.version,
-      CLIENT_HOST_PORT: String(client.containerHostPort ?? client.port),
+      CLIENT_HOST_PORT: String(isolatedClient.containerHostPort ?? isolatedClient.port),
       TRACKER_PORT: String(trackerPort),
       NGINX_HOST_PORT: String(proxyPort),
       NGINX_AUTH_HOST_PORT: String(authProxyPort),
       NGINX_AUTH_PORT: "8081",
       PROXY_HOST: this.getClientServiceName(client),
       PROXY_PORT: String(client.proxyPort ?? client.containerPort ?? client.port),
-      RPC_PORT: String(52000 + clientIndex),
-      PEER_PORT: String(53000 + clientIndex),
-      PEER_UDP_PORT: String(54000 + clientIndex),
+      RPC_PORT: String(52000 + clientIndex + portOffset),
+      PEER_PORT: String(53000 + clientIndex + portOffset),
+      PEER_UDP_PORT: String(54000 + clientIndex + portOffset),
     }
     const composeOptions: IDockerComposeOptions = {
       cwd: testDir,
@@ -102,7 +162,7 @@ export default class ElectorrentTestService {
       log: false,
     }
 
-    return { composeOptions, proxyPort }
+    return { client: isolatedClient, composeOptions, proxyPort }
   }
 
   private getClientServiceName(client: TestClient) {

--- a/test/specs/README.md
+++ b/test/specs/README.md
@@ -6,3 +6,13 @@ Specs are grouped by the client capabilities they require:
 - `mock/` — specs that require the mock client/runtime and should only be listed by the mock test client capability.
 
 Add new specs to the narrowest applicable group. If a spec is only meaningful for a purpose-built test client, keep it out of `standard/` and wire it through that client's `specs` entry in `test/clients/*/index.ts`.
+
+## Concurrency
+
+Set `ELECTORRENT_TEST_CONCURRENCY` to run specs concurrently for each Docker-backed client capability. Each worker receives an isolated Docker Compose project; projects are reused as later specs are scheduled, so specs never share mutable client state and a full stack is not started per spec. Non-Docker capabilities remain serial because they do not use the fixture pool. The default is `1`, and supported values are `1` through `4`.
+
+For example:
+
+```shell
+ELECTORRENT_TEST_CONCURRENCY=2 npm test -- --client qbittorrent:latest --headless
+```

--- a/test/specs/README.md
+++ b/test/specs/README.md
@@ -9,10 +9,10 @@ Add new specs to the narrowest applicable group. If a spec is only meaningful fo
 
 ## Concurrency
 
-Set `ELECTORRENT_TEST_CONCURRENCY` to run specs concurrently for each Docker-backed client capability. Each worker receives an isolated Docker Compose project; projects are reused as later specs are scheduled, so specs never share mutable client state and a full stack is not started per spec. Non-Docker capabilities remain serial because they do not use the fixture pool. The default is `1`, and supported values are `1` through `4`.
+Pass `--parallel` to run up to four specs concurrently for each Docker-backed client capability. Each worker receives an isolated Docker Compose project; projects are reused as later specs are scheduled, so specs never share mutable client state and a full stack is not started per spec. Non-Docker capabilities remain serial because they do not use the fixture pool. Specs run serially by default.
 
 For example:
 
 ```shell
-ELECTORRENT_TEST_CONCURRENCY=2 npm test -- --client qbittorrent:latest --headless
+npm test -- --client qbittorrent:latest --parallel --headless
 ```

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -13,6 +13,18 @@ const standardSpecs = [
 const useDistribution = process.argv.includes('--dist')
 const useHeadless = process.argv.includes('--headless')
 
+function testConcurrency() {
+    const value = Number(process.env.ELECTORRENT_TEST_CONCURRENCY ?? '1')
+
+    if (!Number.isInteger(value) || value < 1 || value > 4) {
+        throw new Error('ELECTORRENT_TEST_CONCURRENCY must be an integer between 1 and 4')
+    }
+
+    return value
+}
+
+const concurrency = testConcurrency()
+
 function requestedClients() {
     return process.argv.flatMap((argument, index, arguments_) => {
         if (argument === '--client') {
@@ -38,6 +50,7 @@ const specReporterPath = fileURLToPath(new URL('./test/framework/spec-reporter.t
 function electronCapability(client: (typeof selectedClients)[number]): WebdriverIO.Capabilities {
     return {
         browserName: 'electron',
+        'wdio:maxInstances': client.fixture ? concurrency : 1,
         'wdio:specs': client.specs ?? standardSpecs,
         'electorrent:client': client,
         'wdio:electronServiceOptions': {
@@ -121,7 +134,7 @@ export const config: WebdriverIO.Config = {
     // from the same test should run tests.
     //
     maxInstances: 4,
-    maxInstancesPerCapability: 1,
+    maxInstancesPerCapability: concurrency,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -12,18 +12,7 @@ const standardSpecs = [
 ]
 const useDistribution = process.argv.includes('--dist')
 const useHeadless = process.argv.includes('--headless')
-
-function testConcurrency() {
-    const value = Number(process.env.ELECTORRENT_TEST_CONCURRENCY ?? '1')
-
-    if (!Number.isInteger(value) || value < 1 || value > 4) {
-        throw new Error('ELECTORRENT_TEST_CONCURRENCY must be an integer between 1 and 4')
-    }
-
-    return value
-}
-
-const concurrency = testConcurrency()
+const concurrency = process.argv.includes('--parallel') ? 4 : 1
 
 function requestedClients() {
     return process.argv.flatMap((argument, index, arguments_) => {


### PR DESCRIPTION
## Summary
- run Docker-backed client specs with up to four concurrent WDIO workers via `--parallel`
- lease workers isolated, reusable Docker Compose fixture slots
- namespace ports and Compose projects per slot while keeping mock specs serial

## Design
WDIO machine sharding would duplicate dependency installation, packaging, and Compose startup. A bounded fixture pool instead starts four isolated stacks per client job and reuses them across specs, preserving state isolation without paying stack startup cost per spec.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/connection-tls.spec.ts" --spec "test/specs/standard/torrent-speed-limits.spec.ts" --spec "test/specs/standard/tracker-filters.spec.ts" --spec "test/specs/standard/torrent-labels.spec.ts" --parallel --headless`