### PR TITLE
chore: configure Chrome DevTools MCP for Electron inspection

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,1 +1,17 @@
 sandbox_mode = "danger-full-access"
+
+[mcp_servers.chrome_devtools]
+command = "npx"
+args = [
+    "-y",
+    "chrome-devtools-mcp@1.8.0",
+    "--browser-url=http://127.0.0.1:9222",
+    "--no-usage-statistics",
+    "--no-performance-crux",
+]
+startup_timeout_sec = 30
+tool_timeout_sec = 60
+
+[mcp_servers.chrome_devtools.tools.evaluate_script]
+approval_mode = "approve"
+output_token_limit = 30000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,16 @@ gh pr checks --watch
 
 Do not actively poll or send progress updates. Resume only when checks are terminal or a check fails
 
+## Inspecting Electron with Chrome DevTools MCP
+The project-scoped `.codex/config.toml` registers the `chrome_devtools` MCP server. It is loaded for new Codex sessions opened from this trusted repository.
+
+Build the app, then start the inspectable Electron instance:
+```shell
+npm run app:mcp
+```
+
+Wait for `http://127.0.0.1:9222/json/version` to respond before using the MCP tools. Use `list_pages` to select the Electorrent renderer and `evaluate_script` with `() => document.documentElement.outerHTML` to inspect its HTML. The debugging port controls the application, so keep it bound to loopback and stop the Electron process when inspection is complete.
+
 # Coding Guidelines
 * Always use `--headless` when running tests
 * Avoid using `browser.execute` in browser testing - prefer organic user interaction

--- a/package-lock.json
+++ b/package-lock.json
@@ -8215,6 +8215,18 @@
         }
       }
     },
+    "node_modules/create-wdio/node_modules/@types/node": {
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.9.0"
+      }
+    },
     "node_modules/create-wdio/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -8525,6 +8537,15 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/create-wdio/node_modules/undici-types": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/create-wdio/node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -13493,6 +13514,18 @@
         }
       }
     },
+    "node_modules/inquirer/node_modules/@types/node": {
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.9.0"
+      }
+    },
     "node_modules/inquirer/node_modules/cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -13562,6 +13595,15 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/inquirer/node_modules/undici-types": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/inquirer/node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "app": "electron app/main.js",
     "app:debug": "NODE_ENV=test npm run app -- --force-title-bar-menu",
+    "app:mcp": "electron --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222 app/main.js",
     "build": "npm run build:webpack -- --mode production --config-node-env production",
     "build:webpack": "webpack --config webpack.config.js",
     "build:watch": "webpack --config webpack.config.js --mode development --config-node-env development --watch",


### PR DESCRIPTION
## Summary

- Configure the project-scoped Chrome DevTools MCP server.
- Add an `app:mcp` script to launch Electron with loopback remote debugging.
- Document the Electron inspection workflow in `AGENTS.md`.
- Update the lockfile for dependency metadata changes.

## Testing

- Not run (not requested)