### PR TITLE
feat(qbittorrent): support HTTP Basic auth

### DIFF
--- a/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/base-api.ts
@@ -21,6 +21,7 @@ export type QBittorrentApiOptions = {
     ca?: Uint8Array
     strictSSL?: boolean
     timeout?: number
+    useBasicAuth?: boolean
 }
 
 export abstract class QBittorrentBaseApi {
@@ -60,6 +61,13 @@ export abstract class QBittorrentBaseApi {
             headers: {
                 Referer: this.origin,
             },
+            ...(options.useBasicAuth ? {
+                auth: {
+                    user: this.user,
+                    pass: this.pass,
+                    sendImmediately: true,
+                },
+            } : {}),
         }
     }
 

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -148,7 +148,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
 
     private async selectApi(server: BittorrentServerConfig) {
         const origin = serverOriginUrl(server)
-        const requestOptions = {
+        const requestOptions: request.CoreOptions & request.UriOptions = {
             timeout: HTTP_LOGIN_TIMEOUT,
             ca: server.certificateData,
             strictSSL: server.tlsSecurity !== "insecure",
@@ -159,16 +159,30 @@ export class QBittorrentRuntime implements BittorrentRuntime {
             uri: this.url(server, "version/api"),
         }
 
-        const hasLegacyApi = await new Promise<boolean>((resolve, reject) => {
-            request(requestOptions, (err: any, res: any) => {
+        const probeLegacyApi = (useBasicAuth: boolean) => new Promise<number>((resolve, reject) => {
+            request({
+                ...requestOptions,
+                ...(useBasicAuth ? {
+                    auth: {
+                        user: server.user,
+                        pass: server.password,
+                        sendImmediately: true,
+                    },
+                } : {}),
+            }, (err: any, res: any) => {
                 if (err) {
                     reject(err)
                     return
                 }
 
-                resolve(res?.statusCode === 200)
+                resolve(res?.statusCode || 0)
             })
         })
+
+        const statusCode = await probeLegacyApi(false)
+        const authenticatedStatusCode = statusCode === 401 ? await probeLegacyApi(true) : statusCode
+        const useBasicAuth = statusCode === 401 && authenticatedStatusCode !== 401
+        const hasLegacyApi = authenticatedStatusCode === 200
 
         const options = {
             origin,
@@ -178,6 +192,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
             ca: server.certificateData,
             strictSSL: server.tlsSecurity !== "insecure",
             timeout: HTTP_REQUEST_TIMEOUT,
+            useBasicAuth,
         }
 
         return hasLegacyApi ? new QBittorrentApiV1(options) : new QBittorrentApiV2(options)

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -39,7 +39,28 @@ const legacyFeatures = {
   uploadFileSelection: false,
 } satisfies TorrentClientFeatures
 
+const basicAuthSpecs = [
+  "test/specs/qbittorrent/http-basic-auth.spec.ts",
+]
+
 export default {
+  "qbittorrent:http-basic-auth": defineClient({
+    key: "qbittorrent:http-basic-auth",
+    clientId: "qbittorrent",
+    features,
+    fixture: "clients/qbittorrent",
+    version: "latest",
+    port: 58080,
+    containerPort: 8080,
+    containerHostPort: 58081,
+    proxyPort: 8080,
+    authProxyHostPort: 58080,
+    authProxyPasswordFile: "qbittorrent-basic-auth.htpasswd",
+    username: "admin",
+    password: "adminadmin",
+    specs: basicAuthSpecs,
+    downloadRoot: "/downloads",
+  }),
   "qbittorrent:4.1": defineClient({
     key: "qbittorrent:4.1",
     clientId: "qbittorrent",

--- a/test/clients/types.ts
+++ b/test/clients/types.ts
@@ -15,6 +15,7 @@ export interface TestClient {
   containerHostPort?: number
   proxyPort?: number
   authProxyHostPort?: number
+  authProxyPasswordFile?: string
   acceptHttpStatus: number
   acceptHttpPath?: string
   stopLabel: string

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - PROXY_HOST=${PROXY_HOST}
       - PROXY_PORT=${PROXY_PORT}
       - NGINX_AUTH_PORT=${NGINX_AUTH_PORT:-8081}
+      - NGINX_AUTH_PASSWORD_FILE=${NGINX_AUTH_PASSWORD_FILE:-rtorrent-basic-auth.htpasswd}
 
   aria2:
     image: opengg/aria2:${VERSION:-edge}

--- a/test/framework/service.ts
+++ b/test/framework/service.ts
@@ -149,6 +149,7 @@ export default class ElectorrentTestService {
       NGINX_HOST_PORT: String(proxyPort),
       NGINX_AUTH_HOST_PORT: String(authProxyPort),
       NGINX_AUTH_PORT: "8081",
+      NGINX_AUTH_PASSWORD_FILE: client.authProxyPasswordFile ?? "rtorrent-basic-auth.htpasswd",
       PROXY_HOST: this.getClientServiceName(client),
       PROXY_PORT: String(client.proxyPort ?? client.containerPort ?? client.port),
       RPC_PORT: String(52000 + clientIndex + portOffset),

--- a/test/shared/nginx/rootfs/etc/nginx/conf.d/qbittorrent-basic-auth.htpasswd
+++ b/test/shared/nginx/rootfs/etc/nginx/conf.d/qbittorrent-basic-auth.htpasswd
@@ -1,0 +1,1 @@
+admin:{PLAIN}adminadmin

--- a/test/shared/nginx/rootfs/etc/nginx/templates/default.conf.template
+++ b/test/shared/nginx/rootfs/etc/nginx/templates/default.conf.template
@@ -12,7 +12,7 @@ server {
 
   location / {
     auth_basic "Electorrent test fixture";
-    auth_basic_user_file /etc/nginx/conf.d/rtorrent-basic-auth.htpasswd;
+    auth_basic_user_file /etc/nginx/conf.d/${NGINX_AUTH_PASSWORD_FILE};
 
     proxy_http_version 1.1;
     proxy_set_header   Host               ${PROXY_HOST}:${PROXY_PORT};

--- a/test/specs/qbittorrent/http-basic-auth.spec.ts
+++ b/test/specs/qbittorrent/http-basic-auth.spec.ts
@@ -1,0 +1,12 @@
+import { configureSpec, getTestFixture } from "../../framework/fixture"
+
+const client = getTestFixture().client
+
+describe("qBittorrent HTTP Basic authentication", function () {
+  configureSpec({ login: false })
+
+  it("logs in through an HTTP Basic authenticated reverse proxy", async function () {
+    await this.app.login(client)
+    await this.app.torrentsPageIsVisible()
+  })
+})


### PR DESCRIPTION
## Summary

- retry qBittorrent API detection with HTTP Basic credentials after a 401 challenge
- retain Basic credentials for API requests while preserving native qBittorrent cookie authentication
- add an nginx-backed qBittorrent fixture and focused login test

Closes #787

## Validation

- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:http-basic-auth" --spec "test/specs/qbittorrent/http-basic-auth.spec.ts" --headless