### PR TITLE
feat: configurable torrent deletion confirmation

### DIFF
--- a/src/renderer/app/directives/settings-general/settings-general.template.html
+++ b/src/renderer/app/directives/settings-general/settings-general.template.html
@@ -275,10 +275,10 @@
         <div class="content">
             <div class="header">
                 <i class="warning sign icon"></i>
-                Confirm torrent deletion
+                Confirm torrent data deletion
             </div>
             <div class="description">
-                Display a confirmation dialog before deleting torrents
+                Display a confirmation dialog before deleting torrents and their data
             </div>
         </div>
         <div class="center aligned extra content">

--- a/src/renderer/app/directives/settings-general/settings-general.template.html
+++ b/src/renderer/app/directives/settings-general/settings-general.template.html
@@ -270,4 +270,19 @@
             <toggle ng-model="ctl.settings.alwaysPromptUploadOptions"></toggle>
         </div>
     </div>
+
+    <div class="ui card">
+        <div class="content">
+            <div class="header">
+                <i class="warning sign icon"></i>
+                Confirm torrent deletion
+            </div>
+            <div class="description">
+                Display a confirmation dialog before deleting torrents
+            </div>
+        </div>
+        <div class="center aligned extra content">
+            <toggle ng-model="ctl.settings.confirmTorrentDeletion"></toggle>
+        </div>
+    </div>
 </div>

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -381,6 +381,12 @@ export class TorrentsPageController {
 
         function remove() {
             const selectedTorrents = $scope.arrayTorrents.filter(({ selected: isSelected }: { selected: boolean }) => isSelected);
+            if (selectedTorrents.length === 0) {
+                return $q.resolve();
+            }
+            if (settings.confirmTorrentDeletion !== false && !window.confirm("Are you sure you want to delete the selected torrents?")) {
+                return $q.resolve();
+            }
             return $rootScope.$btclient?.deleteTorrents(selectedTorrents)
                 .then(() => {
                     return syncAfterTorrentMutation();

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -266,7 +266,11 @@ export class TorrentsPageController {
         $scope.$on("remove-and-delete:torrents", () => {
             const deleteAction = findContextActionByRole($rootScope.$btclient?.contextMenu || [], "delete");
             if (deleteAction && selected.length > 0) {
-                openDeleteConfirmation(deleteAction.click, deleteAction.label);
+                if (settings.confirmTorrentDeletion !== false) {
+                    openDeleteConfirmation(deleteAction.click, deleteAction.label);
+                } else {
+                    runContextAction(deleteAction.click, selected);
+                }
             }
         });
 
@@ -382,9 +386,6 @@ export class TorrentsPageController {
         function remove() {
             const selectedTorrents = $scope.arrayTorrents.filter(({ selected: isSelected }: { selected: boolean }) => isSelected);
             if (selectedTorrents.length === 0) {
-                return $q.resolve();
-            }
-            if (settings.confirmTorrentDeletion !== false && !window.confirm("Are you sure you want to delete the selected torrents?")) {
                 return $q.resolve();
             }
             return $rootScope.$btclient?.deleteTorrents(selectedTorrents)
@@ -772,7 +773,7 @@ export class TorrentsPageController {
                 }
                 return $q.resolve();
             }
-            if (item && item.role === "delete") {
+            if (item && item.role === "delete" && settings.confirmTorrentDeletion !== false) {
                 openDeleteConfirmation(action, label);
                 return $q.resolve();
             }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -325,6 +325,7 @@ export interface AppSettings<TServer = StoredServerConfig> {
     debugMode?: boolean
     autoRemoveTorrents?: boolean
     alwaysPromptUploadOptions?: boolean
+    confirmTorrentDeletion?: boolean
     watchDirectory?: string
     ui: {
         resizeMode: string

--- a/src/shared/settings-defaults.ts
+++ b/src/shared/settings-defaults.ts
@@ -11,6 +11,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     debugMode: false,
     autoRemoveTorrents: false,
     alwaysPromptUploadOptions: false,
+    confirmTorrentDeletion: true,
     watchDirectory: '',
     ui: {
         resizeMode: 'OverflowResizer',

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -53,6 +53,22 @@ async function sendTorrentActionShortcut(accelerator: string) {
   }, accelerator)
 }
 
+async function hasTorrentActionShortcut(accelerator: string): Promise<boolean> {
+  return await browser.electron.execute((electron, accelerator) => {
+    const menu = electron.Menu.getApplicationMenu()
+    const actionsMenu = menu?.items.find((item) => item.id === "actions" || item.label === "Actions")
+    const findShortcut = (items: Electron.MenuItem[]): Electron.MenuItem | undefined => {
+      for (const item of items) {
+        if (item.accelerator === accelerator) return item
+        const submenuItem = item.submenu && findShortcut(item.submenu.items)
+        if (submenuItem) return submenuItem
+      }
+    }
+    const menuItem = actionsMenu?.submenu && findShortcut(actionsMenu.submenu.items)
+    return Boolean(menuItem && menuItem.visible && menuItem.enabled)
+  }, accelerator)
+}
+
 async function sendRemoveShortcut() {
   await sendTorrentActionShortcut("Delete")
 }
@@ -168,6 +184,9 @@ describe("torrent actions", function () {
   })
 
   it("Delete removes the torrent without confirmation", async function () {
+    if (!await hasTorrentActionShortcut("Delete")) {
+      return this.skip()
+    }
     this.timeout(60 * 1000)
     const filename = await createTorrentFile(tracker, {
       torrentName: createUniqueLabel("remove-no-confirm"),

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -9,7 +9,7 @@ import { waitForModalClose, waitForModalOpen } from "../../e2e/modal"
 import { createTorrentFile } from "../../torrent"
 import { configureSpec, createUniqueLabel, getTestFixture } from "../../framework/fixture"
 
-const { assert } = chai
+const assert: Chai.AssertStatic = chai.assert
 const fixture = getTestFixture()
 const client = fixture.client
 const backend = fixture.backend
@@ -27,7 +27,7 @@ function findDownloadedDirectoryCommand(downloadRoot: string, contentName: strin
   return `find ${shellQuote(downloadRoot)} -maxdepth 5 -type d -name ${shellQuote(contentName)} -print -quit`
 }
 
-async function sendRemoveAndDeleteShortcut() {
+async function sendTorrentActionShortcut(accelerator: string) {
   await browser.electron.execute((electron) => {
     const win = electron.BrowserWindow.getFocusedWindow()
       || electron.BrowserWindow.getAllWindows().find((window) => !window.isDestroyed())
@@ -38,7 +38,7 @@ async function sendRemoveAndDeleteShortcut() {
     const actionsMenu = menu?.items.find((item) => item.id === "actions" || item.label === "Actions")
     const findShortcut = (items: Electron.MenuItem[]): Electron.MenuItem | undefined => {
       for (const item of items) {
-        if (item.accelerator === "CmdOrCtrl+Delete") return item
+        if (item.accelerator === accelerator) return item
         const submenuItem = item.submenu && findShortcut(item.submenu.items)
         if (submenuItem) return submenuItem
       }
@@ -46,11 +46,19 @@ async function sendRemoveAndDeleteShortcut() {
     const menuItem = actionsMenu?.submenu && findShortcut(actionsMenu.submenu.items)
 
     if (!menuItem || !menuItem.visible || !menuItem.enabled) {
-      throw new Error("CmdOrCtrl+Delete action is unavailable")
+      throw new Error(`${accelerator} action is unavailable`)
     }
 
     menuItem.click({}, win, win.webContents)
-  })
+  }, accelerator)
+}
+
+async function sendRemoveShortcut() {
+  await sendTorrentActionShortcut("Delete")
+}
+
+async function sendRemoveAndDeleteShortcut() {
+  await sendTorrentActionShortcut("CmdOrCtrl+Delete")
 }
 
 describe("torrent actions", function () {
@@ -133,7 +141,7 @@ describe("torrent actions", function () {
     }
   })
 
-  it("delete action shows a confirmation modal", async function () {
+  it("remove and delete action shows a confirmation modal", async function () {
     const modal = await torrent.openDeleteConfirmation()
     await eventually(() => modal.$(".content").getText()).contains("Are you sure")
 
@@ -157,6 +165,56 @@ describe("torrent actions", function () {
     await waitForModalClose(modal)
 
     await torrent.waitForExist()
+  })
+
+  it("Delete removes the torrent without confirmation", async function () {
+    this.timeout(60 * 1000)
+    const filename = await createTorrentFile(tracker, {
+      torrentName: createUniqueLabel("remove-no-confirm"),
+      fileSize: 1,
+    })
+    const torrentToRemove = await this.app.uploadTorrent({ filename })
+
+    await torrentToRemove.waitForExist({ timeout: 20 * 1000 })
+    await $(torrentToRemove.query).click()
+    await sendRemoveShortcut()
+    await torrentToRemove.waitForGone()
+
+    assert.isFalse(await $("#deleteTorrentModal").isDisplayed())
+  })
+
+  it("delete confirmation setting disables remove and delete confirmations", async function () {
+    this.timeout(60 * 1000)
+    const filename = await createTorrentFile(tracker, {
+      torrentName: createUniqueLabel("delete-no-confirm"),
+      fileSize: 1,
+    })
+    const torrentToDelete = await this.app.uploadTorrent({ filename })
+
+    await torrentToDelete.waitForExist({ timeout: 20 * 1000 })
+    await this.app.openSettings()
+    await this.app.settingsGotoTab("general")
+    const initialState = await this.app.getGeneralToggleState("Confirm torrent data deletion")
+    await this.app.setGeneralToggle("Confirm torrent data deletion", false)
+    await this.app.settingsSave()
+    await this.app.torrentsPageIsVisible()
+
+    try {
+      await $(torrentToDelete.query).click()
+      await sendRemoveAndDeleteShortcut()
+      await torrentToDelete.waitForGone()
+      assert.isFalse(await $("#deleteTorrentModal").isDisplayed())
+    } finally {
+      await this.app.openSettings()
+      await this.app.settingsGotoTab("general")
+      await this.app.setGeneralToggle("Confirm torrent data deletion", initialState)
+      await this.app.settingsSave()
+      await this.app.torrentsPageIsVisible()
+
+      if (await torrentToDelete.isExisting()) {
+        await torrentToDelete.delete()
+      }
+    }
   })
 
   it("torrent is stopped and resumed", async function () {

--- a/test/specs/standard/torrent-actions.spec.ts
+++ b/test/specs/standard/torrent-actions.spec.ts
@@ -28,7 +28,7 @@ function findDownloadedDirectoryCommand(downloadRoot: string, contentName: strin
 }
 
 async function sendTorrentActionShortcut(accelerator: string) {
-  await browser.electron.execute((electron) => {
+  await browser.electron.execute((electron, accelerator) => {
     const win = electron.BrowserWindow.getFocusedWindow()
       || electron.BrowserWindow.getAllWindows().find((window) => !window.isDestroyed())
 


### PR DESCRIPTION
Adds a user-configurable confirmation dialog before deleting torrents as raised in #407.

Changes

- Adds  confirmTorrentDeletion  to the shared settings contract.
- Enables confirmation by default for backward-compatible behavior.
- Adds a Confirm torrent deletion toggle under Settings → General.
- Skips the confirmation dialog when the setting is disabled.
