### PR TITLE
feat(rtorrent): show peer connection and flags

### DIFF
--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -507,17 +507,37 @@ export class RtorrentRuntime implements BittorrentRuntime {
             uploadSpeed: "p.up_rate",
             downloaded: "p.down_total",
             uploaded: "p.up_total",
+            incoming: "p.is_incoming",
+            encrypted: "p.is_encrypted",
+            obfuscated: "p.is_obfuscated",
+            snubbed: "p.is_snubbed",
+            unwanted: "p.is_unwanted",
+            preferred: "p.is_preferred",
+            banned: "p.banned",
         })
-        return peers.map((peer) => ({
-            ip: typeof peer.ip === "string" ? peer.ip : "",
-            port: Number(peer.port) || undefined,
-            client: typeof peer.client === "string" ? peer.client : "",
-            progress: Math.max(0, Math.min(1, (Number(peer.progress) || 0) / 100)),
-            downloadSpeed: Number(peer.downloadSpeed) || 0,
-            uploadSpeed: Number(peer.uploadSpeed) || 0,
-            downloaded: Number(peer.downloaded) || 0,
-            uploaded: Number(peer.uploaded) || 0,
-        }))
+        return peers.map((peer) => {
+            const flags = [
+                [peer.encrypted, "Encrypted"],
+                [peer.obfuscated, "Obfuscated"],
+                [peer.snubbed, "Snubbed"],
+                [peer.unwanted, "Unwanted"],
+                [peer.preferred, "Preferred"],
+                [peer.banned, "Banned"],
+            ].flatMap(([value, label]) => Number(value) !== 0 ? [label] : [])
+
+            return {
+                ip: typeof peer.ip === "string" ? peer.ip : "",
+                port: Number(peer.port) || undefined,
+                client: typeof peer.client === "string" ? peer.client : "",
+                progress: Math.max(0, Math.min(1, (Number(peer.progress) || 0) / 100)),
+                downloadSpeed: Number(peer.downloadSpeed) || 0,
+                uploadSpeed: Number(peer.uploadSpeed) || 0,
+                downloaded: Number(peer.downloaded) || 0,
+                uploaded: Number(peer.uploaded) || 0,
+                connection: Number(peer.incoming) !== 0 ? "Incoming" : "Outgoing",
+                flags: flags.join(", ") || "None",
+            }
+        })
     }
 
     async getTorrentTrackers(hash: string): Promise<BittorrentTorrentDetailsTracker[]> {

--- a/test/clients/rtorrent/index.ts
+++ b/test/clients/rtorrent/index.ts
@@ -17,6 +17,11 @@ const features = {
   },
 } satisfies TorrentClientFeatures
 
+const specs = [
+  "test/specs/standard/**/*.spec.ts",
+  "test/specs/rtorrent/**/*.spec.ts",
+]
+
 export default {
   rtorrent: defineClient({
     key: "rtorrent",
@@ -31,6 +36,7 @@ export default {
     authProxyHostPort: 48081,
     username: "admin",
     password: "admin",
+    specs,
     downloadRoot: "/downloads",
     saveLocation: "/downloads/custom/save/location",
   }),
@@ -47,6 +53,7 @@ export default {
     authProxyHostPort: 48083,
     username: "admin",
     password: "admin",
+    specs,
     downloadRoot: "/downloads",
     saveLocation: "/downloads/custom/save/location",
   }),

--- a/test/specs/rtorrent/torrent-peer-columns.spec.ts
+++ b/test/specs/rtorrent/torrent-peer-columns.spec.ts
@@ -1,0 +1,59 @@
+import * as e2e from "../../e2e"
+import { eventually } from "../../e2e/eventually"
+import { configureSpec, getTestFixture, requireFeature } from "../../framework/fixture"
+import { createTorrentFile } from "../../torrent"
+
+describe("rTorrent peer columns", function () {
+  configureSpec()
+  requireFeature(({ features }) => features.torrentPeers === true)
+
+  it("shows connection direction and flags for a connected peer", async function () {
+    this.timeout(60 * 1000)
+
+    const filename = await createTorrentFile(getTestFixture().tracker, {
+      fileSize: 100_000,
+      downloadSpeed: 1,
+      uploadSpeed: 1,
+      seedDelay: 15,
+    })
+    const torrent: e2e.Torrent = await this.app.uploadTorrent({ filename })
+    await torrent.waitForExist()
+
+    let detailsPanelOpen = false
+    try {
+      const panel = await torrent.openDetailsPanel()
+      detailsPanelOpen = true
+      await torrent.openDetailsTab("peers")
+
+      const peersTab = panel.$("[data-role='torrent-details-peers']")
+      await eventually(async () => (await peersTab.$$("tbody td[data-col='ip']")).length).satisfies(
+        "contain a connected peer row",
+        (peerCount) => peerCount > 0,
+        { timeout: 30_000 },
+      )
+
+      const connection = await peersTab.$("tbody td[data-col='connection']").getText()
+      const flags = await peersTab.$("tbody td[data-col='flags']").getText()
+      const validFlags = new Set([
+        "Encrypted",
+        "Obfuscated",
+        "Snubbed",
+        "Unwanted",
+        "Preferred",
+        "Banned",
+        "None",
+      ])
+
+      new Set(["Incoming", "Outgoing"]).has(connection).should.equal(true)
+      flags.should.not.equal("")
+      flags.split(", ").every((flag) => validFlags.has(flag)).should.equal(true)
+    } finally {
+      if (detailsPanelOpen) {
+        await torrent.closeDetailsPanel()
+      }
+      if (await torrent.isExisting()) {
+        await torrent.delete()
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- map rTorrent peer direction to Incoming or Outgoing
- expose readable peer-state flags from rTorrent's peer API
- add dedicated rTorrent browser coverage for both columns

## Validation
- npm run lint
- npm run build
- npm run test -- --client rtorrent:latest --spec test/specs/rtorrent/torrent-peer-columns.spec.ts --headless

Closes #782