### PR TITLE
fix(files): show compact priority menu

### DIFF
--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.less
@@ -12,7 +12,14 @@ torrent-details-files-tab {
     .torrent-details-file-cell > span { display: block; }
     .torrent-details-file-progress { display: flex; align-items: center; gap: .5rem; }
     .torrent-details-file-progress > .ui.tiny.indicating.progress { flex: 1 1 auto; margin: 0; }
-    .ui.mini.dropdown.torrent-details-file-priority { min-width: 7em; min-height: 0; padding-top: .45em; padding-bottom: .45em; }
+    .ui.mini.dropdown.torrent-details-file-priority {
+        min-width: 7em;
+        min-height: 0;
+        padding-top: .45em;
+        padding-bottom: .45em;
+
+        > .menu > .item { min-height: 0; padding: .45em .75em; }
+    }
     .ui.tiny.negative.message.torrent-details-files-error { position: sticky; top: 0; z-index: 2; margin: 0; }
 
     .ui.checkbox.torrent-details-file-checkbox {
@@ -43,6 +50,8 @@ torrent-details-files-tab {
         }
 
         > tbody > tr > td { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        > tbody > tr > td[data-col='priority'],
+        > tbody > tr > td[data-col='priority'] > .torrent-details-file-cell { overflow: visible; }
     }
 
     .torrent-details-file-selection-column {

--- a/test/specs/standard/torrent-file-priority.spec.ts
+++ b/test/specs/standard/torrent-file-priority.spec.ts
@@ -47,8 +47,18 @@ describe("torrent file priority", function () {
     const dropdown = (await getFileDropdowns())[0]
     const fileIndex = await dropdown.getAttribute("data-file-index")
     if (!fileIndex) throw new Error("File priority dropdown did not expose its file index")
+    const priorityCell = await dropdown.parentElement()
+    const priorityTableCell = await priorityCell.parentElement()
+    ;(await priorityCell.getCSSProperty("overflow-y")).value.should.equal("visible")
+    ;(await priorityTableCell.getCSSProperty("overflow-y")).value.should.equal("visible")
+    const filename = priorityTableCell.parentElement().$("[data-col='name'] .torrent-details-file-name > span")
+    ;(await filename.getCSSProperty("overflow-x")).value.should.equal("hidden")
+    ;(await filename.getCSSProperty("text-overflow")).value.should.equal("ellipsis")
+
     await dropdown.click()
     const item = dropdown.$(`[data-priority-id='${target.id}']`)
+    await item.waitForDisplayed({ timeout: 10_000 })
+    ;(await item.getSize("height")).should.be.at.most(await dropdown.getSize("height"))
     await item.waitForClickable({ timeout: 10_000 })
     await item.click()
     const updatedDropdown = panel.$(`tbody tr:not(.torrent-details-folder-row) [data-role='torrent-details-file-priority'][data-file-index='${fileIndex}']`)


### PR DESCRIPTION
## Summary

- allow file-priority menus to escape their table cells while retaining filename clipping and ellipsis
- reduce priority menu item spacing to match the compact dropdown trigger
- extend the file-priority E2E test to cover overflow, visibility, sizing, selection, and persistence

## Validation

- `npm run lint`
- `npm run build`
- `npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-file-priority.spec.ts" --headless`
- Electron UI inspected through Chrome DevTools; all menu items are visible and compact