### PR TITLE
fix(ui): hide scrollbar corner

### DIFF
--- a/src/renderer/styles/app/partials/layout.less
+++ b/src/renderer/styles/app/partials/layout.less
@@ -69,6 +69,10 @@ body {
     -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
 }
 
+::-webkit-scrollbar-corner {
+    background: rgba(0, 0, 0, 0) !important;
+}
+
 ::-webkit-scrollbar * {
     background: transparent;
 }


### PR DESCRIPTION
## Summary

- make the Chromium scrollbar corner transparent globally
- remove the white square where horizontal and vertical scrollbars meet
- apply consistently across light and dark themes

## Validation

- npm run lint
- npm run build
- npm run test -- --client "qbittorrent:latest" --spec "test/specs/standard/layout.spec.ts" --headless