### PR TITLE
fix(files): make folder toggle square

### DIFF
--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
@@ -57,9 +57,10 @@ torrent-details-files-tab {
     .torrent-details-folder-toggle.ui.button {
         flex: 0 0 18px;
         width: 18px;
+        height: 18px;
         min-height: 18px;
         margin: 0 2px 0 0;
-        padding: 0;
+        padding: 0 !important;
         border: 0;
         box-shadow: none;
         .icon { width: auto; margin: 0; }


### PR DESCRIPTION
## Summary

Make the torrent-details folder toggle square by explicitly matching its height to its 18px width.

## Root cause

The toggle had an explicit width but no explicit height, allowing it to expand vertically.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "torrent-details" --headless`