### PR TITLE
test(compose): remove temporary storage mounts

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -4,8 +4,6 @@ x-peer: &peer
   build: ./shared/opentracker/peer
   volumes:
     - ./shared/opentracker/data/shared:/shared
-  tmpfs:
-    - /srv
   entrypoint: ["tail", "-f", "/dev/null"]
 
 services:
@@ -47,8 +45,6 @@ services:
       - ${CLIENT_HOST_PORT:-6800}:6800
     volumes:
       - ./clients/aria2/aria2.conf:/config/aria2.conf
-    tmpfs:
-      - /downloads:mode=1777
 
   deluge:
     image: linuxserver/deluge:${VERSION:-latest}
@@ -60,11 +56,6 @@ services:
       - ./clients/deluge/core.conf:/config/core.conf:ro
     ports:
       - ${CLIENT_HOST_PORT:-8112}:8112
-    tmpfs:
-      - /config
-      - /downloads
-      - /home/deluge
-      - /root/Downloads
 
   qbittorrent:
     image: linuxserver/qbittorrent:${VERSION:-latest}
@@ -74,8 +65,6 @@ services:
       - WEBUI_PORT=8080
     volumes:
       - ./clients/qbittorrent/qBittorrent.conf:/defaults/qBittorrent.conf
-    tmpfs:
-      - /downloads
 
   rtorrent:
     image: linuxserver/rutorrent:${VERSION:-latest}
@@ -84,9 +73,6 @@ services:
       - ${RPC_PORT:-5000}:5000
       - ${PEER_PORT:-51413}:51413
       - ${PEER_UDP_PORT:-6881}:6881/udp
-    tmpfs:
-      - /downloads
-      - /config
 
   rtorrent-crazymax:
     image: crazymax/rtorrent-rutorrent:5.3.1-0.16.13
@@ -104,10 +90,6 @@ services:
       - WAN_IP_CMD=hostname -i
     volumes:
       - ./clients/rtorrent-crazymax/.rtorrent.rc:/data/rtorrent/.rtorrent.rc
-      - rtorrent-crazymax-data:/data
-    tmpfs:
-      - /downloads
-      - /passwd
 
   transmission:
     image: linuxserver/transmission:${VERSION:-latest}
@@ -116,17 +98,8 @@ services:
       - PASS=password
     ports:
       - ${CLIENT_HOST_PORT:-9091}:9091
-    tmpfs:
-      - /downloads
-      - /downloads/complete
-      - /downloads/incomplete
 
   utorrent:
     image: ekho/utorrent:${VERSION:-latest}
     ports:
       - ${CLIENT_HOST_PORT:-8080}:8080
-    tmpfs:
-      - /data:uid=1001,gid=1001
-
-volumes:
-  rtorrent-crazymax-data:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,9 +1,12 @@
 # Shared test stack used by ElectorrentTestService.
 # Each WebdriverIO client fixture slot runs this stack as its own compose project.
+# Bare volume targets are anonymous: they provide writable runtime filesystems
+# without introducing persistent, named test data.
 x-peer: &peer
   build: ./shared/opentracker/peer
   volumes:
     - ./shared/opentracker/data/shared:/shared
+    - /srv
   entrypoint: ["tail", "-f", "/dev/null"]
 
 services:
@@ -45,6 +48,7 @@ services:
       - ${CLIENT_HOST_PORT:-6800}:6800
     volumes:
       - ./clients/aria2/aria2.conf:/config/aria2.conf
+      - /downloads
 
   deluge:
     image: linuxserver/deluge:${VERSION:-latest}
@@ -54,6 +58,10 @@ services:
       - TZ=Etc/UTC
     volumes:
       - ./clients/deluge/core.conf:/config/core.conf:ro
+      - /config
+      - /downloads
+      - /home/deluge
+      - /root/Downloads
     ports:
       - ${CLIENT_HOST_PORT:-8112}:8112
 
@@ -65,6 +73,7 @@ services:
       - WEBUI_PORT=8080
     volumes:
       - ./clients/qbittorrent/qBittorrent.conf:/defaults/qBittorrent.conf
+      - /downloads
 
   rtorrent:
     image: linuxserver/rutorrent:${VERSION:-latest}
@@ -73,6 +82,9 @@ services:
       - ${RPC_PORT:-5000}:5000
       - ${PEER_PORT:-51413}:51413
       - ${PEER_UDP_PORT:-6881}:6881/udp
+    volumes:
+      - /downloads
+      - /config
 
   rtorrent-crazymax:
     image: crazymax/rtorrent-rutorrent:5.3.1-0.16.13
@@ -90,6 +102,9 @@ services:
       - WAN_IP_CMD=hostname -i
     volumes:
       - ./clients/rtorrent-crazymax/.rtorrent.rc:/data/rtorrent/.rtorrent.rc
+      - /data
+      - /downloads
+      - /passwd
 
   transmission:
     image: linuxserver/transmission:${VERSION:-latest}
@@ -98,8 +113,17 @@ services:
       - PASS=password
     ports:
       - ${CLIENT_HOST_PORT:-9091}:9091
+    volumes:
+      - /downloads
+      - /downloads/complete
+      - /downloads/incomplete
 
   utorrent:
     image: ekho/utorrent:${VERSION:-latest}
     ports:
       - ${CLIENT_HOST_PORT:-8080}:8080
+    environment:
+      - UID=1000
+      - GID=1000
+    volumes:
+      - /data


### PR DESCRIPTION
## Summary
- remove all tmpfs mounts from the test compose services
- remove the persistent rTorrent CrazyMax data volume
- verify a simple torrent download for every supported test client

## Validation
- npm run lint
- npm run build
- 7 targeted headless client download tests