### PR TITLE
fix(updates): use dmg_arm64 platform for Apple silicon

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,7 +18,6 @@ mac:
       arch:
         - universal
         - arm64
-        - x64
 win:
   target: squirrel
   publish:

--- a/src/main/lib/update-url.ts
+++ b/src/main/lib/update-url.ts
@@ -8,10 +8,6 @@ export function buildUpdateUrl(endpoint: string, platform: NodeJS.Platform, vers
     const updateType = UPDATE_TYPES[platform]
     if (!updateType) return null
 
-    const updateUrl = `${endpoint}update/${updateType}/${version}`
-    if (platform !== 'darwin' || !['arm64', 'x64'].includes(architecture)) {
-        return updateUrl
-    }
-
-    return `${updateUrl}?arch=${architecture}`
+    const architectureSuffix = platform === 'darwin' && architecture === 'arm64' ? '_arm64' : ''
+    return `${endpoint}update/${updateType}${architectureSuffix}/${version}`
 }

--- a/test/specs/mock/software-update.spec.ts
+++ b/test/specs/mock/software-update.spec.ts
@@ -83,22 +83,28 @@ describe("software updates", function () {
   })
 })
 
-describe("macOS software update architecture", function () {
+describe("software update URL", function () {
   const endpoint = "https://electorrent.example/"
 
-  for (const architecture of ["arm64", "x64"]) {
-    it(`requests the ${architecture} update`, function () {
-      assert.equal(
-        buildUpdateUrl(endpoint, "darwin", "2.16.2", architecture),
-        `${endpoint}update/dmg/2.16.2?arch=${architecture}`,
-      )
+  const supportedPlatforms: Array<{
+    platform: NodeJS.Platform
+    architecture: string
+    updatePath: string
+  }> = [
+    { platform: "darwin", architecture: "arm64", updatePath: "dmg_arm64" },
+    { platform: "darwin", architecture: "x64", updatePath: "dmg" },
+    { platform: "darwin", architecture: "unknown", updatePath: "dmg" },
+    { platform: "win32", architecture: "x64", updatePath: "win32" },
+    { platform: "linux", architecture: "x64", updatePath: "appimage" },
+  ]
+
+  for (const { platform, architecture, updatePath } of supportedPlatforms) {
+    it(`builds the ${platform} ${architecture} update URL`, function () {
+      assert.equal(buildUpdateUrl(endpoint, platform, "2.16.2", architecture), `${endpoint}update/${updatePath}/2.16.2`)
     })
   }
 
-  it("falls back to the universal update for an unknown architecture", function () {
-    assert.equal(
-      buildUpdateUrl(endpoint, "darwin", "2.16.2", "unknown"),
-      `${endpoint}update/dmg/2.16.2`,
-    )
+  it("returns null for an unsupported platform", function () {
+    assert.isNull(buildUpdateUrl(endpoint, "aix", "2.16.2", "ppc64"))
   })
 })


### PR DESCRIPTION
## Summary
- route native Apple-silicon updates through Hazel’s `dmg_arm64` platform
- keep Intel and legacy clients on the universal `dmg` route
- remove the colliding x64 DMG artifact and expand URL coverage

## Release server audit
The private Electorrent release-server runtime matches upstream Hazel 5.1.1. No server change or redeployment is required.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test -- --client "mock" --spec "test/specs/mock/software-update.spec.ts" --headless`