### PR TITLE
fix(tray): open window on click

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -354,11 +354,7 @@ async function bootstrap() {
         }
 
         tray.setToolTip(app.name)
-        tray.on('click', () => {
-            refreshTrayMenu()
-            tray?.popUpContextMenu()
-        })
-        tray.on('double-click', showOrCreateTorrentWindow)
+        tray.on('click', showOrCreateTorrentWindow)
         refreshTrayMenu()
     }
 


### PR DESCRIPTION
## Summary

- open or create the Electorrent window on a normal tray icon click
- keep the existing context menu available through right-click
- remove the tray double-click handler

Closes #810

## Validation

- `npm run lint`
- `npm run build`
- `npm run smoketest`