### PR TITLE
fix(details): persist table column widths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "angular-animate": "^1.8.2",
         "angular-marked": "^1.2.2",
         "angular-resource": "^1.8.2",
-        "angular-table-resize": "^3.0.1",
+        "angular-table-resize": "^3.0.2",
         "angular-ui-sortable": "^0.19.0",
         "axios": "^1.18.1",
         "base64-js": "^1.2.0",
@@ -5246,9 +5246,9 @@
       "dev": true
     },
     "node_modules/angular-table-resize": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/angular-table-resize/-/angular-table-resize-3.0.1.tgz",
-      "integrity": "sha512-6d/GSLZWbMN5cFVOykSiC5MeUJttcH+Rw8it83VSnMnJ2OoFdHcziXO853erigsXEVLnTgIEdcpLNr8JPhNPkg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/angular-table-resize/-/angular-table-resize-3.0.2.tgz",
+      "integrity": "sha512-VbtqWY+ptLOOeXISVgYaxl4yZQ+MVn22PCimVBCGQk54QMWZge6QmlgM1uSHPe1WImH73brzTFGI0tFq3hU84g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "angular-animate": "^1.8.2",
     "angular-marked": "^1.2.2",
     "angular-resource": "^1.8.2",
-    "angular-table-resize": "^3.0.1",
+    "angular-table-resize": "^3.0.2",
     "angular-ui-sortable": "^0.19.0",
     "axios": "^1.18.1",
     "base64-js": "^1.2.0",

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
@@ -29,7 +29,7 @@
         <th ng-repeat="column in ctl.scope.columns track by column.id" rz-col="column.id" sort-header sort-key="column.id">
           <span class="torrent-details-table-header-label">{{ column.label }}</span>
         </th>
-        <th class="torrent-details-tracker-actions" ng-if="ctl.canManageTrackers()">Actions</th>
+        <th id="torrentDetailsTrackersActions" class="torrent-details-tracker-actions" ng-if="ctl.canManageTrackers()">Actions</th>
       </tr>
     </thead>
     <tbody>

--- a/test/specs/standard/torrent-details.spec.ts
+++ b/test/specs/standard/torrent-details.spec.ts
@@ -193,6 +193,53 @@ describe("torrent details", function () {
     await eventually(async () => (await urlHeader.getSize()).width)
       .satisfies(`change by at least 10 from ${initialWidth}`, (nextWidth) => Math.abs(nextWidth - initialWidth) >= 10)
 
+    const resizedWidth = (await urlHeader.getSize()).width
+
+    await torrent.closeDetailsPanel()
+
+    const reopenedPanel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("trackers")
+
+    const reopenedTrackersTable = reopenedPanel.$("[data-role='torrent-details-trackers-table']")
+    await reopenedTrackersTable.waitForDisplayed({ timeout: 30_000 })
+    const reopenedWidth = (await reopenedTrackersTable.$("thead th:first-child").getSize()).width
+    reopenedWidth.should.be.closeTo(resizedWidth, 1)
+
+    await torrent.closeDetailsPanel()
+  })
+
+  it("retains the resized tracker actions column", async function () {
+    this.timeout(60 * 1000)
+
+    if (getTestFixture().client.features.torrentTrackerManagement !== true) {
+      return this.skip()
+    }
+
+    const panel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("trackers")
+
+    const trackersTable = panel.$("[data-role='torrent-details-trackers-table']")
+    const actionsHeader = trackersTable.$("thead th.torrent-details-tracker-actions")
+    await actionsHeader.scrollIntoView({ block: "center", inline: "center" })
+    const handle = actionsHeader.$(".rz-handle")
+    await handle.waitForDisplayed({ timeout: 10_000 })
+
+    const initialWidth = (await actionsHeader.getSize()).width
+    await handle.dragAndDrop({ x: -40, y: 0 })
+    await eventually(async () => (await actionsHeader.getSize()).width)
+      .satisfies(`change by at least 10 from ${initialWidth}`, (nextWidth) => Math.abs(nextWidth - initialWidth) >= 10)
+
+    const resizedWidth = (await actionsHeader.getSize()).width
+    await torrent.closeDetailsPanel()
+
+    const reopenedPanel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("trackers")
+
+    const reopenedActionsHeader = reopenedPanel.$("[data-role='torrent-details-trackers-table'] thead th.torrent-details-tracker-actions")
+    await reopenedActionsHeader.waitForDisplayed({ timeout: 30_000 })
+    const reopenedWidth = (await reopenedActionsHeader.getSize()).width
+    reopenedWidth.should.be.closeTo(resizedWidth, 1)
+
     await torrent.closeDetailsPanel()
   })
 
@@ -240,6 +287,19 @@ describe("torrent details", function () {
 
     await eventually(async () => (await controlledHeader.getSize()).width)
       .satisfies(`change by at least 10 from ${initialWidth}`, (nextWidth) => Math.abs(nextWidth - initialWidth) >= 10)
+
+    const resizedWidth = (await controlledHeader.getSize()).width
+
+    await torrent.closeDetailsPanel()
+
+    const reopenedPanel = await torrent.openDetailsPanel()
+    await torrent.openDetailsTab("files")
+
+    const reopenedFilesTable = reopenedPanel.$("[data-role='torrent-details-files-table']")
+    await reopenedFilesTable.waitForDisplayed({ timeout: 30_000 })
+    const reopenedHeaders = await reopenedFilesTable.$$("thead th")
+    const reopenedWidth = (await reopenedHeaders[1].getSize()).width
+    reopenedWidth.should.be.closeTo(resizedWidth, 1)
 
     await torrent.closeDetailsPanel()
   })


### PR DESCRIPTION
## Summary
- upgrade angular-table-resize to 3.0.2
- give the static tracker Actions header a stable persistence identifier
- verify tracker and file column widths survive closing and reopening details

## Validation
- npm run lint
- npm run build
- npm run test -- --client qbittorrent:latest --spec test/specs/standard/torrent-details.spec.ts --headless