### PR TITLE
feat(rtorrent): support file selection

### DIFF
--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -94,10 +94,18 @@ export class RtorrentRuntime implements BittorrentRuntime {
             return
         }
 
+        await this.setTorrentFileSelection(hash, unwantedFiles)
+    }
+
+    async setTorrentFileSelection(hash: string, files: BittorrentFileSelection[]): Promise<void> {
+        if (files.length === 0) {
+            return
+        }
+
         await this.call("system.multicall", [[
-            ...unwantedFiles.map((file): RtorrentMethodCall => ({
+            ...files.map((file): RtorrentMethodCall => ({
                 methodName: "f.priority.set",
-                params: [`${hash}:f${file.index}`, 0],
+                params: [`${hash}:f${file.index}`, file.wanted ? 1 : 0],
             })),
             {
                 methodName: "d.update_priorities",
@@ -240,6 +248,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
             features: {
                 magnetLinks: true,
                 labels: true,
+                fileSelection: true,
                 uploadFileSelection: true,
                 torrentDetails: true,
                 torrentPeers: true,

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -105,7 +105,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
         await this.call("system.multicall", [[
             ...files.map((file): RtorrentMethodCall => ({
                 methodName: "f.priority.set",
-                params: [`${hash}:f${file.index}`, file.wanted ? 1 : 0],
+                params: [`${hash}:f${file.index}`, file.wanted ? 2 : 0],
             })),
             {
                 methodName: "d.update_priorities",

--- a/src/renderer/app/bittorrent/rtorrent/rtorrentservice.ts
+++ b/src/renderer/app/bittorrent/rtorrent/rtorrentservice.ts
@@ -1,8 +1,8 @@
 import { Column } from "@renderer/app/services/column";
-import { Torrent } from "@renderer/app/bittorrent/abstracttorrent";
+import { Torrent, TorrentFile } from "@renderer/app/bittorrent/abstracttorrent";
 import { TorrentActionList, TorrentClient, TorrentDetailsInfoSection, TorrentSpeedLimitOptions, TorrentUpdates, TorrentUploadOptions } from "@renderer/app/bittorrent/torrentclient";
 import { RtorrentTorrent } from "./torrentr";
-import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, uploadTorrent } from "@renderer/app/bittorrent/ipc";
+import { addTorrentUrl, getSnapshot, getTorrentDetails, invokeAction, setTorrentFileSelection, uploadTorrent } from "@renderer/app/bittorrent/ipc";
 import type { BittorrentTorrentDetailsData } from "@shared/ipc-contract";
 
 export class RtorrentClient extends TorrentClient<RtorrentTorrent> {
@@ -79,6 +79,10 @@ export class RtorrentClient extends TorrentClient<RtorrentTorrent> {
 
     setSpeedLimits(torrents: RtorrentTorrent[], options: TorrentSpeedLimitOptions): Promise<void> {
       return invokeAction("setSpeedLimits", torrents.map((torrent) => torrent.id), options)
+    }
+
+    setTorrentFileSelection(torrent: RtorrentTorrent, files: TorrentFile[]): Promise<void> {
+      return setTorrentFileSelection(torrent.id, files)
     }
 
     protected getTorrentDetailsData(torrent: RtorrentTorrent): Promise<BittorrentTorrentDetailsData> {

--- a/test/clients/rtorrent/index.ts
+++ b/test/clients/rtorrent/index.ts
@@ -5,6 +5,7 @@ import { defineClient } from "../define"
 const features = {
   magnetLinks: true,
   labels: true,
+  fileSelection: true,
   uploadFileSelection: true,
   torrentDetails: true,
   torrentPeers: true,


### PR DESCRIPTION
## Summary

- advertise existing-torrent file selection for rTorrent
- update per-file priorities through `f.priority.set` and refresh them with `d.update_priorities`
- expose selection through the renderer client and enable the shared test for both rTorrent fixtures

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "rtorrent" --spec "test/specs/standard/torrent-file-selection.spec.ts" --headless`
- `npm run test -- --client "rtorrent:latest" --spec "test/specs/standard/torrent-file-selection.spec.ts" --headless`