### PR TITLE
fix(linux): use static AppImage runtime

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,8 @@
 directories:
   output: dist
   buildResources: build
+toolsets:
+  appimage: 1.0.3
 productName: Electorrent
 appId: com.github.tympanix.electorrent
 mac:


### PR DESCRIPTION
## Summary

- configure electron-builder to use AppImage toolset 1.0.3
- replace the legacy FUSE2-dependent runtime with the static AppImage runtime
- preserve electron-builder block-map generation for differential updates

Closes #781

## Validation

- npm run lint
- npm run build
- npm run smoketest
- npx electron-builder --linux AppImage --publish never
- verified the generated AppImage runtime is static-pie linked