### PR TITLE
feat(table): set 250px default column width

### DIFF
--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.controller.ts
@@ -5,6 +5,7 @@ import {
   TorrentDetailsPanelData,
 } from "@renderer/app/bittorrent/torrentclient";
 import { loadSortingState, SortChange, SortingOptions } from "@renderer/app/directives/sorting/sorting.controller";
+import { DEFAULT_TABLE_RESIZE_OPTIONS, TableResizeOptions } from "@renderer/app/lib/table-resize-options";
 import type { SettingsService } from "@renderer/app/services/settings";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import type { BittorrentFilePriority } from "@shared/ipc-contract";
@@ -35,6 +36,7 @@ export interface TorrentDetailsFilesTabScope extends IScope {
   files: TorrentDetailsFiles;
   resizeMode: string;
   resizeProfile: string;
+  tableResizeOptions: Readonly<TableResizeOptions>;
   sortedFiles: TorrentDetailsFileRow[];
   loading: boolean;
   loaded: boolean;
@@ -72,6 +74,7 @@ export class TorrentDetailsFilesTabController {
     this.scope.error = null;
     this.scope.selectionUpdating = false;
     this.scope.selectionError = null;
+    this.scope.tableResizeOptions = DEFAULT_TABLE_RESIZE_OPTIONS;
     this.configureResize();
     this.scope.$watch(
       () => this.scope.files,

--- a/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-files-tab/torrent-details-files-tab.template.html
@@ -18,6 +18,7 @@
       rz-table
       rz-profile="ctl.scope.resizeProfile"
       rz-mode="ctl.scope.resizeMode"
+      rz-options="ctl.scope.tableResizeOptions"
       rz-container=".torrent-details-files-content"
       columns="ctl.scope.files.columns"
       class="ui compact single line unstackable fixed torrent resize table"

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.controller.ts
@@ -1,5 +1,6 @@
 import { IScope } from "angular"
 import type { SortChange } from "@renderer/app/directives/sorting/sorting.controller"
+import { DEFAULT_TABLE_RESIZE_OPTIONS, type TableResizeOptions } from "@renderer/app/lib/table-resize-options"
 import type { SettingsService } from "@renderer/app/services/settings"
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope"
 import type { BittorrentTorrentPeer } from "@shared/ipc-contract"
@@ -10,6 +11,7 @@ export interface TorrentDetailsPeersTabScope extends IScope {
   peers: { items: BittorrentTorrentPeer[] }
   resizeMode: string
   resizeProfile: string
+  tableResizeOptions: Readonly<TableResizeOptions>
   columns: TorrentDetailsPeerColumn[]
   sortedPeers: BittorrentTorrentPeer[]
   loading: boolean
@@ -52,6 +54,7 @@ export class TorrentDetailsPeersTabController {
     this.scope.loading = false
     this.scope.loaded = false
     this.scope.error = null
+    this.scope.tableResizeOptions = DEFAULT_TABLE_RESIZE_OPTIONS
     this.configureResize()
     this.scope.$watch(() => this.scope.peers, () => this.sortPeers())
     this.scope.$watchGroup(

--- a/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-peers-tab/torrent-details-peers-tab.template.html
@@ -16,6 +16,7 @@
       rz-table
       rz-profile="ctl.scope.resizeProfile"
       rz-mode="ctl.scope.resizeMode"
+      rz-options="ctl.scope.tableResizeOptions"
       rz-container=".torrent-details-peers-content"
       columns="ctl.scope.columns"
     >

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
@@ -1,5 +1,6 @@
 import { IScope } from "angular"
 import type { SortChange } from "@renderer/app/directives/sorting/sorting.controller"
+import { DEFAULT_TABLE_RESIZE_OPTIONS, type TableResizeOptions } from "@renderer/app/lib/table-resize-options"
 import type { SettingsService } from "@renderer/app/services/settings"
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope"
 import type { BittorrentTorrentDetailsTracker } from "@shared/ipc-contract"
@@ -17,6 +18,7 @@ export interface TorrentDetailsTrackersTabScope extends IScope {
   trackers: BittorrentTorrentDetailsTracker[]
   resizeMode: string
   resizeProfile: string
+  tableResizeOptions: Readonly<TableResizeOptions>
   columns: TorrentDetailsTrackerColumn[]
   sortedTrackers: BittorrentTorrentDetailsTracker[]
   loading: boolean
@@ -64,6 +66,7 @@ export class TorrentDetailsTrackersTabController {
     this.scope.error = null
     this.scope.mutationError = null
     this.scope.trackerUrl = ""
+    this.scope.tableResizeOptions = DEFAULT_TABLE_RESIZE_OPTIONS
     this.configureResize()
     this.scope.$watch(() => this.scope.trackers, () => this.sortTrackers())
     this.scope.$watchGroup(

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
@@ -21,6 +21,7 @@
     rz-table
     rz-profile="ctl.scope.resizeProfile"
     rz-mode="ctl.scope.resizeMode"
+    rz-options="ctl.scope.tableResizeOptions"
     rz-container=".torrent-details-trackers-content"
     columns="ctl.scope.columns"
   >

--- a/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
+++ b/src/renderer/app/directives/torrents-page/torrents-page.controller.ts
@@ -4,6 +4,7 @@ import { PendingTorrentUploadItem, PendingTorrentUploadList } from "@renderer/ap
 import { ModalController } from "@renderer/app/directives/modal/modal.controller";
 import type { SortChange } from "@renderer/app/directives/sorting/sorting.controller";
 import { matchesLabelFilter } from "@renderer/app/directives/torrent-sidebar/torrent-label-filter";
+import { DEFAULT_TABLE_RESIZE_OPTIONS } from "@renderer/app/lib/table-resize-options";
 import type { ElectorrentRootScope } from "@renderer/app/types/root-scope";
 import type { TorrentActionItem } from "@shared/torrent-actions";
 
@@ -72,6 +73,7 @@ export class TorrentsPageController {
         $scope.trackers = [];
         $scope.guiBusy = true;
         $scope.pendingTorrentFiles = [];
+        $scope.tableResizeOptions = DEFAULT_TABLE_RESIZE_OPTIONS;
         $scope.uploadAdvancedOptionsKey = "Ctrl";
         $scope.deleteConfirmation = {
             action: null,

--- a/src/renderer/app/directives/torrents-page/torrents-page.template.html
+++ b/src/renderer/app/directives/torrents-page/torrents-page.template.html
@@ -81,6 +81,7 @@
                     rz-busy="guiBusy"
                     rz-profile="$server.id"
                     rz-mode="settings.ui.resizeMode"
+                    rz-options="tableResizeOptions"
                     rz-container=".main-content"
                     columns="$server.columns"
                     class="ui single line unstackable selectable fixed torrent resize table"

--- a/src/renderer/app/lib/table-resize-options.ts
+++ b/src/renderer/app/lib/table-resize-options.ts
@@ -1,0 +1,7 @@
+export interface TableResizeOptions {
+  defaultWidth: number
+}
+
+export const DEFAULT_TABLE_RESIZE_OPTIONS: Readonly<TableResizeOptions> = Object.freeze({
+  defaultWidth: 250,
+})

--- a/test/specs/standard/torrent-columns.spec.ts
+++ b/test/specs/standard/torrent-columns.spec.ts
@@ -1,7 +1,7 @@
 import chai from "chai"
 import fs from "node:fs"
 import parseTorrent from "parse-torrent"
-import { $, $$ } from "@wdio/globals"
+import { $ } from "@wdio/globals"
 import * as e2e from "../../e2e"
 import { eventually } from "../../e2e/eventually"
 import { createTorrentFile } from "../../torrent"
@@ -11,7 +11,7 @@ const { assert } = chai
 const fixture = getTestFixture()
 const client = fixture.client
 const tracker = fixture.tracker
-const minimumColumnWidth = 25
+const defaultColumnWidth = 250
 
 const builtInColumns = [
   "Name",
@@ -179,7 +179,7 @@ describe("torrent columns", function () {
       .satisfies("show a completion date", (value) => dateIsSensible(value.trim()), { timeout: 20 * 1000 })
   })
 
-  it("gives newly enabled columns a minimum width", async function () {
+  it("gives newly enabled columns the default width", async function () {
     this.timeout(60 * 1000)
 
     await this.app.openSettings()
@@ -199,11 +199,8 @@ describe("torrent columns", function () {
     await this.app.settingsSave()
     await this.app.torrentsPageIsVisible()
 
-    const headers = await $$("#torrentTable thead th")
-    for (const header of headers) {
-      const columnName = (await header.getText()).trim()
-      const width = (await header.getSize()).width
-      assert.isAtLeast(width, minimumColumnWidth, `${columnName} column width`)
-    }
+    const ratioHeader = $("#torrentTable thead").$("th=Ratio")
+    await ratioHeader.waitForDisplayed({ timeout: 10 * 1000 })
+    assert.closeTo((await ratioHeader.getSize()).width, defaultColumnWidth, 1)
   })
 })


### PR DESCRIPTION
## Summary
- configure every angular-table-resize table with a 250px default column width
- share one immutable resize-options object across torrent and details tables
- verify newly enabled columns receive the configured default width

## Validation
- npm run lint
- npm run build
- npm run test -- --client qbittorrent:latest --spec test/specs/standard/torrent-columns.spec.ts --headless