### PR TITLE
build: exclude source maps from packages

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -5,6 +5,8 @@ toolsets:
   appimage: 1.0.3
 productName: Electorrent
 appId: com.github.tympanix.electorrent
+files:
+  - '!**/*.map'
 mac:
   category: public.app-category.utilities
   extendInfo:


### PR DESCRIPTION
## Summary

- exclude generated `.map` files from electron-builder package contents
- keep source-map generation available for development builds
- reduce the packaged `app.asar` size by avoiding approximately 20 MB of source maps

Addresses action point 4 in #797.

## Validation

- `npm run lint`
- `npm run build`
- `npx electron-builder --dir --config.directories.output=/tmp/electorrent-package-check`
- inspected packaged archive: 0 `.map` files (22 remain in `app/` for development)
- `npm run smoketest` *(blocked by pre-existing missing generated fixtures under `test/shared/opentracker/data/shared/`; setup fails with `ENOENT`)*