### PR TITLE
feat(files): add priority controls

### DIFF
--- a/src/main/lib/bittorrent/clients/deluge/index.ts
+++ b/src/main/lib/bittorrent/clients/deluge/index.ts
@@ -1,7 +1,7 @@
 import request from "request"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFilePriority, BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
 import {
     defer,
     HTTP_LOGIN_TIMEOUT,
@@ -83,6 +83,12 @@ const DELUGE_TORRENT_DETAIL_FIELDS = [
 ]
 
 const DELUGE_TORRENT_FILES_FIELDS = ["files", "file_progress", "file_priorities"]
+const DELUGE_FILE_PRIORITIES: readonly BittorrentFilePriority[] = Object.freeze([
+    { id: "skip", label: "Skip", value: 0, wanted: false },
+    { id: "normal", label: "Normal", value: 1, wanted: true },
+    { id: "high", label: "High", value: 2, wanted: true },
+    { id: "highest", label: "Highest", value: 5, wanted: true },
+])
 
 export class DelugeRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
@@ -295,6 +301,7 @@ export class DelugeRuntime implements BittorrentRuntime {
                 magnetLinks: Array.isArray(methods) && methods.includes("core.add_torrent_magnet"),
                 labels: this.supportsLabels,
                 uploadFileSelection: true,
+                filePriorities: DELUGE_FILE_PRIORITIES,
                 torrentDetails: true,
                 torrentPeers: true,
                 torrentTrackers: true,
@@ -430,6 +437,19 @@ export class DelugeRuntime implements BittorrentRuntime {
                     wanted: priority !== 0,
                 }
             })
+    }
+
+    async setTorrentFilePriority(hash: string, fileIndexes: number[], priorityId: string): Promise<void> {
+        const priority = DELUGE_FILE_PRIORITIES.find((item) => item.id === priorityId)
+        if (!priority) throw new Error(`Unsupported Deluge file priority: ${priorityId}`)
+        if (!fileIndexes.length) return
+
+        const files = await this.getTorrentFiles(hash)
+        const priorities = files.map((file) => file.priority ?? 1)
+        fileIndexes.forEach((index) => {
+            if (index >= 0 && index < priorities.length) priorities[index] = priority.value
+        })
+        await defer<void>((done) => this.rpc("core.set_torrent_file_priorities", [hash, priorities], done))
     }
 
     async getTorrentPeers(hash: string): Promise<BittorrentTorrentPeer[]> {

--- a/src/main/lib/bittorrent/clients/mock.ts
+++ b/src/main/lib/bittorrent/clients/mock.ts
@@ -1,4 +1,5 @@
 import type {
+    BittorrentFilePriority,
     BittorrentFileSelection,
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
@@ -13,6 +14,12 @@ import parseTorrent from "parse-torrent"
 
 const PRIORITY_SKIP = 0
 const PRIORITY_NORMAL = 1
+const MOCK_FILE_PRIORITIES: readonly BittorrentFilePriority[] = Object.freeze([
+    { id: "skip", label: "Skip", value: 0, wanted: false },
+    { id: "normal", label: "Normal", value: 1, wanted: true },
+    { id: "high", label: "High", value: 6, wanted: true },
+    { id: "maximum", label: "Maximum", value: 7, wanted: true },
+])
 
 interface MockTorrent {
     added_on: number
@@ -117,6 +124,7 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
                 magnetLinks: true,
                 labels: true,
                 fileSelection: true,
+                filePriorities: MOCK_FILE_PRIORITIES,
                 uploadFileSelection: true,
                 setLocation: true,
                 torrentDetails: true,
@@ -385,6 +393,14 @@ export class MockBittorrentRuntime implements BittorrentRuntime {
                 file.priority = selection.wanted ? PRIORITY_NORMAL : PRIORITY_SKIP
             }
         })
+    }
+
+    async setTorrentFilePriority(hash: string, fileIndexes: number[], priorityId: string): Promise<void> {
+        this.assertConnected()
+        const priority = MOCK_FILE_PRIORITIES.find((item) => item.id === priorityId)
+        if (!priority) throw new Error(`Unsupported mock file priority: ${priorityId}`)
+        const files = this.files.get(hash) || []
+        files.filter((file) => fileIndexes.includes(file.index)).forEach((file) => { file.priority = priority.value })
     }
 
     async setRatioLimit(hashes: string[], options: Record<string, any>): Promise<void> {

--- a/src/main/lib/bittorrent/clients/qbittorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/qbittorrent/index.ts
@@ -3,6 +3,7 @@ import request from "request"
 import parseTorrent from "parse-torrent"
 
 import type {
+    BittorrentFilePriority,
     BittorrentFileSelection,
     BittorrentServerConfig,
     BittorrentTorrentDetailsData,
@@ -20,6 +21,12 @@ import type { QBittorrentBaseApi } from "./base-api"
 
 const QBITTORRENT_PRIORITY_SKIP = 0
 const QBITTORRENT_PRIORITY_NORMAL = 1
+const QBITTORRENT_FILE_PRIORITIES: readonly BittorrentFilePriority[] = Object.freeze([
+    { id: "skip", label: "Skip", value: 0, wanted: false },
+    { id: "normal", label: "Normal", value: 1, wanted: true },
+    { id: "high", label: "High", value: 6, wanted: true },
+    { id: "maximum", label: "Maximum", value: 7, wanted: true },
+])
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null
@@ -222,6 +229,7 @@ export class QBittorrentRuntime implements BittorrentRuntime {
                 magnetLinks: true,
                 labels: true,
                 fileSelection: true,
+                filePriorities: QBITTORRENT_FILE_PRIORITIES,
                 uploadFileSelection: api.supportsUploadFileSelection,
                 setLocation: true,
                 torrentDetails: true,
@@ -739,5 +747,20 @@ export class QBittorrentRuntime implements BittorrentRuntime {
 
         await setPriority(unwantedIds, QBITTORRENT_PRIORITY_SKIP)
         await setPriority(wantedIds, QBITTORRENT_PRIORITY_NORMAL)
+    }
+
+    async setTorrentFilePriority(hash: string, fileIndexes: number[], priorityId: string): Promise<void> {
+        const priority = QBITTORRENT_FILE_PRIORITIES.find((item) => item.id === priorityId)
+        if (!priority) {
+            throw new Error(`Unsupported qBittorrent file priority: ${priorityId}`)
+        }
+        if (!fileIndexes.length) return
+
+        await new Promise<void>((resolve, reject) => {
+            this.getApi().setTorrentFilePriority(hash, fileIndexes, priority.value, (err: unknown) => {
+                if (err) reject(err)
+                else resolve()
+            })
+        })
     }
 }

--- a/src/main/lib/bittorrent/clients/rtorrent/index.ts
+++ b/src/main/lib/bittorrent/clients/rtorrent/index.ts
@@ -3,7 +3,7 @@ import { URL } from "node:url"
 import xmlrpc from "@electorrent/xmlrpc"
 import parseTorrent from "parse-torrent"
 
-import type { BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
+import type { BittorrentFilePriority, BittorrentFileSelection, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from "@shared/ipc-contract"
 import { defer, HTTP_LOGIN_TIMEOUT, serverUrl } from "@main/lib/bittorrent/helpers"
 import type { BittorrentRuntime } from "@main/lib/bittorrent/types"
 import type { TorrentActionItem } from "@shared/torrent-actions"
@@ -20,6 +20,12 @@ type RtorrentDeleteMetadata = {
 }
 
 type RtorrentMulticallCommand = string | [string, ...any[]]
+
+const RTORRENT_FILE_PRIORITIES: readonly BittorrentFilePriority[] = Object.freeze([
+    { id: "skip", label: "Skip", value: 0, wanted: false },
+    { id: "normal", label: "Normal", value: 1, wanted: true },
+    { id: "high", label: "High", value: 2, wanted: true },
+])
 
 function normalizeFilePath(value: unknown): string {
     if (typeof value === "string") {
@@ -111,6 +117,20 @@ export class RtorrentRuntime implements BittorrentRuntime {
                 methodName: "d.update_priorities",
                 params: [hash],
             },
+        ]])
+    }
+
+    async setTorrentFilePriority(hash: string, fileIndexes: number[], priorityId: string): Promise<void> {
+        const priority = RTORRENT_FILE_PRIORITIES.find((item) => item.id === priorityId)
+        if (!priority) throw new Error(`Unsupported rTorrent file priority: ${priorityId}`)
+        if (!fileIndexes.length) return
+
+        await this.call("system.multicall", [[
+            ...fileIndexes.map((index): RtorrentMethodCall => ({
+                methodName: "f.priority.set",
+                params: [`${hash}:f${index}`, priority.value],
+            })),
+            { methodName: "d.update_priorities", params: [hash] },
         ]])
     }
 
@@ -249,6 +269,7 @@ export class RtorrentRuntime implements BittorrentRuntime {
                 magnetLinks: true,
                 labels: true,
                 fileSelection: true,
+                filePriorities: RTORRENT_FILE_PRIORITIES,
                 uploadFileSelection: true,
                 torrentDetails: true,
                 torrentPeers: true,

--- a/src/main/lib/bittorrent/clients/transmission.ts
+++ b/src/main/lib/bittorrent/clients/transmission.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios'
 import httpAdapter from 'axios/lib/adapters/http.js'
 import https from 'https'
 
-import type { BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from '@shared/ipc-contract'
+import type { BittorrentFilePriority, BittorrentServerConfig, BittorrentTorrentDetailsData, BittorrentTorrentDetailsFile, BittorrentTorrentDetailsTracker, BittorrentTorrentPeer, TorrentClientConnection } from '@shared/ipc-contract'
 import {
     HTTP_LOGIN_TIMEOUT,
     HTTP_REQUEST_TIMEOUT,
@@ -102,6 +102,12 @@ const TRANSMISSION_TORRENT_DETAILS_FIELDS = TRANSMISSION_FIELDS.filter((field) =
 ].includes(field))
 
 const TRANSMISSION_TORRENT_FILES_FIELDS = ['files', 'fileStats', 'priorities', 'wanted']
+const TRANSMISSION_FILE_PRIORITIES: readonly BittorrentFilePriority[] = Object.freeze([
+    { id: 'skip', label: 'Skip', value: 0, wanted: false },
+    { id: 'low', label: 'Low', value: -1, wanted: true },
+    { id: 'normal', label: 'Normal', value: 0, wanted: true },
+    { id: 'high', label: 'High', value: 1, wanted: true },
+])
 
 export class TransmissionRuntime implements BittorrentRuntime {
     readonly actions: TorrentActionItem[] = [
@@ -230,6 +236,7 @@ export class TransmissionRuntime implements BittorrentRuntime {
                 magnetLinks: true,
                 labels: true,
                 uploadFileSelection: true,
+                filePriorities: TRANSMISSION_FILE_PRIORITIES,
                 setLocation: true,
                 torrentDetails: true,
                 torrentPeers: true,
@@ -609,6 +616,18 @@ export class TransmissionRuntime implements BittorrentRuntime {
         return this.doAction('torrent-set-location', hashes, {
             location,
             move: true,
+        }).then((response) => this.ensureSuccess(response)).then(() => undefined)
+    }
+
+    setTorrentFilePriority(hash: string, fileIndexes: number[], priorityId: string): Promise<void> {
+        const priority = TRANSMISSION_FILE_PRIORITIES.find((item) => item.id === priorityId)
+        if (!priority) return Promise.reject(new Error(`Unsupported Transmission file priority: ${priorityId}`))
+        if (!fileIndexes.length) return Promise.resolve()
+
+        const priorityField = priority.wanted ? `priority-${priority.id}` : undefined
+        return this.doAction('torrent-set', [hash], {
+            [priority.wanted ? 'files-wanted' : 'files-unwanted']: fileIndexes,
+            ...(priorityField ? { [priorityField]: fileIndexes } : {}),
         }).then((response) => this.ensureSuccess(response)).then(() => undefined)
     }
 

--- a/src/main/lib/bittorrent/manager.ts
+++ b/src/main/lib/bittorrent/manager.ts
@@ -7,6 +7,7 @@ import type {
     BittorrentInvokeActionRequest,
     BittorrentServerConfig,
     BittorrentSetTorrentFileSelectionRequest,
+    BittorrentSetTorrentFilePriorityRequest,
     TorrentClientConnection,
     BittorrentTorrentDetailsData,
     BittorrentTorrentDetailsFile,
@@ -250,6 +251,14 @@ class BittorrentManager {
             throw new Error("Torrent file selection not supported for this client")
         }
         return runtime.setTorrentFileSelection(request.id, request.files)
+    }
+
+    async setTorrentFilePriority(sender: WebContents, request: BittorrentSetTorrentFilePriorityRequest) {
+        const runtime = await this.getSession(sender)
+        if (typeof runtime.setTorrentFilePriority !== "function") {
+            throw new Error("Torrent file priorities not supported for this client")
+        }
+        return runtime.setTorrentFilePriority(request.id, request.fileIndexes, request.priorityId)
     }
 
     disconnectWindow(sender: WebContents | null | undefined) {

--- a/src/main/lib/bittorrent/types.ts
+++ b/src/main/lib/bittorrent/types.ts
@@ -24,5 +24,6 @@ export interface BittorrentRuntime {
     getTorrentPeers?(id: string): Promise<BittorrentTorrentPeer[]>
     getTorrentTrackers?(id: string): Promise<BittorrentTorrentDetailsTracker[]>
     setTorrentFileSelection?(id: string, files: BittorrentFileSelection[]): Promise<void>
+    setTorrentFilePriority?(id: string, fileIndexes: number[], priorityId: string): Promise<void>
     disconnect?(): Promise<void>
 }

--- a/src/main/lib/ipc.ts
+++ b/src/main/lib/ipc.ts
@@ -288,6 +288,10 @@ export function registerHandlers({ isDebug, forceTitleBarMenu, getWindow, consum
         return bittorrentManager.setTorrentFileSelection(event.sender, request)
     })
 
+    ipcMain.handle(IPC_CHANNELS.bittorrent.setTorrentFilePriority, async function(event: IpcMainInvokeEvent, request) {
+        return bittorrentManager.setTorrentFilePriority(event.sender, request)
+    })
+
     ipcMain.handle(IPC_CHANNELS.updates.check, async function(_event: IpcMainInvokeEvent, { verbose }) {
         updater.checkForUpdates(verbose)
     })

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -65,6 +65,7 @@ const electorrentBridge: ElectorrentBridge = {
         getTorrentPeers: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentPeers, request),
         getTorrentTrackers: (request) => invoke(IPC_CHANNELS.bittorrent.getTorrentTrackers, request),
         setTorrentFileSelection: (request) => invoke(IPC_CHANNELS.bittorrent.setTorrentFileSelection, request),
+        setTorrentFilePriority: (request) => invoke(IPC_CHANNELS.bittorrent.setTorrentFilePriority, request),
     },
     updates: {
         check: (verbose?: boolean) => invoke(IPC_CHANNELS.updates.check, { verbose }),

--- a/src/renderer/app/bittorrent/ipc.ts
+++ b/src/renderer/app/bittorrent/ipc.ts
@@ -83,3 +83,7 @@ export function getTorrentTrackers(id: string) {
 export function setTorrentFileSelection(id: string, files: BittorrentFileSelection[]) {
     return bridge().setTorrentFileSelection({ id, files })
 }
+
+export function setTorrentFilePriority(id: string, fileIndexes: number[], priorityId: string) {
+    return bridge().setTorrentFilePriority({ id, fileIndexes, priorityId })
+}

--- a/src/renderer/app/bittorrent/torrentclient.ts
+++ b/src/renderer/app/bittorrent/torrentclient.ts
@@ -1,6 +1,7 @@
 import { Torrent, TorrentFile } from "./abstracttorrent"
 import type {
     BittorrentTorrentDetailsData,
+    BittorrentFilePriority,
     BittorrentTorrentDetailsFile,
     BittorrentTorrentPeer,
     BittorrentTorrentDetailsTracker,
@@ -9,7 +10,7 @@ import type {
     TorrentSpeedLimitOptions,
     TorrentUploadOptions,
 } from "@shared/ipc-contract"
-import { connect, getActions, getTorrentFiles as getTorrentFilesData, getTorrentPeers as getTorrentPeersData, getTorrentTrackers as getTorrentTrackersData, invokeAction } from "./ipc"
+import { connect, getActions, getTorrentFiles as getTorrentFilesData, getTorrentPeers as getTorrentPeersData, getTorrentTrackers as getTorrentTrackersData, invokeAction, setTorrentFilePriority as setTorrentFilePriorityData } from "./ipc"
 import type { TorrentActionItem, TorrentActionRole } from "@shared/torrent-actions"
 
 export type { TorrentSpeedLimitOptions, TorrentUploadOptions, TorrentUploadOptionsEnable } from "@shared/ipc-contract"
@@ -58,6 +59,7 @@ const DEFAULT_FEATURES: ResolvedTorrentClientFeatures = Object.freeze({
     magnetLinks: false,
     labels: false,
     fileSelection: false,
+    filePriorities: Object.freeze([]),
     uploadFileSelection: false,
     setLocation: false,
     torrentDetails: false,
@@ -173,6 +175,7 @@ export interface TorrentDetailsFileColumn {
 
 export interface TorrentDetailsFileItem extends BittorrentTorrentDetailsFile {
     wanted: boolean
+    priorityId?: string
 }
 
 export interface TorrentDetailsPanelData {
@@ -316,6 +319,13 @@ export abstract class TorrentClient<T extends Torrent = Torrent> {
             throw new Error("File selection not supported for this client")
         }
         return Promise.reject(new Error("File selection not implemented for this client"))
+    }
+
+    async setTorrentFilePriority(torrent: T, files: TorrentDetailsFileItem[], priority: BittorrentFilePriority): Promise<void> {
+        if (!this.features.filePriorities.length) {
+            throw new Error("File priorities not supported for this client")
+        }
+        return setTorrentFilePriorityData(torrent.id, files.map((file) => file.index), priority.id)
     }
 
     /**

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
@@ -7,6 +7,7 @@ import {
 import { loadSortingState, SortChange, SortingOptions } from "@renderer/app/directives/sorting/sorting.controller";
 import type { SettingsService } from "@renderer/app/services/settings";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
+import type { BittorrentFilePriority } from "@shared/ipc-contract";
 
 type TorrentDetailsFiles = TorrentDetailsPanelData["files"];
 
@@ -77,6 +78,7 @@ export class TorrentDetailsFilesTabController {
       (files) => {
         files?.items.forEach((file) => {
           file.wanted = file.wanted !== false;
+          file.priorityId = this.priorityForFile(file)?.id;
         });
         this.scope.selectionError = null;
         this.loadSortingSettings();
@@ -99,6 +101,18 @@ export class TorrentDetailsFilesTabController {
 
   canSelectFiles() {
     return !!this.rootScope.$btclient?.features.fileSelection;
+  }
+
+  canChangeFilePriority() {
+    return this.filePriorities().length > 0;
+  }
+
+  filePriorities(): readonly BittorrentFilePriority[] {
+    return this.rootScope.$btclient?.features.filePriorities || [];
+  }
+
+  priorityLabel(file: TorrentDetailsFileItem) {
+    return this.priorityForFile(file)?.label || (file.priority == null ? "" : String(file.priority));
   }
 
   changeSorting = ({ sortKey, descending }: SortChange) => {
@@ -153,6 +167,13 @@ export class TorrentDetailsFilesTabController {
   toggleRowSelection(row: TorrentDetailsFileRow, event: Event) {
     event.stopPropagation();
     return this.updateFileSelection(row.filesInSubtree, !this.rowWanted(row));
+  }
+
+  changeRowPriority(row: TorrentDetailsFileRow) {
+    const priority = this.filePriorities().find((item) => item.id === row.data.priorityId);
+    if (priority) {
+      return this.updateFilePriority(row.filesInSubtree, priority);
+    }
   }
 
   formatFileCell(column: TorrentDetailsFileColumn, file: TorrentDetailsFileItem) {
@@ -291,6 +312,7 @@ export class TorrentDetailsFilesTabController {
         return values.reduce((sum, file) => sum + Number(file[key]), 0) / values.length;
       };
       const priorities = new Set(node.filesInSubtree.map((file) => file.priority).filter((value) => value != null));
+      const priorityIds = new Set(node.filesInSubtree.map((file) => file.priorityId));
       node.data = {
         ...node.data,
         size: totalSize,
@@ -298,6 +320,7 @@ export class TorrentDetailsFilesTabController {
         availability: weightedValue("availability"),
         wanted: node.filesInSubtree.every((file) => file.wanted !== false),
         priority: priorities.size === 1 ? priorities.values().next().value : undefined,
+        priorityId: priorityIds.size === 1 ? priorityIds.values().next().value : undefined,
       };
       return node.filesInSubtree;
     };
@@ -332,6 +355,49 @@ export class TorrentDetailsFilesTabController {
       this.scope.selectionUpdating = false;
       this.scope.$evalAsync();
     }
+  }
+
+  private async updateFilePriority(files: TorrentDetailsFileItem[], priority: BittorrentFilePriority) {
+    const client = this.rootScope.$btclient;
+    const torrent = this.scope.torrent;
+    if (!this.canChangeFilePriority() || !client || !torrent || this.scope.selectionUpdating || !files.length) {
+      return;
+    }
+
+    const previous = files.map((file) => ({
+      file,
+      priority: file.priority,
+      priorityId: file.priorityId,
+      wanted: file.wanted,
+    }));
+    files.forEach((file) => {
+      file.priority = priority.value;
+      file.priorityId = priority.id;
+      file.wanted = priority.wanted;
+    });
+    this.scope.selectionUpdating = true;
+    this.scope.selectionError = null;
+    this.sortFiles();
+
+    try {
+      await client.setTorrentFilePriority(torrent, files, priority);
+    } catch (err) {
+      previous.forEach((entry) => {
+        entry.file.priority = entry.priority;
+        entry.file.priorityId = entry.priorityId;
+        entry.file.wanted = entry.wanted;
+      });
+      this.scope.selectionError = err && err.message ? err.message : "Failed to update file priority";
+      this.sortFiles();
+    } finally {
+      this.scope.selectionUpdating = false;
+      this.scope.$evalAsync();
+    }
+  }
+
+  private priorityForFile(file: TorrentDetailsFileItem) {
+    return this.filePriorities().find((priority) =>
+      priority.value === file.priority && priority.wanted === (file.wanted !== false));
   }
 
   private async load() {

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
@@ -12,6 +12,7 @@ torrent-details-files-tab {
     .torrent-details-file-cell > span { display: block; }
     .torrent-details-file-progress { display: flex; align-items: center; gap: .5rem; }
     .torrent-details-file-progress > .ui.tiny.indicating.progress { flex: 1 1 auto; margin: 0; }
+    .ui.mini.dropdown.torrent-details-file-priority { min-width: 7em; min-height: 0; padding-top: .45em; padding-bottom: .45em; }
     .ui.tiny.negative.message.torrent-details-files-error { position: sticky; top: 0; z-index: 2; margin: 0; }
 
     .ui.checkbox.torrent-details-file-checkbox {

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
@@ -58,7 +58,7 @@
       </thead>
       <tbody>
         <tr
-          ng-repeat="row in ctl.scope.sortedFiles track by row.key"
+          ng-repeat="row in ctl.scope.sortedFiles track by row.key + ':' + (row.data.priorityId || 'mixed')"
           ng-class="{ 'torrent-details-folder-row': row.isDirectory }"
           data-file-index="{{ row.file.index }}"
           data-file-path="{{ row.data.path }}"
@@ -78,35 +78,56 @@
                 <label></label>
               </div>
             </div>
-            <div ng-if="column.id !== 'wanted'" ng-switch="column.format" class="torrent-details-file-cell">
-              <div ng-switch-when="progress" class="torrent-details-file-progress">
-                <div class="ui tiny indicating progress">
-                  <div class="bar" ng-style="{ width: ctl.fileProgressPercent(row.data) + '%' }"></div>
+            <div ng-if="column.id !== 'wanted'" class="torrent-details-file-cell">
+              <dropdown
+                ng-if="column.id === 'priority' && ctl.canChangeFilePriority()"
+                title="Mixed"
+                class="mini compact torrent-details-file-priority"
+                data-role="torrent-details-file-priority"
+                data-file-index="{{ row.file ? row.file.index : '' }}"
+                aria-label="Priority for {{ row.data.name }}"
+                ng-model="row.data.priorityId"
+                ng-disabled="ctl.scope.selectionUpdating"
+                ng-change="ctl.changeRowPriority(row)">
+                <dropdown-item
+                  ng-repeat="priority in ctl.filePriorities() track by priority.id"
+                  value="priority.id"
+                  title="priority.label"
+                  data-priority-id="{{ priority.id }}">
+                  {{ priority.label }}
+                </dropdown-item>
+              </dropdown>
+              <span ng-if="column.id === 'priority' && !ctl.canChangeFilePriority()">{{ ctl.priorityLabel(row.data) }}</span>
+              <div ng-if="column.id !== 'priority'" ng-switch="column.format">
+                <div ng-switch-when="progress" class="torrent-details-file-progress">
+                  <div class="ui tiny indicating progress">
+                    <div class="bar" ng-style="{ width: ctl.fileProgressPercent(row.data) + '%' }"></div>
+                  </div>
+                  <span>{{ ctl.fileProgressPercent(row.data) | number:1 }}%</span>
                 </div>
-                <span>{{ ctl.fileProgressPercent(row.data) | number:1 }}%</span>
-              </div>
-              <div
-                ng-switch-default
-                ng-if="column.id === 'name'"
-                class="torrent-details-file-name"
-                ng-style="{ 'padding-left': (row.depth * 18) + 'px' }"
-                title="{{ row.data.path }}"
-                ng-click="row.isDirectory && ctl.toggleFolder(row, $event)"
-              >
-                <button
-                  ng-if="row.isDirectory"
-                  type="button"
-                  class="ui icon basic button torrent-details-folder-toggle"
-                  aria-label="{{ ctl.isFolderExpanded(row) ? 'Collapse' : 'Expand' }} {{ row.data.name }}"
-                  aria-expanded="{{ ctl.isFolderExpanded(row) }}"
-                  ng-click="ctl.toggleFolder(row, $event)"
+                <div
+                  ng-switch-default
+                  ng-if="column.id === 'name'"
+                  class="torrent-details-file-name"
+                  ng-style="{ 'padding-left': (row.depth * 18) + 'px' }"
+                  title="{{ row.data.path }}"
+                  ng-click="row.isDirectory && ctl.toggleFolder(row, $event)"
                 >
-                  <i class="icon" ng-class="ctl.isFolderExpanded(row) ? 'caret down' : 'caret right'"></i>
-                </button>
-                <i ng-if="!row.isDirectory" class="file outline icon torrent-details-file-icon"></i>
-                <span>{{ row.data.name }}</span>
+                  <button
+                    ng-if="row.isDirectory"
+                    type="button"
+                    class="ui icon basic button torrent-details-folder-toggle"
+                    aria-label="{{ ctl.isFolderExpanded(row) ? 'Collapse' : 'Expand' }} {{ row.data.name }}"
+                    aria-expanded="{{ ctl.isFolderExpanded(row) }}"
+                    ng-click="ctl.toggleFolder(row, $event)"
+                  >
+                    <i class="icon" ng-class="ctl.isFolderExpanded(row) ? 'caret down' : 'caret right'"></i>
+                  </button>
+                  <i ng-if="!row.isDirectory" class="file outline icon torrent-details-file-icon"></i>
+                  <span>{{ row.data.name }}</span>
+                </div>
+                <span ng-switch-default ng-if="column.id !== 'name'">{{ ctl.formatFileCell(column, row.data) }}</span>
               </div>
-              <span ng-switch-default ng-if="column.id !== 'name'">{{ ctl.formatFileCell(column, row.data) }}</span>
             </div>
           </td>
         </tr>

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -200,6 +200,19 @@ export interface BittorrentSetTorrentFileSelectionRequest {
     files: BittorrentFileSelection[]
 }
 
+export interface BittorrentFilePriority {
+    readonly id: string
+    readonly label: string
+    readonly value: number
+    readonly wanted: boolean
+}
+
+export interface BittorrentSetTorrentFilePriorityRequest {
+    id: string
+    fileIndexes: number[]
+    priorityId: string
+}
+
 export interface LaunchPayload {
     magnets: PendingTorrentUploadLink[]
     torrentFiles: PendingTorrentUploadFile[]
@@ -260,6 +273,7 @@ export interface TorrentClientFeatures {
     readonly magnetLinks?: boolean
     readonly labels?: boolean
     readonly fileSelection?: boolean
+    readonly filePriorities?: readonly BittorrentFilePriority[]
     readonly uploadFileSelection?: boolean
     readonly setLocation?: boolean
     readonly torrentDetails?: boolean
@@ -303,6 +317,7 @@ export interface ResolvedTorrentClientFeatures {
     readonly magnetLinks: boolean
     readonly labels: boolean
     readonly fileSelection: boolean
+    readonly filePriorities: readonly BittorrentFilePriority[]
     readonly uploadFileSelection: boolean
     readonly setLocation: boolean
     readonly torrentDetails: boolean
@@ -463,6 +478,7 @@ export interface ElectorrentBridge {
         getTorrentPeers(request: BittorrentGetTorrentPeersRequest): Promise<BittorrentTorrentPeer[]>
         getTorrentTrackers(request: BittorrentGetTorrentTrackersRequest): Promise<BittorrentTorrentDetailsTracker[]>
         setTorrentFileSelection(request: BittorrentSetTorrentFileSelectionRequest): Promise<void>
+        setTorrentFilePriority(request: BittorrentSetTorrentFilePriorityRequest): Promise<void>
     }
     updates: {
         check(verbose?: boolean): Promise<void>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -40,6 +40,7 @@ export const IPC_CHANNELS = {
         getTorrentPeers: 'bittorrent:get-torrent-peers',
         getTorrentTrackers: 'bittorrent:get-torrent-trackers',
         setTorrentFileSelection: 'bittorrent:set-torrent-file-selection',
+        setTorrentFilePriority: 'bittorrent:set-torrent-file-priority',
     },
     updates: {
         check: 'updates:check',

--- a/test/clients/deluge/index.ts
+++ b/test/clients/deluge/index.ts
@@ -5,6 +5,12 @@ import { defineClient } from "../define"
 const baseFeatures = {
   labels: true,
   uploadFileSelection: true,
+  filePriorities: [
+    { id: "skip", label: "Skip", value: 0, wanted: false },
+    { id: "normal", label: "Normal", value: 1, wanted: true },
+    { id: "high", label: "High", value: 2, wanted: true },
+    { id: "highest", label: "Highest", value: 5, wanted: true },
+  ],
   torrentDetails: true,
   torrentPeers: true,
   torrentTrackers: true,

--- a/test/clients/mock/index.ts
+++ b/test/clients/mock/index.ts
@@ -5,6 +5,12 @@ const features = {
   magnetLinks: true,
   labels: true,
   fileSelection: true,
+  filePriorities: [
+    { id: "skip", label: "Skip", value: 0, wanted: false },
+    { id: "normal", label: "Normal", value: 1, wanted: true },
+    { id: "high", label: "High", value: 6, wanted: true },
+    { id: "maximum", label: "Maximum", value: 7, wanted: true },
+  ],
   uploadFileSelection: true,
   setLocation: true,
   torrentDetails: true,

--- a/test/clients/qbittorrent/index.ts
+++ b/test/clients/qbittorrent/index.ts
@@ -6,6 +6,12 @@ const features = {
   magnetLinks: true,
   labels: true,
   fileSelection: true,
+  filePriorities: [
+    { id: "skip", label: "Skip", value: 0, wanted: false },
+    { id: "normal", label: "Normal", value: 1, wanted: true },
+    { id: "high", label: "High", value: 6, wanted: true },
+    { id: "maximum", label: "Maximum", value: 7, wanted: true },
+  ],
   uploadFileSelection: true,
   setLocation: true,
   torrentDetails: true,

--- a/test/clients/rtorrent/index.ts
+++ b/test/clients/rtorrent/index.ts
@@ -6,6 +6,11 @@ const features = {
   magnetLinks: true,
   labels: true,
   fileSelection: true,
+  filePriorities: [
+    { id: "skip", label: "Skip", value: 0, wanted: false },
+    { id: "normal", label: "Normal", value: 1, wanted: true },
+    { id: "high", label: "High", value: 2, wanted: true },
+  ],
   uploadFileSelection: true,
   torrentDetails: true,
   torrentPeers: true,

--- a/test/clients/transmission/index.ts
+++ b/test/clients/transmission/index.ts
@@ -6,6 +6,12 @@ const features = {
   magnetLinks: true,
   labels: true,
   uploadFileSelection: true,
+  filePriorities: [
+    { id: "skip", label: "Skip", value: 0, wanted: false },
+    { id: "low", label: "Low", value: -1, wanted: true },
+    { id: "normal", label: "Normal", value: 0, wanted: true },
+    { id: "high", label: "High", value: 1, wanted: true },
+  ],
   setLocation: true,
   torrentDetails: true,
   torrentPeers: true,

--- a/test/specs/standard/torrent-file-priority.spec.ts
+++ b/test/specs/standard/torrent-file-priority.spec.ts
@@ -1,0 +1,67 @@
+import * as e2e from "../../e2e"
+import { eventually } from "../../e2e/eventually"
+import { configureSpec, getTestFixture, requireFeature } from "../../framework/fixture"
+import { createTorrentFile } from "../../torrent"
+
+const tracker = getTestFixture().tracker
+
+describe("torrent file priority", function () {
+  configureSpec()
+  requireFeature(({ features }) => Boolean(features.filePriorities?.length))
+
+  let torrent: e2e.Torrent
+
+  before(async function () {
+    const filename = await createTorrentFile(tracker, {
+      files: {
+        "first.bin": 100000,
+        "nested/second.bin": 100000,
+      },
+      downloadSpeed: 1,
+      uploadSpeed: 1,
+    })
+    torrent = await this.app.uploadTorrent({ filename })
+    await torrent.waitForExist()
+  })
+
+  after(async function () {
+    if (torrent && await torrent.isExisting()) await torrent.delete()
+  })
+
+  it("changes and persists a semantic priority in a multi-file torrent", async function () {
+    this.timeout(60 * 1000)
+
+    const priorities = getTestFixture().client.features.filePriorities || []
+    priorities.length.should.be.greaterThan(1)
+    const target = priorities.find((priority) => priority.id === "skip") || priorities[priorities.length - 1]
+
+    const panel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("files")
+
+    const getFileDropdowns = async () => {
+      return panel.$$("tbody tr:not(.torrent-details-folder-row) [data-role='torrent-details-file-priority']")
+    }
+    await eventually(async () => (await getFileDropdowns()).length)
+      .satisfies("include at least two file priority dropdowns", (count) => count >= 2, { timeout: 30_000 })
+
+    const dropdown = (await getFileDropdowns())[0]
+    const fileIndex = await dropdown.getAttribute("data-file-index")
+    if (!fileIndex) throw new Error("File priority dropdown did not expose its file index")
+    await dropdown.click()
+    const item = dropdown.$(`[data-priority-id='${target.id}']`)
+    await item.waitForClickable({ timeout: 10_000 })
+    await item.click()
+    const updatedDropdown = panel.$(`tbody tr:not(.torrent-details-folder-row) [data-role='torrent-details-file-priority'][data-file-index='${fileIndex}']`)
+    await eventually(() => updatedDropdown.$(".text").getText()).equals(target.label)
+
+    await torrent.closeDetailsPanel()
+    const reopenedPanel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("files")
+
+    const persistedDropdown = reopenedPanel.$(`tbody tr:not(.torrent-details-folder-row) [data-role='torrent-details-file-priority'][data-file-index='${fileIndex}']`)
+    await persistedDropdown.waitForDisplayed({ timeout: 30_000 })
+    await eventually(() => persistedDropdown.$(".text").getText()).equals(target.label)
+
+    await torrent.closeDetailsPanel()
+  })
+})


### PR DESCRIPTION
## Summary
- expose client-specific semantic file-priority capabilities
- add agnostic IPC and backend implementations for qBittorrent, rTorrent, Deluge, Transmission, and mock
- render compact priority dropdowns for file and folder rows with optimistic updates and rollback
- cover multi-file priority changes and persistence with a headless end-to-end test

## Validation
- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "torrent-file-priority.spec.ts" --headless