### PR TITLE
feat(settings): add bits per second speed unit option

### DIFF
--- a/src/renderer/app/directives/settings-general/settings-general.template.html
+++ b/src/renderer/app/directives/settings-general/settings-general.template.html
@@ -73,6 +73,23 @@
     <div class="ui card">
         <div class="content">
             <div class="header">
+                <i class="tachometer alternate icon"></i>
+                Speed Units
+            </div>
+            <div class="description">
+                Show transfer speeds in bytes per second or bits per second
+            </div>
+        </div>
+        <div class="center aligned extra content">
+            <dropdown class="fluid" title="Speed Units" ng-model="ctl.settings.ui.speedUnit">
+                <dropdown-item data-value="bytes">Bytes (MB/s)</dropdown-item>
+                <dropdown-item data-value="bits">Bits (Mb/s)</dropdown-item>
+            </dropdown>
+        </div>
+    </div>
+    <div class="ui card">
+        <div class="content">
+            <div class="header">
                 <i class="expand icon"></i>
                 Table Resize Style
             </div>

--- a/src/renderer/app/filters/bytes.filter.ts
+++ b/src/renderer/app/filters/bytes.filter.ts
@@ -1,4 +1,5 @@
 import { IFilterNumber } from "angular";
+import { formatBytes } from "@renderer/app/filters/speed-format";
 
 export class BytesFilter {
     public static getInstance(): () => IFilterNumber {
@@ -6,26 +7,6 @@ export class BytesFilter {
     }
 
     public transform: IFilterNumber = (value, fractionSize = 1): string => {
-        if (value === null || value === undefined) {
-            return "";
-        }
-
-        const bytes = Number(value);
-        const decimals = Number(fractionSize);
-
-        if (!Number.isFinite(bytes) || bytes < 0) {
-            return "";
-        }
-
-        if (bytes === 0) {
-            return "0 B";
-        }
-
-        const k = 1024;
-        const dm = decimals < 0 ? 0 : decimals;
-        const sizes = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
-        const i = Math.floor(Math.log(bytes) / Math.log(k));
-
-        return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+        return formatBytes(value, fractionSize);
     };
 }

--- a/src/renderer/app/filters/speed-format.ts
+++ b/src/renderer/app/filters/speed-format.ts
@@ -1,0 +1,44 @@
+import { IFilterNumber } from "angular";
+import type { SpeedUnit } from "@shared/ipc-contract";
+
+/**
+ * Bit rates conventionally use decimal (SI) prefixes rather than the binary
+ * prefixes used for byte sizes, e.g. 1 Mb equals 1.000.000 bits.
+ */
+const BIT_UNIT_BASE = 1000;
+const BIT_UNITS = ["b", "kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"];
+
+function formatBits(value: number | string | null | undefined, fractionSize = 1): string {
+    if (value === null || value === undefined) {
+        return "";
+    }
+
+    const bytes = Number(value);
+    const decimals = Number(fractionSize);
+
+    if (!Number.isFinite(bytes) || bytes < 0) {
+        return "";
+    }
+
+    if (bytes === 0) {
+        return "0 b";
+    }
+
+    const bits = bytes * 8;
+    const dm = decimals < 0 ? 0 : decimals;
+    const i = Math.min(Math.floor(Math.log(bits) / Math.log(BIT_UNIT_BASE)), BIT_UNITS.length - 1);
+
+    return `${parseFloat((bits / Math.pow(BIT_UNIT_BASE, i)).toFixed(dm))} ${BIT_UNITS[i]}`;
+}
+
+/**
+ * Formats a byte rate in the unit preferred by the user, without a trailing
+ * time suffix. Callers append their own suffix, e.g. "/s".
+ */
+export function formatSpeedValue(
+    bytesPerSecond: number | string | null | undefined,
+    unit: SpeedUnit,
+    bytesFilter: IFilterNumber,
+): string {
+    return unit === "bits" ? formatBits(bytesPerSecond) : bytesFilter(bytesPerSecond);
+}

--- a/src/renderer/app/filters/speed-format.ts
+++ b/src/renderer/app/filters/speed-format.ts
@@ -1,5 +1,5 @@
-import { IFilterNumber } from "angular";
-import type { SpeedUnit } from "@shared/ipc-contract";
+const BYTE_UNIT_BASE = 1024;
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
 /**
  * Bit rates conventionally use decimal (SI) prefixes rather than the binary
@@ -8,7 +8,13 @@ import type { SpeedUnit } from "@shared/ipc-contract";
 const BIT_UNIT_BASE = 1000;
 const BIT_UNITS = ["b", "kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"];
 
-function formatBits(value: number | string | null | undefined, fractionSize = 1): string {
+function format(
+    value: number | string | null | undefined,
+    fractionSize: number | string,
+    scale: number,
+    base: number,
+    units: string[],
+): string {
     if (value === null || value === undefined) {
         return "";
     }
@@ -21,24 +27,22 @@ function formatBits(value: number | string | null | undefined, fractionSize = 1)
     }
 
     if (bytes === 0) {
-        return "0 b";
+        return `0 ${units[0]}`;
     }
 
-    const bits = bytes * 8;
+    const scaled = bytes * scale;
     const dm = decimals < 0 ? 0 : decimals;
-    const i = Math.min(Math.floor(Math.log(bits) / Math.log(BIT_UNIT_BASE)), BIT_UNITS.length - 1);
+    const i = Math.min(Math.floor(Math.log(scaled) / Math.log(base)), units.length - 1);
 
-    return `${parseFloat((bits / Math.pow(BIT_UNIT_BASE, i)).toFixed(dm))} ${BIT_UNITS[i]}`;
+    return `${parseFloat((scaled / Math.pow(base, i)).toFixed(dm))} ${units[i]}`;
 }
 
-/**
- * Formats a byte rate in the unit preferred by the user, without a trailing
- * time suffix. Callers append their own suffix, e.g. "/s".
- */
-export function formatSpeedValue(
-    bytesPerSecond: number | string | null | undefined,
-    unit: SpeedUnit,
-    bytesFilter: IFilterNumber,
-): string {
-    return unit === "bits" ? formatBits(bytesPerSecond) : bytesFilter(bytesPerSecond);
+/** Formats a byte count using binary prefixes, e.g. "1.5 MB". */
+export function formatBytes(value: number | string | null | undefined, fractionSize: number | string = 1): string {
+    return format(value, fractionSize, 1, BYTE_UNIT_BASE, BYTE_UNITS);
+}
+
+/** Formats a byte count as bits using decimal prefixes, e.g. "12.6 Mb". */
+export function formatBits(value: number | string | null | undefined, fractionSize: number | string = 1): string {
+    return format(value, fractionSize, 8, BIT_UNIT_BASE, BIT_UNITS);
 }

--- a/src/renderer/app/filters/speed-limit.filter.ts
+++ b/src/renderer/app/filters/speed-limit.filter.ts
@@ -1,25 +1,36 @@
 import { IFilterNumber, IFilterService } from "angular";
+import { formatSpeedValue } from "@renderer/app/filters/speed-format";
+import type { SettingsService } from "@renderer/app/services/settings";
 
 type BytesFilterTransform = IFilterNumber;
 
 interface SpeedLimitFilterTransform extends IFilterNumber {
     (bytesPerSecond: number | string | null | undefined): string;
+    $stateful?: boolean;
 }
 
 interface SpeedLimitFilterFactory {
-    ($filter: IFilterService): SpeedLimitFilterTransform;
+    ($filter: IFilterService, settingsService: SettingsService): SpeedLimitFilterTransform;
     $inject?: string[];
 }
 
 export class SpeedLimitFilter {
     public static getInstance(): SpeedLimitFilterFactory {
-        const factory: SpeedLimitFilterFactory = ($filter: IFilterService) =>
-            new SpeedLimitFilter($filter<BytesFilterTransform>("bytes")).transform;
-        factory.$inject = ["$filter"];
+        const factory: SpeedLimitFilterFactory = ($filter: IFilterService, settingsService: SettingsService) => {
+            const transform = new SpeedLimitFilter($filter<BytesFilterTransform>("bytes"), settingsService).transform;
+            // The rendered unit comes from user settings rather than from the
+            // filter input, so opt out of the stateless filter optimisation.
+            transform.$stateful = true;
+            return transform;
+        };
+        factory.$inject = ["$filter", "settingsService"];
         return factory;
     }
 
-    constructor(private bytesFilter: BytesFilterTransform) {}
+    constructor(
+        private bytesFilter: BytesFilterTransform,
+        private settingsService: SettingsService,
+    ) {}
 
     public transform: SpeedLimitFilterTransform = (bytesPerSecond): string => {
         const value = Number(bytesPerSecond);
@@ -32,6 +43,7 @@ export class SpeedLimitFilter {
             return "∞";
         }
 
-        return `${this.bytesFilter(value)}/s`;
+        const unit = this.settingsService.getAllSettings().ui.speedUnit;
+        return `${formatSpeedValue(value, unit, this.bytesFilter)}/s`;
     };
 }

--- a/src/renderer/app/filters/speed-limit.filter.ts
+++ b/src/renderer/app/filters/speed-limit.filter.ts
@@ -1,8 +1,6 @@
-import { IFilterNumber, IFilterService } from "angular";
-import { formatSpeedValue } from "@renderer/app/filters/speed-format";
+import { IFilterNumber } from "angular";
+import { formatBits, formatBytes } from "@renderer/app/filters/speed-format";
 import type { SettingsService } from "@renderer/app/services/settings";
-
-type BytesFilterTransform = IFilterNumber;
 
 interface SpeedLimitFilterTransform extends IFilterNumber {
     (bytesPerSecond: number | string | null | undefined): string;
@@ -10,27 +8,24 @@ interface SpeedLimitFilterTransform extends IFilterNumber {
 }
 
 interface SpeedLimitFilterFactory {
-    ($filter: IFilterService, settingsService: SettingsService): SpeedLimitFilterTransform;
+    (settingsService: SettingsService): SpeedLimitFilterTransform;
     $inject?: string[];
 }
 
 export class SpeedLimitFilter {
     public static getInstance(): SpeedLimitFilterFactory {
-        const factory: SpeedLimitFilterFactory = ($filter: IFilterService, settingsService: SettingsService) => {
-            const transform = new SpeedLimitFilter($filter<BytesFilterTransform>("bytes"), settingsService).transform;
+        const factory: SpeedLimitFilterFactory = (settingsService: SettingsService) => {
+            const transform = new SpeedLimitFilter(settingsService).transform;
             // The rendered unit comes from user settings rather than from the
             // filter input, so opt out of the stateless filter optimisation.
             transform.$stateful = true;
             return transform;
         };
-        factory.$inject = ["$filter", "settingsService"];
+        factory.$inject = ["settingsService"];
         return factory;
     }
 
-    constructor(
-        private bytesFilter: BytesFilterTransform,
-        private settingsService: SettingsService,
-    ) {}
+    constructor(private settingsService: SettingsService) {}
 
     public transform: SpeedLimitFilterTransform = (bytesPerSecond): string => {
         const value = Number(bytesPerSecond);
@@ -43,7 +38,7 @@ export class SpeedLimitFilter {
             return "∞";
         }
 
-        const unit = this.settingsService.getAllSettings().ui.speedUnit;
-        return `${formatSpeedValue(value, unit, this.bytesFilter)}/s`;
+        const format = this.settingsService.getAllSettings().ui.speedUnit === "bits" ? formatBits : formatBytes;
+        return `${format(value)}/s`;
     };
 }

--- a/src/renderer/app/filters/speed.filter.ts
+++ b/src/renderer/app/filters/speed.filter.ts
@@ -1,4 +1,6 @@
 import { IFilterNumber, IFilterService } from "angular";
+import { formatSpeedValue } from "@renderer/app/filters/speed-format";
+import type { SettingsService } from "@renderer/app/services/settings";
 
 type BytesFilterTransform = IFilterNumber;
 type SpeedFilterTorrent = {
@@ -7,22 +9,31 @@ type SpeedFilterTorrent = {
 
 interface SpeedFilterTransform extends IFilterNumber {
     (bytesPerSecond: number | string, torrent?: SpeedFilterTorrent | number | string): string;
+    $stateful?: boolean;
 }
 
 interface SpeedFilterFactory {
-    ($filter: IFilterService): SpeedFilterTransform;
+    ($filter: IFilterService, settingsService: SettingsService): SpeedFilterTransform;
     $inject?: string[];
 }
 
 export class SpeedFilter {
     public static getInstance(): SpeedFilterFactory {
-        const factory: SpeedFilterFactory = ($filter: IFilterService) =>
-            new SpeedFilter($filter<BytesFilterTransform>("bytes")).transform;
-        factory.$inject = ["$filter"];
+        const factory: SpeedFilterFactory = ($filter: IFilterService, settingsService: SettingsService) => {
+            const transform = new SpeedFilter($filter<BytesFilterTransform>("bytes"), settingsService).transform;
+            // The rendered unit comes from user settings rather than from the
+            // filter input, so opt out of the stateless filter optimisation.
+            transform.$stateful = true;
+            return transform;
+        };
+        factory.$inject = ["$filter", "settingsService"];
         return factory;
     }
 
-    constructor(private bytesFilter: BytesFilterTransform) {}
+    constructor(
+        private bytesFilter: BytesFilterTransform,
+        private settingsService: SettingsService,
+    ) {}
 
     public transform: SpeedFilterTransform = (bytesPerSecond, torrent): string => {
         let display = true;
@@ -32,7 +43,8 @@ export class SpeedFilter {
         }
 
         if (display) {
-            return `${this.bytesFilter(bytesPerSecond)}/s`;
+            const unit = this.settingsService.getAllSettings().ui.speedUnit;
+            return `${formatSpeedValue(bytesPerSecond, unit, this.bytesFilter)}/s`;
         }
 
         return "";

--- a/src/renderer/app/filters/speed.filter.ts
+++ b/src/renderer/app/filters/speed.filter.ts
@@ -1,8 +1,7 @@
-import { IFilterNumber, IFilterService } from "angular";
-import { formatSpeedValue } from "@renderer/app/filters/speed-format";
+import { IFilterNumber } from "angular";
+import { formatBits, formatBytes } from "@renderer/app/filters/speed-format";
 import type { SettingsService } from "@renderer/app/services/settings";
 
-type BytesFilterTransform = IFilterNumber;
 type SpeedFilterTorrent = {
     isStatusDownloading: () => boolean;
 };
@@ -13,27 +12,24 @@ interface SpeedFilterTransform extends IFilterNumber {
 }
 
 interface SpeedFilterFactory {
-    ($filter: IFilterService, settingsService: SettingsService): SpeedFilterTransform;
+    (settingsService: SettingsService): SpeedFilterTransform;
     $inject?: string[];
 }
 
 export class SpeedFilter {
     public static getInstance(): SpeedFilterFactory {
-        const factory: SpeedFilterFactory = ($filter: IFilterService, settingsService: SettingsService) => {
-            const transform = new SpeedFilter($filter<BytesFilterTransform>("bytes"), settingsService).transform;
+        const factory: SpeedFilterFactory = (settingsService: SettingsService) => {
+            const transform = new SpeedFilter(settingsService).transform;
             // The rendered unit comes from user settings rather than from the
             // filter input, so opt out of the stateless filter optimisation.
             transform.$stateful = true;
             return transform;
         };
-        factory.$inject = ["$filter", "settingsService"];
+        factory.$inject = ["settingsService"];
         return factory;
     }
 
-    constructor(
-        private bytesFilter: BytesFilterTransform,
-        private settingsService: SettingsService,
-    ) {}
+    constructor(private settingsService: SettingsService) {}
 
     public transform: SpeedFilterTransform = (bytesPerSecond, torrent): string => {
         let display = true;
@@ -43,8 +39,8 @@ export class SpeedFilter {
         }
 
         if (display) {
-            const unit = this.settingsService.getAllSettings().ui.speedUnit;
-            return `${formatSpeedValue(bytesPerSecond, unit, this.bytesFilter)}/s`;
+            const format = this.settingsService.getAllSettings().ui.speedUnit === "bits" ? formatBits : formatBytes;
+            return `${format(bytesPerSecond)}/s`;
         }
 
         return "";

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -31,6 +31,7 @@ export interface ContextMenuPlacement {
 export type ColorTheme = "light" | "dark"
 export type ThemePreference = ColorTheme | "system"
 export type SystemStartupOption = "disabled" | "open" | "background"
+export type SpeedUnit = "bytes" | "bits"
 
 export interface AppMeta {
     appName: string
@@ -334,6 +335,7 @@ export interface AppSettings<TServer = StoredServerConfig> {
         fixedHeader: boolean
         theme: ThemePreference
         sidebarCollapsed: boolean
+        speedUnit: SpeedUnit
     }
     servers: TServer[]
     certificates: string[]

--- a/src/shared/settings-defaults.ts
+++ b/src/shared/settings-defaults.ts
@@ -21,6 +21,7 @@ const DEFAULT_SETTINGS: AppSettings = {
         fixedHeader: false,
         theme: 'system',
         sidebarCollapsed: false,
+        speedUnit: 'bytes',
     },
 }
 

--- a/test/specs/mock/speed-units.spec.ts
+++ b/test/specs/mock/speed-units.spec.ts
@@ -1,0 +1,71 @@
+import chai from "chai"
+import { $$, browser } from "@wdio/globals"
+import { Torrent } from "../../e2e"
+import { eventually } from "../../e2e/eventually"
+import { configureSpec, getTestFixture } from "../../framework/fixture"
+
+const assert: Chai.AssertStatic = chai.assert
+
+// The "Saved Settings" notification overlaps the settings button while it is
+// on screen, so wait it out before navigating back into the settings page.
+async function waitForNotificationsToClear() {
+  await eventually(async () => (await $$(".ui.message.positive")).length).equals(0, { timeout: 20 * 1000 })
+}
+
+describe("mock speed units", function () {
+  configureSpec()
+
+  it("defaults to bytes per second", async function () {
+    const app = getTestFixture().app
+
+    await app.openSettings()
+    await app.settingsGotoTab("general")
+    assert.equal(await app.getGeneralDropdownValue("Speed Units"), "Bytes (MB/s)")
+    await app.settingsCancel()
+  })
+
+  it("renders transfer speeds in the configured unit", async function () {
+    const hash = "0000000000000000000000000000000000000002"
+    await browser.execute(async (torrent) => {
+      await (window as any).electorrent.bittorrent.invokeAction({
+        action: "addMockedTorrent",
+        args: [torrent],
+      })
+    }, {
+      hash,
+      name: "Speed unit torrent",
+      state: "downloading",
+      dl_speed: 1024 * 1024,
+      up_speed: 512 * 1024,
+    })
+
+    const app = getTestFixture().app
+    const torrent = new Torrent({ hash, app })
+    await torrent.waitForExist()
+
+    const downloadSpeed = async () => (await torrent.getColumn("downloadSpeed")).trim()
+    const uploadSpeed = async () => (await torrent.getColumn("uploadSpeed")).trim()
+
+    await eventually(downloadSpeed).equals("1 MB/s")
+    await eventually(uploadSpeed).equals("512 KB/s")
+
+    await app.openSettings()
+    await app.settingsGotoTab("general")
+    await app.selectGeneralDropdownValue("Speed Units", "Bits (Mb/s)")
+    await app.settingsSave()
+    await app.torrentsPageIsVisible()
+    await waitForNotificationsToClear()
+
+    await eventually(downloadSpeed).equals("8.4 Mb/s")
+    await eventually(uploadSpeed).equals("4.2 Mb/s")
+
+    await app.openSettings()
+    await app.settingsGotoTab("general")
+    await app.selectGeneralDropdownValue("Speed Units", "Bytes (MB/s)")
+    await app.settingsSave()
+    await app.torrentsPageIsVisible()
+    await waitForNotificationsToClear()
+
+    await eventually(downloadSpeed).equals("1 MB/s")
+  })
+})


### PR DESCRIPTION
## Summary

Transfer speeds are always rendered in bytes per second. This adds a **Speed Units**
setting under General Settings so they can be shown in bits per second instead — the
unit ISPs and network tools use, which makes it easier to compare against line speed.

Default is `bytes`, so existing behaviour is unchanged.

## What changed

- New `ui.speedUnit` setting (`"bytes" | "bits"`), defaulting to `bytes`
- New `speed-format.ts` helper formatting a byte rate as bits using decimal (SI)
  prefixes, per networking convention — 1 MB/s renders as 8.4 Mb/s
- `speed` and `speedLimit` filters resolve the unit from `settingsService`
- Settings card in General Settings

Applies to the torrent table speed columns, the status bar totals, the peers tab and
the speed/limit fields in the details panel. Byte sizes are untouched, and the speed
limit *input* fields stay in KB/s since that is what the clients expect.

## Note on `$stateful`

Both filters are marked `$stateful`. Their output now depends on user settings rather
than on the input value alone, so Angular's stateless-filter input tracking would keep
displaying the previous unit until the underlying speed changed. Without the flag the
table does not refresh after saving the setting.

## Testing

`npm run lint` and `npm run build` pass. Added `test/specs/mock/speed-units.spec.ts`
covering the default, switching to bits, and switching back. Also verified manually on
Windows against qBittorrent.

Two pre-existing failures in the mock suite (`software-update`, and one case in
`sorting`) reproduce on an unmodified checkout in my environment and appear unrelated.

## Screenshots
<img width="1200" height="800" alt="1-table-bytes" src="https://github.com/user-attachments/assets/23298ff8-3508-422a-8d74-0ad721879e70" />
<img width="1200" height="800" alt="3-setting-bits" src="https://github.com/user-attachments/assets/b547d4af-3c05-430d-aef0-dbfb1bd591aa" />
<img width="1200" height="800" alt="4-table-bits" src="https://github.com/user-attachments/assets/f0f4bf58-ae7f-41b2-b8b9-d28935d33673" />
