### PR TITLE
fix: defer window creation until app is ready on launch handlers

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -441,17 +441,26 @@ async function bootstrap() {
     } else {
         app.on('second-instance', function(_event: ElectronEvent, args: string[]) {
             queueAndFlushPendingLaunchArgs(args)
+            if (!app.isReady()) {
+                return
+            }
             showOrCreateTorrentWindow()
         })
     }
 
     app.on('open-url', function(_event: ElectronEvent, url: string) {
         queueAndFlushPendingLaunchArgs([url])
+        if (!app.isReady()) {
+            return
+        }
         showOrCreateTorrentWindow()
     })
 
     app.on('open-file', function(_event: ElectronEvent, filePath: string) {
         queueAndFlushPendingLaunchArgs([filePath])
+        if (!app.isReady()) {
+            return
+        }
         showOrCreateTorrentWindow()
     })
 


### PR DESCRIPTION
Closes #785

On macOS, `app.on("open-url")`, `app.on("open-file")`, and `app.on("second-instance")` can fire before `app.on("ready")`. The handlers immediately called `showOrCreateTorrentWindow()`, which tries to create a `BrowserWindow` too early and throws:

```
Error: Cannot create BrowserWindow before app is ready
```

This PR keeps queuing the launch arguments but defers `showOrCreateTorrentWindow()` until `app.isReady()` is true. The queued magnet/torrent payloads are still flushed once the renderer loads.

Verified with `npm run lint` and `npm run build`.