### PR TITLE
fix(rtorrent): normalize file paths

### DIFF
--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -21,6 +21,14 @@ type RtorrentDeleteMetadata = {
 
 type RtorrentMulticallCommand = string | [string, ...any[]]
 
+function normalizeFilePath(value: unknown): string {
+    if (typeof value === "string") {
+        return value
+    }
+
+    return Buffer.isBuffer(value) ? value.toString("utf8") : ""
+}
+
 export class RtorrentRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
         { role: "start", label: "Start", action: "start", icon: "play" },
@@ -480,6 +488,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         files.forEach((file) => stringsToNumbers(file))
 
         return files.map((file: Record<string, any>, index: number) => {
+                const filePath = normalizeFilePath(file.path)
                 const size = typeof file.size === "number" ? file.size : 0
                 const totalChunks = typeof file.totalChunks === "number" ? file.totalChunks : 0
                 const completedChunks = typeof file.completedChunks === "number" ? file.completedChunks : 0
@@ -487,8 +496,8 @@ export class RtorrentRuntime implements BittorrentRuntime {
 
                 return {
                     index,
-                    path: file.path || "",
-                    name: (file.path || "").split(/[/\\]/).pop() || "",
+                    path: filePath,
+                    name: filePath.split(/[/\\]/).pop() || "",
                     size,
                     progress: totalChunks > 0 ? Math.max(0, Math.min(1, completedChunks / totalChunks)) : 0,
                     priority,


### PR DESCRIPTION
## Summary

- normalize rTorrent file paths before deriving display names
- decode binary XML-RPC path values from buffers
- fall back to an empty string for other malformed path values

## Research

rTorrent 0.16.x added binary/base64 RPC variants for non-UTF-8 path data. The XML-RPC client decodes base64 values as Node buffers, while the torrent file adapter assumed every truthy `f.path` value was a string. That allowed a non-string RPC value to reach `.split()` and reject the `bittorrent:get-torrent-files` IPC request.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "rtorrent:latest" --spec "test/specs/standard/torrent-details.spec.ts" --headless` (5 passing, 1 skipped)

Closes #784