### PR TITLE
fix(trackers): compact add tracker action

### DIFF
--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.controller.ts
@@ -102,6 +102,14 @@ export class TorrentDetailsPanelController {
     return !!this.rootScope.$btclient?.features.torrentTrackers;
   }
 
+  canManageTrackers() {
+    return !!this.rootScope.$btclient?.features.torrentTrackerManagement;
+  }
+
+  openAddTracker() {
+    this.scope.$broadcast("torrentDetailsTrackers:add");
+  }
+
   startResizing(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.less
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.less
@@ -39,6 +39,19 @@ torrent-details-panel {
 
         > .item > .icon { margin-right: .4rem; }
         > .right.menu > .item > .icon { margin: 0; }
+
+        > .right.menu {
+            align-items: center;
+
+            > .torrent-details-add-tracker {
+                flex: 0 0 auto;
+                margin: 0 .35rem 0 0;
+                padding: .5em .7em;
+                white-space: nowrap;
+
+                > .icon { margin: 0 .4em 0 0; }
+            }
+        }
     }
 
     .torrent-details-panel-body {
@@ -77,4 +90,13 @@ torrent-details-panel {
     .torrent-details-empty-state { color: @mutedTextColor; }
 
     .torrent-details-message { color: inherit; }
+
+    @media (max-width: 720px) {
+        .torrent-details-add-tracker-label { display: none; }
+
+        .ui.top.attached.tabular.menu.torrent-details-tabs
+            > .right.menu
+            > .torrent-details-add-tracker
+            > .icon { margin: 0; }
+    }
 }

--- a/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
+++ b/src/renderer/app/directives/torrent-details-panel/torrent-details-panel.template.html
@@ -42,6 +42,18 @@
       Trackers
     </a>
     <div class="right menu">
+      <button
+        class="ui mini button torrent-details-add-tracker"
+        type="button"
+        data-role="torrent-tracker-add"
+        aria-label="Add tracker"
+        title="Add tracker"
+        ng-if="ctl.isActiveTab('trackers') && ctl.canManageTrackers()"
+        ng-click="ctl.openAddTracker()"
+      >
+        <i class="plus icon" aria-hidden="true"></i>
+        <span class="torrent-details-add-tracker-label">Add tracker</span>
+      </button>
       <a
         class="item"
         data-role="torrent-details-close"

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.controller.ts
@@ -77,7 +77,11 @@ export class TorrentDetailsTrackersTabController {
       ],
       () => this.configureResize(),
     )
-    this.scope.$on("$destroy", () => { this.requestId += 1 })
+    const addTrackerListener = this.scope.$on("torrentDetailsTrackers:add", () => this.openAddTracker())
+    this.scope.$on("$destroy", () => {
+      this.requestId += 1
+      addTrackerListener()
+    })
   }
 
   changeSorting = ({ sortKey, descending }: SortChange<keyof BittorrentTorrentDetailsTracker>) => {

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.less
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.less
@@ -13,13 +13,6 @@ torrent-details-trackers-tab {
         overflow: hidden;
     }
 
-    .torrent-details-trackers-toolbar {
-        flex: 0 0 auto;
-        padding: .35rem;
-        text-align: center;
-        border-bottom: 1px solid @borderColor;
-    }
-
     .torrent-details-trackers-content {
         overflow: auto;
 
@@ -42,5 +35,9 @@ torrent-details-trackers-tab {
         width: 78px;
         text-align: center;
         .ui.button { margin: 0 .1rem; }
+    }
+
+    .torrent-details-empty-add-tracker {
+        margin-left: .6rem;
     }
 }

--- a/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
+++ b/src/renderer/app/directives/torrent-details-trackers-tab/torrent-details-trackers-tab.template.html
@@ -1,9 +1,4 @@
 <div class="torrent-details-trackers" data-role="torrent-details-trackers">
-  <div class="torrent-details-trackers-toolbar" ng-if="ctl.canManageTrackers()">
-    <button class="ui tiny icon button" type="button" data-role="torrent-tracker-add" aria-label="Add tracker" title="Add tracker" ng-click="ctl.openAddTracker()">
-      <i class="plus icon" aria-hidden="true"></i>
-    </button>
-  </div>
   <div ng-if="ctl.scope.loading && !ctl.scope.loaded" class="torrent-details-state torrent-details-panel-loader">
     <div class="ui active inline loader"></div>
   </div>
@@ -50,7 +45,19 @@
         </td>
       </tr>
       <tr ng-if="!ctl.scope.sortedTrackers.length">
-        <td class="torrent-details-empty-state" ng-attr-colspan="{{ ctl.canManageTrackers() ? 11 : 10 }}">No trackers available.</td>
+        <td class="torrent-details-empty-state" ng-attr-colspan="{{ ctl.canManageTrackers() ? 11 : 10 }}">
+          <span>No trackers available.</span>
+          <button
+            ng-if="ctl.canManageTrackers()"
+            class="ui mini button torrent-details-empty-add-tracker"
+            type="button"
+            data-role="torrent-tracker-empty-add"
+            ng-click="ctl.openAddTracker()"
+          >
+            <i class="plus icon" aria-hidden="true"></i>
+            Add tracker
+          </button>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/test/specs/standard/torrent-trackers.spec.ts
+++ b/test/specs/standard/torrent-trackers.spec.ts
@@ -39,7 +39,7 @@ describe("torrent tracker management", function () {
 
     await eventually(() => trackersTab.getText()).contains(initialTracker, { timeout: 30_000 })
 
-    await trackersTab.$("[data-role='torrent-tracker-add']").click()
+    await panel.$("[data-role='torrent-tracker-add']").click()
     const trackerModal = $("#torrent-tracker-modal")
     await waitForModalOpen(trackerModal, 10_000)
     const trackerInput = trackerModal.$("[data-role='torrent-tracker-url']")


### PR DESCRIPTION
## Summary

- move the add tracker action into the details tab bar
- collapse the action to an icon on narrow windows
- add a compact empty-state shortcut and remove the full-width toolbar

## Validation

- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/torrent-trackers.spec.ts" --headless